### PR TITLE
Reduce PR Review API calls with GraphQL

### DIFF
--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -195,7 +195,9 @@ def main(*args, **kwargs):
 
         if summary := response.get("summary"):
             print("Updating PR description with summary...")
-            event.update_pr_description(number, f"{SUMMARY_MARKER}\n\n{ACTIONS_CREDIT}\n\n{summary}", pr_data.get("body"))
+            event.update_pr_description(
+                number, f"{SUMMARY_MARKER}\n\n{ACTIONS_CREDIT}\n\n{summary}", pr_data.get("body")
+            )
         else:
             summary = body
 

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -219,21 +219,22 @@ def main(*args, **kwargs):
         return
 
     # Handle issues and discussions (NOT PRs)
-    available_labels = event.get_repo_data("labels")
-    label_descriptions = {label["name"]: label.get("description") or "" for label in available_labels}
+    if issue_type != "pull request":
+        available_labels = event.get_repo_data("labels")
+        label_descriptions = {label["name"]: label.get("description") or "" for label in available_labels}
 
-    current_labels = (
-        []
-        if issue_type == "discussion"
-        else [label["name"].lower() for label in event.get_repo_data(f"issues/{number}/labels")]
-    )
+        current_labels = (
+            []
+            if issue_type == "discussion"
+            else [label["name"].lower() for label in event.get_repo_data(f"issues/{number}/labels")]
+        )
 
-    relevant_labels = get_relevant_labels(issue_type, title, body, label_descriptions, current_labels)
-    apply_and_check_labels(event, number, node_id, issue_type, username, relevant_labels, label_descriptions)
+        relevant_labels = get_relevant_labels(issue_type, title, body, label_descriptions, current_labels)
+        apply_and_check_labels(event, number, node_id, issue_type, username, relevant_labels, label_descriptions)
 
-    if action in {"opened", "created"}:
-        custom_response = get_first_interaction_response(event, issue_type, title, body, username)
-        event.add_comment(number, node_id, custom_response, issue_type)
+        if action in {"opened", "created"}:
+            custom_response = get_first_interaction_response(event, issue_type, title, body, username)
+            event.add_comment(number, node_id, custom_response, issue_type)
 
 
 if __name__ == "__main__":

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -378,7 +378,9 @@ def dismiss_previous_reviews(event: Action) -> int:
                 event.put(f"{reviews_base}/{review_id}/dismissals", json={"message": "Superseded by new review"})
 
     # Batch delete all inline comments (with author verification)
-    comment_ids = [c["databaseId"] for c in comments if c.get("databaseId") and c.get("author", {}).get("login") == bot_username]
+    comment_ids = [
+        c["databaseId"] for c in comments if c.get("databaseId") and c.get("author", {}).get("login") == bot_username
+    ]
     event.batch_delete_review_comments(comment_ids)
 
     return review_count + 1

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -361,11 +361,12 @@ def dismiss_previous_reviews(event: Action) -> int:
     if not (pr_number := event.pr.get("number")):
         return 1
 
-    # Fetch reviews and comments in single GraphQL query
-    reviews, comments = event.get_pr_reviews_and_comments(pr_number)
     bot_username = event.get_username()
     if not bot_username:
         return 1
+
+    # Fetch reviews and comments in single GraphQL query
+    reviews, comments = event.get_pr_reviews_and_comments(pr_number)
 
     review_count = 0
     reviews_base = f"{GITHUB_API_URL}/repos/{event.repository}/pulls/{pr_number}/reviews"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -378,7 +378,7 @@ def dismiss_previous_reviews(event: Action) -> int:
                 event.put(f"{reviews_base}/{review_id}/dismissals", json={"message": "Superseded by new review"})
 
     # Batch delete all inline comments (with author verification)
-    comment_ids = [c["id"] for c in comments if c.get("id") and c.get("author", {}).get("login") == bot_username]
+    comment_ids = [c["databaseId"] for c in comments if c.get("databaseId") and c.get("author", {}).get("login") == bot_username]
     event.batch_delete_review_comments(comment_ids)
 
     return review_count + 1

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -365,7 +365,7 @@ def dismiss_previous_reviews(event: Action) -> int:
         return 1
 
     # Fetch reviews and comments in single GraphQL query
