### PR TITLE
Improve handling of too-large PR diff

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -22,4 +22,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.0.82"
+__version__ = "0.0.83"

--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -115,7 +115,12 @@ class Action:
         """Retrieves the diff content for a specified pull request."""
         url = f"{GITHUB_API_URL}/repos/{self.repository}/pulls/{self.pr.get('number')}"
         response = self.get(url, headers=self.headers_diff)
-        return response.text if response.status_code == 200 else ""
+        if response.status_code == 200:
+            return response.text
+        elif response.status_code == 406:
+            return "**ERROR: DIFF TOO LARGE - PR exceeds GitHub's 20,000 line limit, unable to retrieve diff."
+        else:
+            return "**ERROR: UNABLE TO RETRIEVE DIFF."
 
     def get_repo_data(self, endpoint: str) -> dict:
         """Fetches repository data from a specified endpoint."""


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved error handling for large or inaccessible GitHub pull request diffs in the Ultralytics Actions toolkit. 🚀

### 📊 Key Changes
- Updated the version to 0.0.83.
- Enhanced the `get_pr_diff` function to:
  - Return a clear error message if a PR diff is too large (over 20,000 lines).
  - Provide a generic error message if the diff cannot be retrieved for other reasons.

### 🎯 Purpose & Impact
- Makes it easier to understand why a PR diff can't be fetched, saving time for developers and users.
- Improves transparency and troubleshooting when working with large or problematic pull requests.
- Ensures users receive helpful feedback instead of silent failures or unclear errors.