### PR TITLE
Explicit codespell --write-changes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
       if: inputs.spelling == 'true' && github.event.action != 'closed'
       run: |
         codespell \
-          -w \
+          --write-changes \
           --ignore-words-list "crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall" \
           --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,__pycache__*,*.ico,*.jpg,*.png,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml"
       shell: bash


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I hereby sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving spelling correction behavior in GitHub Actions workflow

### 📊 Key Changes
- Altered the codespell argument from `-w` to the more explicit `--write-changes`.

### 🎯 Purpose & Impact
- **Purpose**: To increase clarity in the codespell command within the GitHub Actions workflow, ensuring that contributors understand its function.
- **Impact**: Enhances code maintainability and readability, potentially reducing confusion for contributors when they encounter the spelling correction step in the CI process. This change should not affect the functionality, but it does make the codebase more contributor-friendly. 📝💫