### PR TITLE
Update action.yml with `--extend-select RUF`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,7 @@ runs:
         ruff check \
         --fix \
         --unsafe-fixes \
-        --extend-select F,I,D,UP \
+        --extend-select F,I,D,UP,RUF \
         --target-version py39 \
         --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413 \
         . || true


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Expands Ruff linting in the GitHub Action by enabling Ruff’s native rule set (RUF) for broader, more consistent code quality checks. ✅

### 📊 Key Changes
- Adds `RUF` to Ruff’s `--extend-select` set in `action.yml`:
  - From: `F,I,D,UP`
  - To: `F,I,D,UP,RUF`
- Keeps existing options: `--fix`, `--unsafe-fixes`, Python 3.9 target, and selected docstring ignores.

### 🎯 Purpose & Impact
- Improves code quality by enforcing Ruff’s own best-practice rules alongside Pyflakes (F), isort (I), pydocstyle (D), and pyupgrade (UP). 🧹
- Enables more automatic fixes, reducing manual cleanup and ensuring more consistent style across repos using this action. ⚙️
- May surface additional warnings or suggestions; however, the action remains non-blocking (`|| true`), so CI won’t fail. 🚦
- Slightly broader lint coverage could marginally increase runtime but enhances maintainability and readability overall. 📈