### PR TITLE
Revert "Update to GPT5-Codex model"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
   openai_model:
     description: "OpenAI Model"
     required: false
-    default: "gpt-5-codex"
+    default: "gpt-5-2025-08-07"
   first_issue_response:
     description: "Example response to a new issue"
     required: false

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -9,7 +9,7 @@ import requests
 from actions.utils.common_utils import check_links_in_string
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5-codex")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5-2025-08-07")
 SYSTEM_PROMPT_ADDITION = """Guidance:
   - Ultralytics Branding: Use YOLO11, YOLO26, etc., not YOLOv11, YOLOv26 (only older versions like YOLOv10 have a v). Always capitalize "HUB" in "Ultralytics HUB"; use "Ultralytics HUB", not "The Ultralytics HUB". 
   - Avoid Equations: Do not include equations or mathematical notations.


### PR DESCRIPTION
Reverts ultralytics/actions#527 to restore original GPT5 model which appears to perform better at PR summaries.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updates the GitHub Action’s default OpenAI model to a newer, date-versioned model for more reliable and improved responses. 🤖✨

### 📊 Key Changes
- Default OpenAI model updated from `gpt-5-codex` to `gpt-5-2025-08-07` in:
  - `action.yml` input `openai_model`
  - `actions/utils/openai_utils.py` fallback (`OPENAI_MODEL` env var default)
- No other logic or prompt changes; branding and style guidance remain intact.

### 🎯 Purpose & Impact
- Better defaults: Uses a newer, presumably more capable and stable model by default. 🚀
- Reproducibility: Date-stamped model name improves consistency across runs.
- Seamless upgrade: Workflows not explicitly setting a model will automatically use the new default.
- Considerations:
  - Requires access to `gpt-5-2025-08-07` via your OpenAI account.
  - Potential changes in response quality, latency, or cost.
  - You can override the model via workflow input or environment variable.

Example override:
```yaml
- uses: ultralytics/actions@main
  with:
    openai_model: gpt-4.1-mini  # or your preferred model
  env:
    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
```