### PR TITLE
Fix LEFT-RIGHT line numbers

### DIFF
--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -31,25 +31,31 @@ SKIP_PATTERNS = [
 
 
 def parse_diff_files(diff_text: str) -> dict:
-    """Parse diff to extract file paths, valid line numbers, and line content for comments."""
-    files, current_file, current_line = {}, None, 0
+    """Parse diff to extract file paths, valid line numbers, and line content for comments (both sides)."""
+    files, current_file, new_line, old_line = {}, None, 0, 0
 
     for line in diff_text.split("\n"):
         if line.startswith("diff --git"):
             match = re.search(r" b/(.+)$", line)
             current_file = match.group(1) if match else None
-            current_line = 0
+            new_line, old_line = 0, 0
             if current_file:
-                files[current_file] = {}
+                files[current_file] = {"RIGHT": {}, "LEFT": {}}
         elif line.startswith("@@") and current_file:
-            match = re.search(r"@@.*\+(\d+)(?:,\d+)?", line)
-            current_line = int(match.group(1)) if match else 0
-        elif current_file and current_line > 0:
+            # Extract both old and new line numbers
+            match = re.search(r"@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)?", line)
+            if match:
+                old_line, new_line = int(match.group(1)), int(match.group(2))
+        elif current_file and (new_line > 0 or old_line > 0):
             if line.startswith("+") and not line.startswith("+++"):
-                files[current_file][current_line] = line[1:]
-                current_line += 1
-            elif not line.startswith("-"):
-                current_line += 1
+                files[current_file]["RIGHT"][new_line] = line[1:]  # Added line (right/new side)
+                new_line += 1
+            elif line.startswith("-") and not line.startswith("---"):
+                files[current_file]["LEFT"][old_line] = line[1:]  # Removed line (left/old side)
+                old_line += 1
+            elif not line.startswith("\\"):  # Context line (ignore "No newline" markers)
+                new_line += 1
+                old_line += 1
 
     return files
 
@@ -65,8 +71,8 @@ def generate_pr_review(repository: str, diff_text: str, pr_title: str, pr_descri
 
     # Filter out generated/vendored files
     filtered_files = {
-        path: lines
-        for path, lines in diff_files.items()
+        path: sides
+        for path, sides in diff_files.items()
         if not any(re.search(pattern, path) for pattern in SKIP_PATTERNS)
     }
     skipped_count = len(diff_files) - len(filtered_files)
@@ -77,7 +83,7 @@ def generate_pr_review(repository: str, diff_text: str, pr_title: str, pr_descri
 
     file_list = list(diff_files.keys())
     diff_truncated = len(diff_text) > MAX_PROMPT_CHARS
-    lines_changed = sum(len(lines) for lines in diff_files.values())
+    lines_changed = sum(len(sides["RIGHT"]) + len(sides["LEFT"]) for sides in diff_files.values())
 
     content = (
         "You are an expert code reviewer for Ultralytics. Provide detailed inline comments on specific code changes.\n\n"
@@ -101,10 +107,15 @@ def generate_pr_review(repository: str, diff_text: str, pr_title: str, pr_descri
         "- Suggestion content must match the exact indentation of the original line\n"
         "- Avoid triple backticks (```) in suggestions as they break markdown formatting\n"
         "- It's better to flag an issue without a suggestion than provide a wrong or uncertain fix\n\n"
+        "LINE NUMBERS:\n"
+        "- RIGHT side (added +): line numbers from NEW file\n"
+        "- LEFT side (removed -): line numbers from OLD file\n"
+        "- CRITICAL: Verify line numbers match @@ hunks - incorrect numbers are rejected\n\n"
         "Return JSON: "
-        '{"comments": [{"file": "exact/path", "line": N, "severity": "HIGH", "message": "...", "suggestion": "..."}], "summary": "..."}\n\n'
+        '{"comments": [{"file": "exact/path", "line": N, "side": "RIGHT", "severity": "HIGH", "message": "..."}], "summary": "..."}\n\n'
         "Rules:\n"
-        "- Only NEW lines (+ in diff), exact paths (no ./), correct line numbers from @@ hunks\n"
+        "- Verify line numbers from @@ hunks: +N for RIGHT (added), -N for LEFT (removed)\n"
+        "- Exact paths (no ./), 'side' field defaults to RIGHT if omitted\n"
         "- Severity: CRITICAL, HIGH, MEDIUM, LOW, SUGGESTION\n"
         f"- Files changed: {len(file_list)} ({', '.join(file_list[:10])}{'...' if len(file_list) > 10 else ''})\n"
         f"- Lines changed: {lines_changed}\n"
@@ -138,11 +149,23 @@ def generate_pr_review(repository: str, diff_text: str, pr_title: str, pr_descri
         for c in review_data.get("comments", []):
             file_path, line_num = c.get("file"), c.get("line", 0)
             start_line = c.get("start_line")
+            side = c.get("side", "RIGHT")  # Default to RIGHT (added lines)
 
-            # Validate line numbers are in diff
-            if file_path not in diff_files or line_num not in diff_files[file_path]:
-                print(f"Filtered out {file_path}:{line_num} (available: {list(diff_files.get(file_path, {}))[:10]}...)")
+            # Validate line numbers are in diff (check appropriate side)
+            if file_path not in diff_files:
+                print(f"Filtered out {file_path}:{line_num} (file not in diff)")
                 continue
+            if line_num not in diff_files[file_path].get(side, {}):
+                # Try other side if not found
+                other_side = "LEFT" if side == "RIGHT" else "RIGHT"
+                if line_num in diff_files[file_path].get(other_side, {}):
+                    print(f"Switching {file_path}:{line_num} from {side} to {other_side}")
+                    c["side"] = other_side
+                    side = other_side
+                else:
+                    available = {s: list(diff_files[file_path][s].keys())[:10] for s in ["RIGHT", "LEFT"]}
+                    print(f"Filtered out {file_path}:{line_num} (available: {available})")
+                    continue
 
             # Validate start_line if provided - drop start_line for suggestions (single-line only)
             if start_line:
@@ -152,12 +175,12 @@ def generate_pr_review(repository: str, diff_text: str, pr_title: str, pr_descri
                 elif start_line >= line_num:
                     print(f"Invalid start_line {start_line} >= line {line_num} for {file_path}, dropping start_line")
                     c.pop("start_line", None)
-                elif start_line not in diff_files[file_path]:
+                elif start_line not in diff_files[file_path].get(side, {}):
                     print(f"start_line {start_line} not in diff for {file_path}, dropping start_line")
                     c.pop("start_line", None)
 
-            # Deduplicate by line number
-            key = f"{file_path}:{line_num}"
+            # Deduplicate by line number and side
+            key = f"{file_path}:{side}:{line_num}"
             if key not in unique_comments:
                 unique_comments[key] = c
             else:
@@ -269,22 +292,25 @@ def post_review_summary(event: Action, review_data: dict, review_number: int) ->
         severity = comment.get("severity") or "SUGGESTION"
         comment_body = f"{EMOJI_MAP.get(severity, '💭')} **{severity}**: {(comment.get('message') or '')[:1000]}"
 
+        # Get side (LEFT for removed lines, RIGHT for added lines)
+        side = comment.get("side", "RIGHT")
+
         if suggestion := comment.get("suggestion"):
             suggestion = suggestion[:1000]  # Clip suggestion length
             if "```" not in suggestion:
                 # Extract original line indentation and apply to suggestion
-                if original_line := review_data.get("diff_files", {}).get(file_path, {}).get(line):
+                if original_line := review_data.get("diff_files", {}).get(file_path, {}).get(side, {}).get(line):
                     indent = len(original_line) - len(original_line.lstrip())
                     suggestion = " " * indent + suggestion.strip()
                 comment_body += f"\n\n**Suggested change:**\n```suggestion\n{suggestion}\n```"
 
         # Build comment with optional start_line for multi-line context
-        review_comment = {"path": file_path, "line": line, "body": comment_body, "side": "RIGHT"}
+        review_comment = {"path": file_path, "line": line, "body": comment_body, "side": side}
         if start_line := comment.get("start_line"):
             if start_line < line:
                 review_comment["start_line"] = start_line
-                review_comment["start_side"] = "RIGHT"
-                print(f"Multi-line comment: {file_path}:{start_line}-{line}")
+                review_comment["start_side"] = side
+                print(f"Multi-line comment: {file_path}:{start_line}-{line} ({side})")
 
         review_comments.append(review_comment)
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixes and enhances diff parsing and review comment generation to correctly handle LEFT (old) and RIGHT (new) line numbers, improving accuracy of automated PR reviews. 🛠️

### 📊 Key Changes
- Update parse_diff_files to track both old and new hunk line numbers and store content by side: {"RIGHT": {}, "LEFT": {}}
- Validate comments against the correct side with automatic side switching if mismatched; deduplicate by file+side+line
- Count changes across both sides and improve logging of available lines per side
- Extend review prompt with clear LEFT/RIGHT guidance and add a side field to the JSON schema
- Preserve indentation for suggestions using side-aware original line lookup
- Include side and start_side in posted review comments for accurate GitHub rendering

### 🎯 Purpose & Impact
- Prevents invalid or rejected comments by aligning line numbers with @@ hunk semantics
- Enables precise feedback on both added (RIGHT) and removed (LEFT) lines
- Reduces dropped comments and improves reliability of automated code reviews
- Improves multi-line context and suggestion formatting for clearer reviewer guidance ✨