### PR TITLE
Revert "Install `.prettierrc` plugins"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -176,17 +176,7 @@ runs:
     - name: Run Prettier
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (inputs.prettier == 'true' || inputs.markdown == 'true') && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
-        # Build validated plugin list
-        plugins=("prettier@3.6.2" "prettier-plugin-sh")
-        if [ -f ".prettierrc" ]; then
-          for plugin in $(grep -oE '"(@[^/]+/)?prettier-plugin-[^"]*"' .prettierrc | tr -d '"' || true); do
-            # Validate plugin name contains only safe characters
-            if [[ "$plugin" =~ ^[@a-zA-Z0-9/_-]+$ ]]; then
-              plugins+=("$plugin")
-            fi
-          done
-        fi
-        npm install --global "${plugins[@]}"
+        npm install --global prettier@3.6.2 prettier-plugin-sh
         ultralytics-actions-update-markdown-code-blocks
         npx prettier --write --list-different "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json'
         # Bash file format


### PR DESCRIPTION
Reverts ultralytics/actions#593

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Simplifies the Prettier install step in the GitHub Action to use a fixed, minimal plugin set for safer and more consistent formatting. ✨

### 📊 Key Changes
- Replaces dynamic discovery/installation of Prettier plugins from `.prettierrc` with a fixed install of `prettier@3.6.2` and `prettier-plugin-sh`.
- Removes shell logic that parsed `.prettierrc` and validated plugin names.
- Keeps existing Prettier execution and file patterns unchanged.

### 🎯 Purpose & Impact
- Improves security by preventing arbitrary plugin installation from PR content. 🔒
- Increases reliability and determinism of CI formatting runs across repositories. ✅
- Speeds up CI by avoiding extra parsing and network installs for additional plugins. ⚡
- Potential trade-off: projects relying on extra Prettier plugins (e.g., Tailwind-specific formatting) won’t have those plugins available in this action, which may reduce specialized formatting behavior.