### PR TITLE
Update update_markdown_code_blocks.py

### DIFF
--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -39,6 +39,10 @@ def add_indentation(code_block, num_spaces):
 
 def format_code_with_ruff(temp_dir):
     """Formats Python code files in the specified directory using ruff linter and docformatter tools."""
+    if not next(Path(temp_dir).rglob("*.py"), None):
+        print("No Python code blocks found to format")
+        return
+
     try:
         # Run ruff format
         subprocess.run(


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Skip running formatters when no Python code blocks are found in extracted Markdown content, improving CI reliability and speed. 🚀

### 📊 Key Changes
- Added a pre-check in `format_code_with_ruff` to detect absence of `*.py` files.
- If no Python files are found, print “No Python code blocks found to format” and exit early.
- Prevents unnecessary calls to `ruff` and `docformatter`.

### 🎯 Purpose & Impact
- Faster CI runs on docs/Markdown-only changes ⏱️
- Cleaner logs with clear messaging 🧹
- Reduces risk of false failures when no code is present ✅
- Backward-compatible: behavior unchanged when Python code blocks exist 🔄