### PR TITLE
Revert "Update action.yml with `--extend-select RUF`"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,7 @@ runs:
         ruff check \
         --fix \
         --unsafe-fixes \
-        --extend-select F,I,D,UP,RUF \
+        --extend-select F,I,D,UP \
         --target-version py39 \
         --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413 \
         . || true


### PR DESCRIPTION
Reverts ultralytics/actions#600

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes the RUF rule family from Ruff linting in the GitHub Action to reduce noisy or risky autofixes. ✅

### 📊 Key Changes
- Updates `ruff check` in `action.yml` to drop `RUF` from `--extend-select` (now `F,I,D,UP`).
- Keeps autofix enabled with `--fix` and `--unsafe-fixes`, but applies to fewer rule families.
- Maintains Python target `py39` and existing docstring ignores.

### 🎯 Purpose & Impact
- Reduces unexpected or overly aggressive autofixes from Ruff-specific rules 🛡️
- Lowers lint noise for contributors, making CI results clearer and more predictable 📉
- Minimizes risk of stylistic churn or unintended code changes during CI ✨
- Slightly faster linting by checking fewer rules ⚡