### PR TITLE
Run dispatch fork requests on temp branches

### DIFF
--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -31,20 +31,21 @@ def test_get_pr_branch():
 def test_get_pr_branch_fork():
     """Test getting PR branch name for fork PRs."""
     mock_event = MagicMock()
-    mock_event.event_data = {"issue": {"number": 456}, "comment": {"id": 789}}
+    mock_event.event_data = {"issue": {"number": 456}}
     mock_event.repository = "base/repo"
     mock_event.get_repo_data.return_value = {
         "head": {"ref": "fork-branch", "sha": "abc123", "repo": {"id": 2}},
         "base": {"repo": {"id": 1}},
     }
 
-    branch, temp_branch = get_pr_branch(mock_event)
+    with patch("time.time", return_value=1234567.890):
+        branch, temp_branch = get_pr_branch(mock_event)
 
-    assert branch == "temp-ci-456-789"
-    assert temp_branch == "temp-ci-456-789"
+    assert branch == "temp-ci-456-1234567890"
+    assert temp_branch == "temp-ci-456-1234567890"
     mock_event.post.assert_called_once_with(
         "https://api.github.com/repos/base/repo/git/refs",
-        json={"ref": "refs/heads/temp-ci-456-789", "sha": "abc123"},
+        json={"ref": "refs/heads/temp-ci-456-1234567890", "sha": "abc123"},
     )
 
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enable CI for forked PRs by creating temporary branches in the base repo, with automatic cleanup and more reliable workflow detection. 🚀🧹

### 📊 Key Changes
- get_pr_branch now returns a tuple (branch, temp_branch) and creates a temporary branch for forked PRs (e.g., `temp-ci-<pr>-<timestamp>`) pointing to the PR head SHA. 🔀
- trigger_and_get_workflow_info accepts temp_branch, increases the wait time before fetching runs from 10s to 60s, and always deletes the temp branch in a finally block. ⏱️🧹
- main updated to handle the new return type and log when a temp branch is used. 📝
- Added tests for fork PR handling and temp-branch deletion; updated existing tests accordingly. ✅

### 🎯 Purpose & Impact
- CI now runs for PRs from forks, overcoming workflow permission limitations. 🔒
- Automatic temp-branch cleanup keeps the repo tidy and avoids stale refs. 🧼
- Longer wait improves reliability when fetching newly triggered workflow runs, reducing flaky “run not found” issues. 📈
- Backward compatible: same-repo PRs behave as before; only forked PRs use temp branches. 🔁
- Requires sufficient token permissions to create/delete refs on the base repo (contents: write). 🔑