### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -1,6 +1,8 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Test Retry Action
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/actions/security/code-scanning/6](https://github.com/ultralytics/actions/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the provided workflow, it does not appear to require any write permissions, so we will set `contents: read` as the default permission. This ensures that the workflow has only read access to the repository contents and no unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds explicit read-only permissions to the Test Retry GitHub Action workflow for improved security. 🔒

### 📊 Key Changes
- Sets the workflow's permissions to "contents: read" in the test-retry.yml file.

### 🎯 Purpose & Impact
- Enhances security by limiting the workflow's access to repository contents.
- Follows GitHub best practices for least-privilege permissions, reducing potential risks for users and contributors.