### PR TITLE
Remove --pre-summary-newline

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,8 +109,6 @@ runs:
         --wrap-summaries 120 \
         --wrap-descriptions 120 \
         --in-place \
-        --pre-summary-newline \
-        --close-quotes-on-newline \
         --recursive \
         .
       shell: bash

--- a/utils/update_markdown_code_blocks.py
+++ b/utils/update_markdown_code_blocks.py
@@ -72,8 +72,6 @@ def format_code_with_ruff(temp_dir):
                 "--wrap-summaries=120",
                 "--wrap-descriptions=120",
                 "--in-place",
-                "--pre-summary-newline",
-                "--close-quotes-on-newline",
                 "--recursive",
                 str(temp_dir),
             ],


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplified the markdown linting configuration in the GitHub Action.

### 📊 Key Changes
- Removed `--pre-summary-newline` and `--close-quotes-on-newline` options from the markdown linting command.

### 🎯 Purpose & Impact
- **Purpose**: To streamline the markdown linting process by eliminating unnecessary options.
- **Impact**: Makes the action configuration cleaner and easier to maintain; no significant impact on the linting output for most users.