-    reviews, comments = event.get_pr_reviews_and_comments(pr_number)
+    _reviews, _comments = event.get_pr_reviews_and_comments(pr_number)
 
     review_count = 0
     reviews_base = f"{GITHUB_API_URL}/repos/{event.repository}/pulls/{pr_number}/reviews"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -188,7 +188,7 @@ def generate_pr_review(
         "- Extract line numbers from R#### or L#### prefixes in the diff\n"
         "- Exact paths (no ./), 'side' field must match R (RIGHT) or L (LEFT) prefix\n"
         "- Severity: CRITICAL, HIGH, MEDIUM, LOW, SUGGESTION\n"
-        f"- Keep feedback concise: {TARGET_REVIEW_COMMENTS} issues max (less is better) with hard cap at {MAX_REVIEW_COMMENTS}\n"
+        f"- Keep feedback concise: less than {TARGET_REVIEW_COMMENTS} issues is ideal (less is better) with hard cap at {MAX_REVIEW_COMMENTS}\n"
         f"- Files changed: {len(file_list)} ({', '.join(file_list[:30])}{'...' if len(file_list) > 30 else ''})\n"
         f"- Lines changed: {lines_changed}\n"
     )

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from .utils import ACTIONS_CREDIT, GITHUB_API_URL, GRAPHQL_LABEL_AND_COMMENT_ISSUE, Action, get_pr_summary_prompt, get_response
+from .utils import (
+    ACTIONS_CREDIT,
+    GITHUB_API_URL,
+    GRAPHQL_LABEL_AND_COMMENT_ISSUE,
+    Action,
+    get_pr_summary_prompt,
+    get_response,
+)
 
 SUMMARY_MARKER = "## 🛠️ PR Summary"
 
@@ -98,11 +105,9 @@ def label_fixed_issues(event, pr_summary):
 
     # Batch label and comment all issues using GraphQL mutations
     for issue_node_id in issue_node_ids.values():
-        event.graphql_request(GRAPHQL_LABEL_AND_COMMENT_ISSUE, {
-            "issueId": issue_node_id,
-            "labelIds": label_ids,
-            "body": comment
-        })
+        event.graphql_request(
+            GRAPHQL_LABEL_AND_COMMENT_ISSUE, {"issueId": issue_node_id, "labelIds": label_ids, "body": comment}
+        )
 
     return pr_credit
 

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .utils import ACTIONS_CREDIT, GITHUB_API_URL, Action, get_pr_summary_prompt, get_response
+from .utils import ACTIONS_CREDIT, GITHUB_API_URL, GRAPHQL_LABEL_AND_COMMENT_ISSUE, Action, get_pr_summary_prompt, get_response
 
 SUMMARY_MARKER = "## 🛠️ PR Summary"
 
@@ -82,11 +82,27 @@ def label_fixed_issues(event, pr_summary):
         return None
 
     comment = generate_issue_comment(data["url"], pr_summary, pr_credit, data.get("title") or "")
+    closing_issues = data["closingIssuesReferences"]["nodes"]
+    if not closing_issues:
+        return pr_credit
 
-    for issue in data["closingIssuesReferences"]["nodes"]:
-        number = issue["number"]
-        event.post(f"{GITHUB_API_URL}/repos/{event.repository}/issues/{number}/labels", json={"labels": ["fixed"]})
-        event.post(f"{GITHUB_API_URL}/repos/{event.repository}/issues/{number}/comments", json={"body": comment})
+    # Batch get all issue node IDs in single query
+    issue_numbers = [issue["number"] for issue in closing_issues]
+    issue_node_ids = event.get_multiple_issue_node_ids(issue_numbers)
+
+    # Get label IDs once
+    label_ids = event.get_label_ids(["fixed"])
+    if not label_ids:
+        print("Warning: 'fixed' label not found")
+        return pr_credit
+
+    # Batch label and comment all issues using GraphQL mutations
+    for issue_num, issue_node_id in issue_node_ids.items():
+        event.graphql_request(GRAPHQL_LABEL_AND_COMMENT_ISSUE, {
+            "issueId": issue_node_id,
+            "labelIds": label_ids,
+            "body": comment
+        })
 
     return pr_credit
 
@@ -108,9 +124,9 @@ def main(*args, **kwargs):
     print("Generating PR summary...")
     summary = generate_pr_summary(event.repository, diff)
 
-    # Update PR description
+    # Update PR description - use cached body from event data
     print("Updating PR description...")
