### PR TITLE
Update `uv==0.9.4`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
       with:
         ignore-empty-workdir: true
         enable-cache: false
-        version: "0.8.22"
+        version: "0.9.4"
     - name: Install Dependencies
       # Note tomli required for codespell with pyproject.toml
       env:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Bumps the uv setup GitHub Action version used in CI from 0.8.22 to 0.9.4 to improve reliability and performance 🚀

### 📊 Key Changes
- Update action step version: `version: "0.8.22"` → `version: "0.9.4"`
- Retains existing settings like `ignore-empty-workdir: true` and `enable-cache: false`

### 🎯 Purpose & Impact
- Better stability and performance in dependency setup during CI ✅
- Potential speedups and bug fixes from the newer uv action version ⚡
- No changes to user-facing APIs or behavior; impact is limited to CI pipelines and contributors 🛠️
- Helps keep tooling current, reducing maintenance overhead and future incompatibilities 🔧