### PR TITLE
Fix ambiguous variable name

### DIFF
--- a/actions/utils/version_utils.py
+++ b/actions/utils/version_utils.py
@@ -15,7 +15,7 @@ def should_publish(local_version, remote_version):
     """Determine if version should be published based on semver rules."""
     if remote_version:
         local_ver, remote_ver = [tuple(map(int, v.split("."))) for v in [local_version, remote_version]]
-        major_diff, minor_diff, patch_diff = [l - r for l, r in zip(local_ver, remote_ver)]
+        major_diff, minor_diff, patch_diff = [local - remote for local, remote in zip(local_ver, remote_ver)]
         return (
             (major_diff == 0 and minor_diff == 0 and 0 < patch_diff <= 2)  # patch diff <=2
             or (major_diff == 0 and minor_diff == 1 and local_ver[2] == 0)  # new minor version


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactors a small part of the version comparison logic for publishing to improve readability and linting without changing behavior. ✅

### 📊 Key Changes
- Renames list-comprehension variables from `l, r` to `local, remote` in `should_publish()` for clarity.
- Keeps the existing semantic versioning rules intact:
  - Publish on patch increments up to 2.
  - Publish on a new minor version when patch is 0.

### 🎯 Purpose & Impact
- Improves code readability and avoids ambiguous single-letter variables (e.g., `l` vs `1`). ✨
- Aligns with linters and best practices, reducing potential review and CI friction. 🧹
- No functional change—publishing behavior remains exactly the same. 🚀