-    event.update_pr_description(event.pr["number"], summary)
+    event.update_pr_description(event.pr["number"], summary, event.pr.get("body"))
 
     if event.pr.get("merged"):
         print("PR is merged, labeling fixed issues...")

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from .utils import ACTIONS_CREDIT, GITHUB_API_URL, GRAPHQL_LABEL_AND_COMMENT_ISSUE, Action, get_pr_summary_prompt, get_response
+from .utils import (
+    ACTIONS_CREDIT,
+    GITHUB_API_URL,
+    GRAPHQL_LABEL_AND_COMMENT_ISSUE,
+    Action,
+    get_pr_summary_prompt,
+    get_response,
+)
 
 SUMMARY_MARKER = "## 🛠️ PR Summary"
 
@@ -98,11 +105,9 @@ def label_fixed_issues(event, pr_summary):
 
     # Batch label and comment all issues using GraphQL mutations
     for issue_num, issue_node_id in issue_node_ids.items():
-        event.graphql_request(GRAPHQL_LABEL_AND_COMMENT_ISSUE, {
-            "issueId": issue_node_id,
-            "labelIds": label_ids,
-            "body": comment
-        })
+        event.graphql_request(
+            GRAPHQL_LABEL_AND_COMMENT_ISSUE, {"issueId": issue_node_id, "labelIds": label_ids, "body": comment}
+        )
 
     return pr_credit
 

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -97,7 +97,7 @@ def label_fixed_issues(event, pr_summary):
         return pr_credit
 
     # Batch label and comment all issues using GraphQL mutations
