### PR TITLE
Update redirect ignore rules

### DIFF
--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -142,13 +142,15 @@ REDIRECT_START_IGNORE_LIST = frozenset(
         "ultralytics.com/actions",
         "ultralytics.com/bilibili",
         "ultralytics.com/images",
-        "ultralytics.com/license",
+        "ultralytics.com/app-install",
         "ultralytics.com/assets",
         "app.gong.io/call?",
         "docs.openvino.ai",
         ".git",
         "/raw/",  # GitHub images
         ".slack.com",  # Slack URLs to private channels
+        "https://maps.app.goo.gl/nxB8YygRQeXSS9G18", # Ultralytics Madrid office - Cra de San Jeronimo 15
+        "https://maps.app.goo.gl/9sdE3KrQVwc2shb86", # Ultralytics London office - 50 York Way
     }
     | URL_IGNORE_LIST
 )

--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -149,8 +149,8 @@ REDIRECT_START_IGNORE_LIST = frozenset(
         ".git",
         "/raw/",  # GitHub images
         ".slack.com",  # Slack URLs to private channels
-        "https://maps.app.goo.gl/nxB8YygRQeXSS9G18", # Ultralytics Madrid office - Cra de San Jeronimo 15
-        "https://maps.app.goo.gl/9sdE3KrQVwc2shb86", # Ultralytics London office - 50 York Way
+        "https://maps.app.goo.gl/nxB8YygRQeXSS9G18",  # Ultralytics Madrid office - Cra de San Jeronimo 15
+        "https://maps.app.goo.gl/9sdE3KrQVwc2shb86",  # Ultralytics London office - 50 York Way
     }
     | URL_IGNORE_LIST
 )


### PR DESCRIPTION
## Summary
- update redirect ignore rules in `REDIRECT_START_IGNORE_LIST`
- replace `ultralytics.com/license` with `ultralytics.com/app-install`
- add Google Maps short links for the Madrid and London offices

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔗 This PR updates the URL ignore list in `common_utils.py` to allow newly approved Ultralytics links and office location map links to pass automated checks.

### 📊 Key Changes
- Replaced the ignored URL `ultralytics.com/license` with `ultralytics.com/app-install`.
- Added two Google Maps short links to the ignore list:
  - Ultralytics Madrid office
  - Ultralytics London office
- Kept these links within the shared URL filtering logic in `actions/utils/common_utils.py`.

### 🎯 Purpose & Impact
- ✅ Ensures GitHub Actions and related automation do not incorrectly flag these approved links.
- 🏢 Supports use of official office location links in documentation, comments, or workflows without causing validation issues.
- 🔄 Reflects an update in Ultralytics web priorities by recognizing `app-install` instead of the older `license` link.
- 🛠️ Small but useful maintenance change that helps reduce false positives and keeps CI checks running smoothly.