### PR TITLE
Add "Example Usage" to format_python_docstrings.py

### DIFF
--- a/actions/format_python_docstrings.py
+++ b/actions/format_python_docstrings.py
@@ -32,6 +32,7 @@ SECTION_ALIASES = {
     "Example": "Examples",
     "Return": "Returns",
     "Note": "Notes",
+    "Reference": "References",
 }
 LIST_RX = re.compile(r"""^(\s*)(?:[-*•]\s+|(?:\d+|[A-Za-z]+)[\.\)]\s+)""")
 TABLE_RX = re.compile(r"^\s*\|.*\|\s*$")


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Expands the docstring formatter to recognize more heading variations and normalize them for consistent documentation. ✨

### 📊 Key Changes
- Adds "Example Usage" → normalized to "Examples"
- Adds "Reference" → normalized to "References"
- Maintains existing mappings for "Usage", "Usage Example", "Usage Examples", "Example", "Return", and "Note"

### 🎯 Purpose & Impact
- Ensures consistent docstring section names across the codebase, improving readability and docs quality 📚
- Reduces CI noise and review churn by auto-formatting common heading variations ✅
- Improves compatibility with documentation tools that expect standard section headers 🔧
- Backward compatible; no behavior changes outside of docstring formatting 🧩