### PR TITLE
Update action.yml to `default: false`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,19 +7,19 @@ inputs:
   python:
     description: 'Run Python formatting'
     required: false
-    default: 'true'
+    default: false
   docstrings:
     description: 'Run Docstrings formatting'
     required: false
-    default: 'true'
+    default: false
   markdown:
     description: 'Run Markdown formatting'
     required: false
-    default: 'true'
+    default: false
   spelling:
     description: 'Run Spelling checks'
     required: false
-    default: 'true'
+    default: false
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
@kalenmike updates actions to default to false per your idea. Then to disable an action you can simply remove it, i.e. to disable markdown formatting:

```yaml
- name: Run Ultralytics Formatting
  uses: ultralytics/actions@main
  with:
    python: true
    docstrings: true
    markdown: true  <--- set to false or simply delete this line
    spelling: true
```