### PR TITLE
Always retrieve previous tag via API

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -22,4 +22,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.0.41"
+__version__ = "0.0.42"

--- a/actions/summarize_release.py
+++ b/actions/summarize_release.py
@@ -17,7 +17,6 @@ from .utils import (
 
 # Environment variables
 CURRENT_TAG = os.getenv("CURRENT_TAG")
-PREVIOUS_TAG = os.getenv("PREVIOUS_TAG")
 
 
 def get_release_diff(repo_name: str, previous_tag: str, latest_tag: str, headers: dict) -> str:
@@ -165,11 +164,7 @@ def main(*args, **kwargs):
         raise ValueError("One or more required environment variables are missing.")
 
     # Get the diff between the tags
-    previous_tag = (
-        PREVIOUS_TAG
-        if PREVIOUS_TAG and "none" not in PREVIOUS_TAG.lower() and PREVIOUS_TAG != CURRENT_TAG
-        else get_previous_tag()
-    )
+    previous_tag = get_previous_tag()
     diff = get_release_diff(action.repository, previous_tag, CURRENT_TAG, action.headers_diff)
 
     # Get PRs merged between the tags


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Simplified how the script fetches the previous tag for release summaries, reducing complexity and potential errors. 🛠️📉

### 📊 Key Changes  
- Removed reliance on the `PREVIOUS_TAG` environment variable.  
- Streamlined logic by always calling the `get_previous_tag()` function to determine the previous release tag.  

### 🎯 Purpose & Impact  
- **Purpose**: Simplifies the release summarization process by reducing dependency on environment setup and ensuring consistent behavior.  
- **Impact**: Fewer setup errors for users running the release script and more reliable release summaries. 🎉