### PR TITLE
Add Azure OpenAI endpoint support to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,9 @@ inputs:
     description: "OpenAI Model"
     required: false
     default: "gpt-5-2025-08-07"
+  azure_openai_endpoint:
+    description: "Azure OpenAI Endpoint"
+    required: false
   first_issue_response:
     description: "Example response to a new issue"
     required: false
@@ -119,6 +122,7 @@ runs:
         BRAVE_API_KEY: ${{ inputs.brave_api_key }}
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
         OPENAI_MODEL: ${{ inputs.openai_model }}
+        AZURE_OPENAI_ENDPOINT: ${{ inputs.azure_openai_endpoint }}
       run: |
         ultralytics-actions-summarize-pr
       shell: bash
@@ -235,6 +239,7 @@ runs:
         BRAVE_API_KEY: ${{ inputs.brave_api_key }}
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
         OPENAI_MODEL: ${{ inputs.openai_model }}
+        AZURE_OPENAI_ENDPOINT: ${{ inputs.azure_openai_endpoint }}
       run: |
         ultralytics-actions-first-interaction
       shell: bash

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -11,6 +11,7 @@ from actions.utils.common_utils import check_links_in_string
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5-2025-08-07")
+AZURE_OPENAI_ENDPOINT = os.getenv("AZURE_OPENAI_ENDPOINT")
 SYSTEM_PROMPT_ADDITION = """Guidance:
   - Ultralytics Branding: Use YOLO11, YOLO12, etc., not YOLOv11, YOLOv12 (only older versions like YOLOv10 have a v). Always capitalize "HUB" in "Ultralytics HUB"; use "Ultralytics HUB", not "The Ultralytics HUB". 
   - Avoid Equations: Do not include equations or mathematical notations.
@@ -43,8 +44,12 @@ def get_completion(
 ) -> str:
     """Generates a completion using OpenAI's API based on input messages."""
     assert OPENAI_API_KEY, "OpenAI API key is required."
-    url = "https://api.openai.com/v1/chat/completions"
-    headers = {"Authorization": f"Bearer {OPENAI_API_KEY}", "Content-Type": "application/json"}
+    if AZURE_OPENAI_ENDPOINT:
+        url = AZURE_OPENAI_ENDPOINT
+        headers = {"api-key": OPENAI_API_KEY, "Content-Type": "application/json"}
+    else:
+        url = "https://api.openai.com/v1/chat/completions"
+        headers = {"Authorization": f"Bearer {OPENAI_API_KEY}", "Content-Type": "application/json"}
     if messages and messages[0].get("role") == "system":
         messages[0]["content"] += "\n\n" + SYSTEM_PROMPT_ADDITION
 


### PR DESCRIPTION
@glenn-jocher you can see here that PR summary and first comment works fine with Azure Endpoint: https://github.com/fcakyon/actions/pull/4

This PR could increase the reach of Ultralytics Actions to a wider audience 🙏🏻 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds optional Azure OpenAI support to ultralytics/actions, enabling PR summaries and first-interaction replies to use an Azure endpoint instead of OpenAI’s public API. 🚀

### 📊 Key Changes
- New input: `azure_openai_endpoint` in `action.yml` for configuring Azure OpenAI.
- Env wiring: `AZURE_OPENAI_ENDPOINT` passed to both summarize and first-interaction steps.
- Request logic update: If `AZURE_OPENAI_ENDPOINT` is set, requests use that URL and Azure’s `api-key` header; otherwise, defaults to OpenAI’s standard `chat/completions` with Bearer token.

### 🎯 Purpose & Impact
- Enterprise readiness 🏢: Supports organizations restricted to Azure for compliance, security, or data residency.
- Backward compatible ✅: No changes required for existing users; defaults remain the same.
- Flexible configuration 🔧: Teams can switch between OpenAI and Azure OpenAI without code changes.
- Reliability & control 📈: Offers alternative routing that may improve latency, stability, and cost management depending on org setup.

Example usage:
```yaml
- uses: ultralytics/actions@main
  with:
    openai_api_key: ${{ secrets.AZURE_OPENAI_API_KEY }}
    openai_model: gpt-5-2025-08-07
    azure_openai_endpoint: https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=2024-10-01-preview
```