### PR TITLE
Disable Vue due to 80-char wrap bug

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -22,4 +22,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.0.78"
+__version__ = "0.0.79"

--- a/actions/update_file_headers.py
+++ b/actions/update_file_headers.py
@@ -30,7 +30,7 @@ COMMENT_MAP = {
     ".java": ("// ", "/* ", " */"),  # Android Java
     ".kt": ("// ", "/* ", " */"),  # Android Kotlin
     # Vue/Nuxt style
-    ".vue": ("// ", "/* ", " */"),  # Vue single-file components
+    # ".vue": ("// ", "/* ", " */"),  # Vue single-file components (bug due to Prettier wrapping Vue files at 80 chars)
     # React/Next.js style
     ".jsx": ("// ", "/* ", " */"),  # JSX files
     ".tsx": ("// ", "/* ", " */"),  # TSX files

--- a/actions/update_file_headers.py
+++ b/actions/update_file_headers.py
@@ -30,11 +30,7 @@ COMMENT_MAP = {
     ".java": ("// ", "/* ", " */"),  # Android Java
     ".kt": ("// ", "/* ", " */"),  # Android Kotlin
     # Vue/Nuxt style
-    ".vue": (
-        None,
-        "<!-- ",
-        " -->",
-    ),  # Vue single-file components (must use HTML style or Prettier will wrap at 80 chars)
+    ".vue": (None, "<!-- ", " -->"),  # Vue components (must use HTML style, or Prettier will wrap at 80 chars)
     # React/Next.js style
     ".jsx": ("// ", "/* ", " */"),  # JSX files
     ".tsx": ("// ", "/* ", " */"),  # TSX files

--- a/actions/update_file_headers.py
+++ b/actions/update_file_headers.py
@@ -30,7 +30,7 @@ COMMENT_MAP = {
     ".java": ("// ", "/* ", " */"),  # Android Java
     ".kt": ("// ", "/* ", " */"),  # Android Kotlin
     # Vue/Nuxt style
-    # ".vue": (None, "<!-- ", " -->"),  # Vue single-file components (must use HTML style or Prettier will wrap at 80 chars)
+    ".vue": (None, "<!-- ", " -->"),  # Vue single-file components (must use HTML style or Prettier will wrap at 80 chars)
     # React/Next.js style
     ".jsx": ("// ", "/* ", " */"),  # JSX files
     ".tsx": ("// ", "/* ", " */"),  # TSX files

--- a/actions/update_file_headers.py
+++ b/actions/update_file_headers.py
@@ -30,7 +30,11 @@ COMMENT_MAP = {
     ".java": ("// ", "/* ", " */"),  # Android Java
     ".kt": ("// ", "/* ", " */"),  # Android Kotlin
     # Vue/Nuxt style
-    ".vue": (None, "<!-- ", " -->"),  # Vue single-file components (must use HTML style or Prettier will wrap at 80 chars)
+    ".vue": (
+        None,
+        "<!-- ",
+        " -->",
+    ),  # Vue single-file components (must use HTML style or Prettier will wrap at 80 chars)
     # React/Next.js style
     ".jsx": ("// ", "/* ", " */"),  # JSX files
     ".tsx": ("// ", "/* ", " */"),  # TSX files

--- a/actions/update_file_headers.py
+++ b/actions/update_file_headers.py
@@ -30,7 +30,7 @@ COMMENT_MAP = {
     ".java": ("// ", "/* ", " */"),  # Android Java
     ".kt": ("// ", "/* ", " */"),  # Android Kotlin
     # Vue/Nuxt style
-    # ".vue": ("// ", "/* ", " */"),  # Vue single-file components (bug due to Prettier wrapping Vue files at 80 chars)
+    # ".vue": (None, "<!-- ", " -->"),  # Vue single-file components (must use HTML style or Prettier will wrap at 80 chars)
     # React/Next.js style
     ".jsx": ("// ", "/* ", " */"),  # JSX files
     ".tsx": ("// ", "/* ", " */"),  # TSX files


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor update to improve file header handling and bump the package version. 🚀

### 📊 Key Changes
- Updated the package version from 0.0.78 to 0.0.79.
- Disabled automatic header updates for `.vue` files due to formatting issues caused by Prettier.

### 🎯 Purpose & Impact
- Prevents formatting bugs in Vue single-file components, ensuring cleaner code and fewer merge conflicts for developers working with Vue projects.
- Keeps the package versioning up to date, signaling the latest improvements.