### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,7 @@ updates:
     schedule:
       interval: monthly
       time: "04:00"
-    open-pull-requests-limit: 10
-    reviewers:
-      - glenn-jocher
+    open-pull-requests-limit: 3
     labels:
       - dependencies
 
@@ -21,9 +19,7 @@ updates:
     schedule:
       interval: monthly
       time: "04:00"
-    open-pull-requests-limit: 5
-    reviewers:
-      - glenn-jocher
+    open-pull-requests-limit: 3
     labels:
       - dependencies
 
@@ -32,8 +28,6 @@ updates:
     schedule:
       interval: monthly
       time: "04:00"
-    open-pull-requests-limit: 5
-    reviewers:
-      - glenn-jocher
+    open-pull-requests-limit: 3
     labels:
       - dependencies


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Dependabot is now throttled to fewer concurrent PRs and no longer auto-assigns a reviewer, aiming to reduce noise and streamline maintenance. 🚦

### 📊 Key Changes
- Reduced `open-pull-requests-limit` to 3 for all ecosystems (was 10/5/5). 📉
- Removed automatic reviewer assignment of @glenn-jocher. 🧑‍💻
- Kept monthly schedule at 04:00 and `dependencies` label unchanged. ⏰🏷️

### 🎯 Purpose & Impact
- Lowers PR flood, making it easier to review and merge updates consistently. ✅
- Avoids reviewer bottlenecks by not auto-assigning a single maintainer. 🔄
- Improves CI stability by limiting concurrent dependency changes. 🧪
- Possible trade-off: dependency updates may roll out slightly slower if there’s a backlog. ⏳