### PR TITLE
Ignore Alerts for Org members

### DIFF
--- a/utils/autolabel_issue.py
+++ b/utils/autolabel_issue.py
@@ -241,7 +241,7 @@ def main():
 
     if relevant_labels:
         apply_labels(number, relevant_labels)
-        if "Alert" in relevant_labels:  # and not is_org_member(username):
+        if "Alert" in relevant_labels and not is_org_member(username):
             update_issue_pr_content(number)
             close_issue_pr(number)
             lock_issue_pr(number)

--- a/utils/autolabel_issue.py
+++ b/utils/autolabel_issue.py
@@ -212,7 +212,7 @@ def create_alert_label():
     """Creates the 'Alert' label in the repository if it doesn't exist."""
     alert_label = {
         "name": "Alert",
-        "color": "FFA500",  # bright orange
+        "color": "FF0000",  # bright red
         "description": "Potential spam, abuse, or off-topic.",
     }
     response = requests.post(f"{GITHUB_API_URL}/repos/{REPO_NAME}/labels", json=alert_label, headers=GITHUB_HEADERS)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced the auto-labeling script to improve issue management by adding checks for organization membership.

### 📊 Key Changes
- Added a condition to check organization membership before updating and closing issues marked with the "Alert" label.

### 🎯 Purpose & Impact
- **Purpose**: Ensures that only non-organization members' issues with the "Alert" label are automatically closed and locked.
- **Impact**: Reduces the risk of prematurely closing issues from internal users, improving overall issue handling and response accuracy. 🚀🔐