-    for issue_num, issue_node_id in issue_node_ids.items():
+    for issue_node_id in issue_node_ids.values():
         event.graphql_request(GRAPHQL_LABEL_AND_COMMENT_ISSUE, {
             "issueId": issue_node_id,
             "labelIds": label_ids,

--- a/actions/utils/__init__.py
+++ b/actions/utils/__init__.py
@@ -9,7 +9,7 @@ from .common_utils import (
     allow_redirect,
     remove_html_comments,
 )
-from .github_utils import GITHUB_API_URL, GITHUB_GRAPHQL_URL, Action, ultralytics_actions_info
+from .github_utils import GITHUB_API_URL, GITHUB_GRAPHQL_URL, GRAPHQL_LABEL_AND_COMMENT_ISSUE, Action, ultralytics_actions_info
 from .openai_utils import (
     MAX_PROMPT_CHARS,
     filter_labels,
@@ -25,6 +25,7 @@ __all__ = (
     "ACTIONS_CREDIT",
     "GITHUB_API_URL",
     "GITHUB_GRAPHQL_URL",
+    "GRAPHQL_LABEL_AND_COMMENT_ISSUE",
     "MAX_PROMPT_CHARS",
     "REDIRECT_END_IGNORE_LIST",
     "REDIRECT_START_IGNORE_LIST",

--- a/actions/utils/__init__.py
+++ b/actions/utils/__init__.py
@@ -9,7 +9,13 @@ from .common_utils import (
     allow_redirect,
     remove_html_comments,
 )
-from .github_utils import GITHUB_API_URL, GITHUB_GRAPHQL_URL, GRAPHQL_LABEL_AND_COMMENT_ISSUE, Action, ultralytics_actions_info
+from .github_utils import (
+    GITHUB_API_URL,
+    GITHUB_GRAPHQL_URL,
+    GRAPHQL_LABEL_AND_COMMENT_ISSUE,
+    Action,
+    ultralytics_actions_info,
+)
 from .openai_utils import (
     MAX_PROMPT_CHARS,
     filter_labels,

--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -471,12 +471,12 @@ Thank you 🙏
 
         pr_data = result.get("data", {}).get("repository", {}).get("pullRequest", {})
         reviews = pr_data.get("reviews", {}).get("nodes", [])
-        
+
         # Flatten comments from all reviews
         comments = []
         for review in reviews:
             comments.extend(review.get("comments", {}).get("nodes", []))
-        
+
         return reviews, comments
 
     def batch_delete_review_comments(self, comment_ids: list[str]) -> None:

--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -343,7 +343,9 @@ class Action:
             updated_description = current_body.split(start)[0].rstrip() + "\n\n" + new_summary
         else:
             print("PR Summary not found, appending.")
-            updated_description = (current_body.rstrip() + "\n\n" + new_summary) if current_body.strip() else new_summary
+            updated_description = (
+                (current_body.rstrip() + "\n\n" + new_summary) if current_body.strip() else new_summary
+            )
 
         self.patch(url, json={"body": updated_description})
         self._pr_summary_cache = new_summary
@@ -494,16 +496,20 @@ Thank you 🙏
         owner, repo = self.repository.split("/")
         queries = []
         for i, num in enumerate(issue_numbers):
-            queries.append(f'issue{i}: issue(number: {num}) {{ id }}')
+            queries.append(f"issue{i}: issue(number: {num}) {{ id }}")
 
         query = f"""query {{
             repository(owner: \"{owner}\", name: \"{repo}\") {{
-                {' '.join(queries)}
+                {" ".join(queries)}
             }}
         }}"""
         result = self.graphql_request(query)
         repo_data = result.get("data", {}).get("repository", {})
-        return {num: repo_data.get(f"issue{i}", {}).get("id") for i, num in enumerate(issue_numbers) if repo_data.get(f"issue{i}")}
+        return {
+            num: repo_data.get(f"issue{i}", {}).get("id")
+            for i, num in enumerate(issue_numbers)
+            if repo_data.get(f"issue{i}")
+        }
 
     def get_pr_contributors(self) -> tuple[str | None, dict]:
         """Gets PR contributors and closing issues, returns (pr_credit_string, pr_data)."""

--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -482,14 +482,17 @@ Thank you 🙏
         # Limit to first 50 comments to avoid hitting GraphQL complexity limits
         comment_ids = comment_ids[:50]
 
+        # Build mutation with variables
         mutations = []
+        var_defs = []
+        variables = {}
         for i, comment_id in enumerate(comment_ids):
-            mutations.append(
-                f'delete{i}: deletePullRequestReviewComment(input: {{id: "{comment_id}"}}) {{ clientMutationId }}'
-            )
+            mutations.append(f"delete{i}: deletePullRequestReviewComment(input: {{id: $id{i}}}) {{ clientMutationId }}")
+            var_defs.append(f"$id{i}: ID!")
+            variables[f"id{i}"] = comment_id
 
-        mutation = f"mutation {{ {' '.join(mutations)} }}"
-        self.graphql_request(mutation)
+        mutation = f"mutation({', '.join(var_defs)}) {{ {' '.join(mutations)} }}"
+        self.graphql_request(mutation, variables)
 
     def get_multiple_issue_node_ids(self, issue_numbers: list[int]) -> dict[int, str]:
         """Gets multiple issue node IDs in a single GraphQL query."""

--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -343,7 +343,9 @@ class Action:
             updated_description = current_body.split(start)[0].rstrip() + "\n\n" + new_summary
         else:
             print("PR Summary not found, appending.")
-            updated_description = (current_body.rstrip() + "\n\n" + new_summary) if current_body.strip() else new_summary
+            updated_description = (
+                (current_body.rstrip() + "\n\n" + new_summary) if current_body.strip() else new_summary
+            )
 
         self.patch(url, json={"body": updated_description})
         self._pr_summary_cache = new_summary
@@ -479,7 +481,7 @@ Thank you 🙏
 
         # Limit to first 50 comments to avoid hitting GraphQL complexity limits
         comment_ids = comment_ids[:50]
-        
+
         mutations = []
         for i, comment_id in enumerate(comment_ids):
             mutations.append(
@@ -495,28 +497,32 @@ Thank you 🙏
             return {}
 
         owner, repo = self.repository.split("/")
-        
+
         # Build parameterized query to avoid injection risks
         query_parts = []
         for i in range(len(issue_numbers)):
-            query_parts.append(f'issue{i}: issue(number: $num{i}) {{ id }}')
-        
+            query_parts.append(f"issue{i}: issue(number: $num{i}) {{ id }}")
+
         variables = {f"num{i}": num for i, num in enumerate(issue_numbers)}
         variables["owner"] = owner
         variables["repo"] = repo
-        
+
         # Build variable definitions
         var_defs = ["$owner: String!", "$repo: String!"] + [f"$num{i}: Int!" for i in range(len(issue_numbers))]
-        
-        query = f"""query({', '.join(var_defs)}) {{
+
+        query = f"""query({", ".join(var_defs)}) {{
             repository(owner: $owner, name: $repo) {{
-                {' '.join(query_parts)}
+                {" ".join(query_parts)}
             }}
         }}"""
-        
+
         result = self.graphql_request(query, variables)
         repo_data = result.get("data", {}).get("repository", {})
-        return {num: repo_data.get(f"issue{i}", {}).get("id") for i, num in enumerate(issue_numbers) if repo_data.get(f"issue{i}")}
+        return {
+            num: repo_data.get(f"issue{i}", {}).get("id")
+            for i, num in enumerate(issue_numbers)
+            if repo_data.get(f"issue{i}")
+        }
 
     def get_pr_contributors(self) -> tuple[str | None, dict]:
         """Gets PR contributors and closing issues, returns (pr_credit_string, pr_data)."""

--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -125,7 +125,7 @@ query($owner: String!, $repo: String!, $number: Int!, $botLogin: String!) {
                     author { login }
                 }
             }
-            comments(last: 100) {
+            reviewComments(last: 100) {
                 nodes {
                     id
                     author { login }

--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -125,7 +125,7 @@ query($owner: String!, $repo: String!, $number: Int!, $botLogin: String!) {
                     author { login }
                 }
             }
-            comments(first: 100, author: $botLogin) {
+            comments(last: 100) {
                 nodes {
                     id
                     author { login }

--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -123,12 +123,12 @@ query($owner: String!, $repo: String!, $number: Int!, $botLogin: String!) {
                     state
                     body
                     author { login }
-                }
-            }
-            reviewComments(last: 100) {
-                nodes {
-                    id
-                    author { login }
+                    comments(last: 100) {
+                        nodes {
+                            id
+                            author { login }
+                        }
+                    }
                 }
             }
         }
@@ -471,7 +471,12 @@ Thank you 🙏
 
         pr_data = result.get("data", {}).get("repository", {}).get("pullRequest", {})
         reviews = pr_data.get("reviews", {}).get("nodes", [])
-        comments = pr_data.get("comments", {}).get("nodes", [])
+        
+        # Flatten comments from all reviews
+        comments = []
+        for review in reviews:
+            comments.extend(review.get("comments", {}).get("nodes", []))
+        
         return reviews, comments
 
     def batch_delete_review_comments(self, comment_ids: list[str]) -> None:

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -37,15 +37,15 @@ def test_get_event_content_pr():
     # Create mock event
     mock_event = MagicMock()
     mock_event.event_name = "pull_request"
-    mock_event.event_data = {"action": "opened", "pull_request": {"number": 456}}
-
-    # Mock PR data returned from API
-    mock_event.get_repo_data.return_value = {
-        "number": 456,
-        "node_id": "node456",
-        "title": "Test PR",
-        "body": "PR description",
-        "user": {"login": "testuser"},
+    mock_event.event_data = {
+        "action": "opened",
+        "pull_request": {
+            "number": 456,
+            "node_id": "node456",
+            "title": "Test PR",
+            "body": "PR description",
+            "user": {"login": "testuser"},
+        },
     }
 
     number, node_id, title, body, username, issue_type, action = get_event_content(mock_event)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Optimize GitHub PR workflows by batching multiple REST calls into fewer GraphQL requests for PR summaries, reviews, and issue labeling 🚀

### 📊 Key Changes
- 🔁 Reuse existing `pull_request` payload data instead of performing an extra REST call when handling new PR events.
- 🧵 Introduce `get_pr_details_and_labels` to fetch PR body and repository labels in a single GraphQL query for PR-open handling.
- 🧹 Refactor `dismiss_previous_reviews` to use `get_pr_reviews_and_comments` (GraphQL) and `batch_delete_review_comments` to fetch and delete bot reviews/comments more efficiently.
- 🏷️ Add `GRAPHQL_LABEL_AND_COMMENT_ISSUE` and related helpers (`get_multiple_issue_node_ids`, `get_label_ids` usage) to batch-label and comment on closing issues via GraphQL instead of multiple REST calls.
- 📝 Enhance `update_pr_description` to accept a cached PR body, reducing redundant fetches while still safely handling missing descriptions.
- 🔗 Export new GraphQL constants from `actions.utils` and wire them into `summarize_pr.py` and other call sites.

### 🎯 Purpose & Impact
- ⚡ Reduces the number of GitHub REST API calls, lowering latency and the risk of hitting rate limits for busy repositories.
- 🧠 Centralizes PR, review, comment, and label handling through GraphQL, simplifying maintenance and future extensions.
- 🔒 Adds defense-in-depth checks on review/comment authors, improving safety when dismissing or deleting bot-generated content.
- ✅ Keeps existing behavior (summaries, labels, issue auto-labeling) while making the implementation more efficient and scalable for Ultralytics workflows.