### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Dependabot for package version updates
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-# Ultralytics Template 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Continuous Integration (CI) GitHub Actions tests
 
 name: Actions CI

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Contributor License Agreement (CLA) action https://docs.ultralytics.com/help/CLA
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
-# Ultralytics Actions 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Publish pip package to PyPI https://pypi.org/project/ultralytics-actions/
 
 name: Publish to PyPI

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 name: Test Retry Action
 on:
   pull_request:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-# Ultralytics Actions 🚀, AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: "Ultralytics Actions"
 author: "Ultralytics"

--- a/cleanup-disk/action.yml
+++ b/cleanup-disk/action.yml
@@ -1,4 +1,4 @@
-# Ultralytics Actions 🚀, AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: "Disk Space Cleanup"
 author: "Ultralytics"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Ultralytics Actions 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Overview:
 # This pyproject.toml file manages the build, packaging, and distribution of the Ultralytics Actions package.

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -1,4 +1,5 @@
-# Ultralytics Actions 🚀, AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 #
 # Example usage:
 #


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated licensing headers across multiple files for consistency and clarity in `ultralytics/actions`.

### 📊 Key Changes
- Standardized and clarified license headers in all workflow and configuration files.
- Unified the phrasing for the AGPL-3.0 license link (`Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`).

### 🎯 Purpose & Impact
- **Improved Consistency:** Makes licensing information across files uniform, reducing confusion for contributors and users. 📄
- **Better Clarity:** Clearly highlights the license type and link to the Ultralytics license page for better accessibility. 🔗
- **No Functional Changes:** These updates are purely informational and do not alter any workflows or features. ✅