### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,16 @@ packages = { find = { where = ["."], include = ["actions", "actions.*"] } }
 
 [tool.setuptools.dynamic]
 version = { attr = "actions.__version__" }
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.docformatter]
+wrap-summaries = 120
+wrap-descriptions = 120
+pre-summary-newline = true
+close-quotes-on-newline = true
+in-place = true


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added `ruff` and `docformatter` tools to enforce consistent coding style and formatting.

### 📊 Key Changes  
- Integrated `ruff` for linting with a max line length of 120.  
- Configured `docformatter` for consistent docstring formatting (e.g., wrapping summaries/descriptions, handling newlines and quotes).  

### 🎯 Purpose & Impact  
- 🛠 Improves code readability and maintainability by enforcing uniform style across the project.  
- 🚀 Streamlines the development process with automated formatting tools, saving time for developers.  
- 🔍 Enhances clarity in docstrings, making it easier for users and contributors to understand the codebase.