### PR TITLE
Ignore github URLs in broken link checks

### DIFF
--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -34,6 +34,7 @@ def is_url(url, check=True, max_attempts=3, timeout=2):
         "url",
         "example",
         "mailto:",
+        "://github.com"  # ignore GitHub links that may be private repos
     )
     try:
         # Check allow list

--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -34,7 +34,7 @@ def is_url(url, check=True, max_attempts=3, timeout=2):
         "url",
         "example",
         "mailto:",
-        "://github.com"  # ignore GitHub links that may be private repos
+        "://github.com",  # ignore GitHub links that may be private repos
     )
     try:
         # Check allow list


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced URL validation to ignore certain GitHub links.

### 📊 Key Changes
- Updated `is_url` function to include “://github.com” in the list of strings that cause URLs to be ignored.

### 🎯 Purpose & Impact
- **Purpose**: To prevent attempts to validate GitHub links that might be private and cause unnecessary checks.
- **Impact**: Saves processing time and avoids potential errors or access issues when dealing with private GitHub URLs. This makes URL handling more efficient and reliable.