### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,8 @@ jobs:
     needs: [check, publish]
     if: always() && needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Extract PR Details


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/actions/security/code-scanning/7](https://github.com/ultralytics/actions/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the `notify` job. Since the job only performs notification tasks and does not require write access to the repository, we will set the permissions to `contents: read`. This ensures that the job has the minimal permissions necessary to execute its tasks.

The changes will be made in the `.github/workflows/publish.yml` file, specifically within the `notify` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
