### PR TITLE
Ruff check before format

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -150,16 +150,16 @@ runs:
     - name: Run Python
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && inputs.python == 'true' && github.event.action != 'closed'
       run: |
-        ruff format \
-        --line-length 120 \
-        . || true
         ruff check \
         --fix \
         --unsafe-fixes \
         --extend-select I,D,UP \
         --target-version py39 \
         --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413 \
-        .
+        . || true
+        ruff format \
+        --line-length 120 \
+        . || true
         docformatter \
         --wrap-summaries 120 \
         --wrap-descriptions 120 \


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Make Python linting/formatting in the PR workflow non-blocking and reorder steps to apply fixes first, then format ✅

### 📊 Key Changes
- Run `ruff check --fix` before `ruff format` to apply code fixes prior to formatting.
- Add `|| true` to both `ruff check` and `ruff format` so lint/format failures don’t fail the CI step.
- Keep `docformatter` execution, ensuring docstrings are still formatted even if Ruff flags issues.

### 🎯 Purpose & Impact
- Smoother contributor experience: PRs won’t go red just from lint/format issues 🚦➡️🟢
- Ensures maximum auto-fixes: Ruff fixes run first, then formatting polishes the result 🧹
- CI resilience: Subsequent steps (like `docformatter`) always run, improving consistency.
- Trade-off: Lint violations won’t fail the workflow, so enforcement may rely on other checks or reviews.