### PR TITLE
Assign "bug" label to only issues with sufficient information

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -22,4 +22,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.0.93"
+__version__ = "0.0.94"

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -146,6 +146,7 @@ INSTRUCTIONS:
 4. Only use the "Alert" label when you have high confidence that this is an inappropriate {issue_type}.
 5. Respond ONLY with the chosen label names (no descriptions), separated by commas.
 6. If no labels are relevant, respond with 'None'.
+{'7. Only use the "bug" label if the user provides a clear description of the bug, their environment with relevant package versions and a minimum reproducible example.' if issue_type == 'issue' else ''}
 
 AVAILABLE LABELS:
 {labels}
@@ -170,8 +171,6 @@ YOUR RESPONSE (label names only):
         return []
 
     available_labels_lower = {name.lower(): name for name in available_labels}
-    if issue_type == "issue":
-        del available_labels_lower["bug"]  # issues must fill bug report template for bug label
     return [
         available_labels_lower[label.lower().strip()]
         for label in suggested_labels.split(",")

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -146,7 +146,7 @@ INSTRUCTIONS:
 4. Only use the "Alert" label when you have high confidence that this is an inappropriate {issue_type}.
 5. Respond ONLY with the chosen label names (no descriptions), separated by commas.
 6. If no labels are relevant, respond with 'None'.
-{'7. Only use the "bug" label if the user provides a clear description of the bug, their environment with relevant package versions and a minimum reproducible example.' if issue_type == 'issue' else ''}
+{'7. Only use the "bug" label if the user provides a clear description of the bug, their environment with relevant package versions and a minimum reproducible example.' if issue_type == "issue" else ""}
 
 AVAILABLE LABELS:
 {labels}

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -170,6 +170,8 @@ YOUR RESPONSE (label names only):
         return []
 
     available_labels_lower = {name.lower(): name for name in available_labels}
+    if issue_type == "issue":
+        del available_labels_lower["bug"]  # issues must fill bug report template for bug label
     return [
         available_labels_lower[label.lower().strip()]
         for label in suggested_labels.split(",")

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -67,7 +67,7 @@ def test_get_event_content_pr():
 @patch("actions.first_interaction.get_completion")
 def test_get_relevant_labels(mock_get_completion):
     """Test getting relevant labels for an issue."""
-    mock_get_completion.return_value = "bug"
+    mock_get_completion.return_value = "bug, enhancement"
 
     available_labels = {
         "bug": "A bug in the software",
@@ -77,30 +77,13 @@ def test_get_relevant_labels(mock_get_completion):
 
     labels = get_relevant_labels(
         issue_type="issue",
-        title="App crashes when clicking submit button",
-        body="""
-        The application crashes consistently when I click the submit button on the contact form.
-        
-        Environment:
-        - Python 3.9.2
-        - Flask 2.1.0
-        - SQLAlchemy 1.4.23
-        - Chrome 98.0.4758.102
-        
-        Steps to reproduce:
-        1. Navigate to /contact page
-        2. Fill out the form with any data
-        3. Click submit button
-        4. App crashes with 500 error
-        
-        Expected: Form should submit successfully
-        Actual: Server returns 500 error and logs show NoneType error in database handler
-        """,
+        title="Bug: App crashes on startup",
+        body="The application crashes when started",
         available_labels=available_labels,
         current_labels=[],
     )
 
-    assert labels == ["bug"]
+    assert labels == ["bug", "enhancement"]
     mock_get_completion.assert_called_once()
 
 
@@ -131,3 +114,4 @@ def test_create_alert_label():
     assert "labels" in args[0]
     assert kwargs["json"]["name"] == "Alert"
     assert kwargs["json"]["color"] == "FF0000"
+

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -67,7 +67,7 @@ def test_get_event_content_pr():
 @patch("actions.first_interaction.get_completion")
 def test_get_relevant_labels(mock_get_completion):
     """Test getting relevant labels for an issue."""
-    mock_get_completion.return_value = "enhancement, documentation"
+    mock_get_completion.return_value = "bug"
 
     available_labels = {
         "bug": "A bug in the software",
@@ -77,13 +77,30 @@ def test_get_relevant_labels(mock_get_completion):
 
     labels = get_relevant_labels(
         issue_type="issue",
-        title="Provide model cards for all available models",
-        body="Add model cards section to Ultralytics Docs",
+        title="App crashes when clicking submit button",
+        body="""
+        The application crashes consistently when I click the submit button on the contact form.
+        
+        Environment:
+        - Python 3.9.2
+        - Flask 2.1.0
+        - SQLAlchemy 1.4.23
+        - Chrome 98.0.4758.102
+        
+        Steps to reproduce:
+        1. Navigate to /contact page
+        2. Fill out the form with any data
+        3. Click submit button
+        4. App crashes with 500 error
+        
+        Expected: Form should submit successfully
+        Actual: Server returns 500 error and logs show NoneType error in database handler
+        """,
         available_labels=available_labels,
         current_labels=[],
     )
 
-    assert labels == ["enhancement", "documentation"]
+    assert labels == ["bug"]
     mock_get_completion.assert_called_once()
 
 

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -114,4 +114,3 @@ def test_create_alert_label():
     assert "labels" in args[0]
     assert kwargs["json"]["name"] == "Alert"
     assert kwargs["json"]["color"] == "FF0000"
-

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -67,7 +67,7 @@ def test_get_event_content_pr():
 @patch("actions.first_interaction.get_completion")
 def test_get_relevant_labels(mock_get_completion):
     """Test getting relevant labels for an issue."""
-    mock_get_completion.return_value = "bug, enhancement"
+    mock_get_completion.return_value = "enhancement, documentation"
 
     available_labels = {
         "bug": "A bug in the software",
@@ -77,13 +77,13 @@ def test_get_relevant_labels(mock_get_completion):
 
     labels = get_relevant_labels(
         issue_type="issue",
-        title="Bug: App crashes on startup",
-        body="The application crashes when started",
+        title="Provide model cards for all available models",
+        body="Add model cards section to Ultralytics Docs",
         available_labels=available_labels,
         current_labels=[],
     )
 
-    assert labels == ["bug", "enhancement"]
+    assert labels == ["enhancement", "documentation"]
     mock_get_completion.assert_called_once()
 
 


### PR DESCRIPTION
Issues should only have bug labels if the user had manually filled the bug report template with the complete information.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Tightens label handling for new GitHub issues by preventing automatic assignment of the "bug" label unless the proper template is used.

### 📊 Key Changes
- Excludes the "bug" label from auto-suggested labels when the item is an issue.
- Maintains case-insensitive matching for other available labels.

### 🎯 Purpose & Impact
- Ensures users follow the required bug report template for proper diagnostics 🧰.
- Improves triage quality by avoiding mis-labeled issues 🧭.
- Reduces noise for maintainers, leading to faster, more accurate responses ⏱️.