### PR TITLE
Ruff extend-select F

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,7 @@ runs:
         ruff check \
         --fix \
         --unsafe-fixes \
-        --extend-select F401,F841,I,D,UP \
+        --extend-select F,I,D,UP \
         --target-version py39 \
         --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413 \
         . || true


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enable stricter Ruff linting by adding Pyflakes checks (F) to the GitHub Action’s lint step ✅

### 📊 Key Changes
- Added `F` (Pyflakes) to `--extend-select` in `ruff check` within `action.yml`
- Existing selections (`I`, `D`, `UP`) remain: import sorting, docstring, and pyupgrade checks
- Keeps `--fix` and `--unsafe-fixes` enabled with `|| true` to avoid failing the job

### 🎯 Purpose & Impact
- Improves code quality by catching issues like undefined names, unused variables/imports, and logical errors 🧹
- Increases auto-fix coverage (e.g., removing unused imports), reducing manual cleanup for contributors ⚙️
- Maintains non-blocking CI behavior, so developers get stricter lint feedback without failing builds 🚦
- Leads to more consistent, reliable code across repositories using this action 📈