### PR TITLE
Add PR workflow commands

### DIFF
--- a/actions/dispatch_actions.py
+++ b/actions/dispatch_actions.py
@@ -10,9 +10,11 @@ from .utils import ACTIONS_CREDIT, GITHUB_API_URL, Action
 
 # Configuration
 RUN_CI_KEYWORD = "@ultralytics/run-ci"  # and then to merge "@ultralytics/run-ci-and-merge"
+RUN_ALL_KEYWORD = "@ultralytics/run-all"
 RUN_DOCKER_KEYWORD = "@ultralytics/run-docker"
 WORKFLOW_FILES = {
-    RUN_CI_KEYWORD: ["ci.yml", "docker.yml"],
+    RUN_CI_KEYWORD: ["ci.yml"],
+    RUN_ALL_KEYWORD: ["ci.yml", "docker.yml"],
     RUN_DOCKER_KEYWORD: ["docker.yml"],
 }
 
@@ -127,6 +129,8 @@ def update_comment(event, comment_body: str, command: str, triggered_actions: li
 {ACTIONS_CREDIT}
 
 GitHub Actions below triggered via workflow dispatch for this PR at {timestamp} with `{command}` command:
+
+Available commands: `{RUN_CI_KEYWORD}` for CI, `{RUN_ALL_KEYWORD}` for CI + Docker, `{RUN_DOCKER_KEYWORD}` for Docker.
 
 """
 

--- a/actions/dispatch_actions.py
+++ b/actions/dispatch_actions.py
@@ -128,9 +128,8 @@ def update_comment(event, comment_body: str, command: str, triggered_actions: li
 
 {ACTIONS_CREDIT}
 
-GitHub Actions below triggered via workflow dispatch for this PR at {timestamp} with `{command}` command:
-
-Available commands: `{RUN_CI_KEYWORD}` for CI, `{RUN_ALL_KEYWORD}` for CI + Docker, `{RUN_DOCKER_KEYWORD}` for Docker.
+GitHub Actions below triggered via workflow dispatch for this PR at {timestamp} with `{command}` command
+(`{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}` are also available):
 
 """
 

--- a/actions/dispatch_actions.py
+++ b/actions/dispatch_actions.py
@@ -10,7 +10,11 @@ from .utils import ACTIONS_CREDIT, GITHUB_API_URL, Action
 
 # Configuration
 RUN_CI_KEYWORD = "@ultralytics/run-ci"  # and then to merge "@ultralytics/run-ci-and-merge"
-WORKFLOW_FILES = ["ci.yml", "docker.yml"]
+RUN_DOCKER_KEYWORD = "@ultralytics/run-docker"
+WORKFLOW_FILES = {
+    RUN_CI_KEYWORD: ["ci.yml", "docker.yml"],
+    RUN_DOCKER_KEYWORD: ["docker.yml"],
+}
 
 
 def get_pr_branch(event) -> tuple[str, str | None]:
@@ -66,21 +70,21 @@ def get_pr_branch(event) -> tuple[str, str | None]:
     return head.get("ref", "main"), None
 
 
-def trigger_and_get_workflow_info(event, branch: str, temp_branch: str | None = None) -> list[dict]:
+def trigger_and_get_workflow_info(event, branch: str, workflow_files: list[str], temp_branch: str | None = None) -> list[dict]:
     """Triggers workflows and returns their information, deleting temp branch if provided."""
     repo = event.repository
     results = []
 
     try:
         # Trigger all workflows
-        for file in WORKFLOW_FILES:
+        for file in workflow_files:
             event.post(f"{GITHUB_API_URL}/repos/{repo}/actions/workflows/{file}/dispatches", json={"ref": branch})
 
         # Wait for workflows to be created and start
         time.sleep(60)
 
         # Collect information about all workflows
-        for file in WORKFLOW_FILES:
+        for file in workflow_files:
             # Get workflow name
             response = event.get(f"{GITHUB_API_URL}/repos/{repo}/actions/workflows/{file}")
             name = file.replace(".yml", "").title()
@@ -108,7 +112,7 @@ def trigger_and_get_workflow_info(event, branch: str, temp_branch: str | None = 
     return results
 
 
-def update_comment(event, comment_body: str, triggered_actions: list[dict]):
+def update_comment(event, comment_body: str, command: str, triggered_actions: list[dict]):
     """Updates the comment with workflow information."""
     if not triggered_actions:
         return
@@ -120,7 +124,7 @@ def update_comment(event, comment_body: str, triggered_actions: list[dict]):
 
 {ACTIONS_CREDIT}
 
-GitHub Actions below triggered via workflow dispatch for this PR at {timestamp} with `{RUN_CI_KEYWORD}` command:
+GitHub Actions below triggered via workflow dispatch for this PR at {timestamp} with `{command}` command:
 
 """
 
@@ -128,7 +132,7 @@ GitHub Actions below triggered via workflow dispatch for this PR at {timestamp} 
         run_info = f" run {action['run_number']}" if action["run_number"] else ""
         summary += f"* ✅ [{action['name']}]({action['url']}): `{action['file']}`{run_info}\n"
 
-    new_body = comment_body.replace(RUN_CI_KEYWORD, summary).strip()
+    new_body = comment_body.replace(command, summary).strip()
     comment_id = event.event_data["comment"]["id"]
     event.patch(f"{GITHUB_API_URL}/repos/{event.repository}/issues/comments/{comment_id}", json={"body": new_body})
 
@@ -149,11 +153,15 @@ def main(*args, **kwargs):
     comment_body = event.event_data["comment"].get("body") or ""
     username = event.event_data["comment"]["user"]["login"]
 
-    # Check for keyword without surrounding backticks to avoid triggering on replies
-    has_keyword = RUN_CI_KEYWORD in comment_body and comment_body.count(RUN_CI_KEYWORD) > comment_body.count(
-        f"`{RUN_CI_KEYWORD}`"
+    command = next(
+        (
+            keyword
+            for keyword in WORKFLOW_FILES
+            if keyword in comment_body and comment_body.count(keyword) > comment_body.count(f"`{keyword}`")
+        ),
+        None,
     )
-    if not has_keyword or not event.is_org_member(username):
+    if not command or not event.is_org_member(username):
         return
 
     # Get branch, trigger workflows, and update comment
@@ -161,8 +169,8 @@ def main(*args, **kwargs):
     branch, temp_branch = get_pr_branch(event)
     print(f"Triggering workflows on branch: {branch}" + (" (temp)" if temp_branch else ""))
 
-    triggered_actions = trigger_and_get_workflow_info(event, branch, temp_branch)
-    update_comment(event, comment_body, triggered_actions)
+    triggered_actions = trigger_and_get_workflow_info(event, branch, WORKFLOW_FILES[command], temp_branch)
+    update_comment(event, comment_body, command, triggered_actions)
     event.toggle_eyes_reaction(False)
 
 

--- a/actions/dispatch_actions.py
+++ b/actions/dispatch_actions.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from .utils import ACTIONS_CREDIT, GITHUB_API_URL, Action
 
 # Configuration
-RUN_CI_KEYWORD = "@ultralytics/run-ci"  # and then to merge "@ultralytics/run-ci-and-merge"
+RUN_CI_KEYWORD = "@ultralytics/run-ci"
 RUN_ALL_KEYWORD = "@ultralytics/run-all"
 RUN_DOCKER_KEYWORD = "@ultralytics/run-docker"
 WORKFLOW_FILES = {

--- a/actions/dispatch_actions.py
+++ b/actions/dispatch_actions.py
@@ -129,7 +129,7 @@ def update_comment(event, comment_body: str, command: str, triggered_actions: li
 {ACTIONS_CREDIT}
 
 GitHub Actions below triggered via workflow dispatch for this PR at {timestamp} with `{command}` command
-(`{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}` are also available):
+(available commands are `{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}`):
 
 """
 

--- a/actions/dispatch_actions.py
+++ b/actions/dispatch_actions.py
@@ -70,7 +70,9 @@ def get_pr_branch(event) -> tuple[str, str | None]:
     return head.get("ref", "main"), None
 
 
-def trigger_and_get_workflow_info(event, branch: str, workflow_files: list[str], temp_branch: str | None = None) -> list[dict]:
+def trigger_and_get_workflow_info(
+    event, branch: str, workflow_files: list[str], temp_branch: str | None = None
+) -> list[dict]:
     """Triggers workflows and returns their information, deleting temp branch if provided."""
     repo = event.repository
     results = []

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -152,9 +152,10 @@ def test_update_comment_function():
     assert "Actions Trigger" in kwargs["json"]["body"]
     assert "CI Workflow" in kwargs["json"]["body"]
     assert "2023-01-01 12:00:00 UTC" in kwargs["json"]["body"]
-    assert f"(available commands are `{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}`):" in kwargs[
-        "json"
-    ]["body"]
+    assert (
+        f"(available commands are `{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}`):"
+        in kwargs["json"]["body"]
+    )
 
 
 def test_main_triggers_ci_only():

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -152,7 +152,7 @@ def test_update_comment_function():
     assert "Actions Trigger" in kwargs["json"]["body"]
     assert "CI Workflow" in kwargs["json"]["body"]
     assert "2023-01-01 12:00:00 UTC" in kwargs["json"]["body"]
-    assert RUN_ALL_KEYWORD in kwargs["json"]["body"]
+    assert f"`{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}`" in kwargs["json"]["body"]
 
 
 def test_main_triggers_ci_only():

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -152,7 +152,9 @@ def test_update_comment_function():
     assert "Actions Trigger" in kwargs["json"]["body"]
     assert "CI Workflow" in kwargs["json"]["body"]
     assert "2023-01-01 12:00:00 UTC" in kwargs["json"]["body"]
-    assert f"`{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}`" in kwargs["json"]["body"]
+    assert f"(available commands are `{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}`):" in kwargs[
+        "json"
+    ]["body"]
 
 
 def test_main_triggers_ci_only():

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock, patch
 
 from actions.dispatch_actions import (
     RUN_ALL_KEYWORD,
-    RUN_DOCKER_KEYWORD,
     RUN_CI_KEYWORD,
+    RUN_DOCKER_KEYWORD,
     get_pr_branch,
     main,
     trigger_and_get_workflow_info,

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -4,8 +4,9 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from actions.dispatch_actions import (
-    RUN_CI_KEYWORD,
+    RUN_ALL_KEYWORD,
     RUN_DOCKER_KEYWORD,
+    RUN_CI_KEYWORD,
     get_pr_branch,
     main,
     trigger_and_get_workflow_info,
@@ -151,12 +152,12 @@ def test_update_comment_function():
     assert "Actions Trigger" in kwargs["json"]["body"]
     assert "CI Workflow" in kwargs["json"]["body"]
     assert "2023-01-01 12:00:00 UTC" in kwargs["json"]["body"]
+    assert RUN_ALL_KEYWORD in kwargs["json"]["body"]
 
 
-def test_main_triggers_workflows():
-    """Test main function when comment contains trigger keyword."""
+def test_main_triggers_ci_only():
+    """Test main function triggers only CI for the CI command."""
     with patch("actions.dispatch_actions.Action") as MockAction:
-        # Configure mock
         mock_event = MockAction.return_value
         mock_event.event_name = "issue_comment"
         mock_event.repository = "test/repo"
@@ -167,20 +168,36 @@ def test_main_triggers_workflows():
         }
         mock_event.is_org_member.return_value = True
 
-        # Create minimal patches for the functions called by main
         with patch("actions.dispatch_actions.get_pr_branch") as mock_get_branch:
             with patch("actions.dispatch_actions.trigger_and_get_workflow_info") as mock_trigger:
                 with patch("actions.dispatch_actions.update_comment"):
-                    # Set return values
                     mock_get_branch.return_value = ("feature-branch", None)
                     mock_trigger.return_value = [{"name": "CI", "file": "ci.yml", "url": "url", "run_number": 1}]
-
-                    # Call the function
                     main()
 
-        # Verify main component calls were made
-        mock_event.is_org_member.assert_called_once_with("testuser")
-        mock_get_branch.assert_called_once()
+        mock_trigger.assert_called_once_with(mock_event, "feature-branch", ["ci.yml"], None)
+
+
+def test_main_triggers_all_workflows():
+    """Test main function triggers CI and Docker for the all command."""
+    with patch("actions.dispatch_actions.Action") as MockAction:
+        mock_event = MockAction.return_value
+        mock_event.event_name = "issue_comment"
+        mock_event.repository = "test/repo"
+        mock_event.event_data = {
+            "action": "created",
+            "issue": {"pull_request": {}},
+            "comment": {"body": f"Please run all {RUN_ALL_KEYWORD}", "user": {"login": "testuser"}, "id": 789},
+        }
+        mock_event.is_org_member.return_value = True
+
+        with patch("actions.dispatch_actions.get_pr_branch") as mock_get_branch:
+            with patch("actions.dispatch_actions.trigger_and_get_workflow_info") as mock_trigger:
+                with patch("actions.dispatch_actions.update_comment"):
+                    mock_get_branch.return_value = ("feature-branch", None)
+                    mock_trigger.return_value = [{"name": "CI", "file": "ci.yml", "url": "url", "run_number": 1}]
+                    main()
+
         mock_trigger.assert_called_once_with(mock_event, "feature-branch", ["ci.yml", "docker.yml"], None)
 
 

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from actions.dispatch_actions import (
-    RUN_DOCKER_KEYWORD,
     RUN_CI_KEYWORD,
+    RUN_DOCKER_KEYWORD,
     get_pr_branch,
     main,
     trigger_and_get_workflow_info,
@@ -201,7 +201,9 @@ def test_main_triggers_docker_only():
             with patch("actions.dispatch_actions.trigger_and_get_workflow_info") as mock_trigger:
                 with patch("actions.dispatch_actions.update_comment"):
                     mock_get_branch.return_value = ("feature-branch", None)
-                    mock_trigger.return_value = [{"name": "Docker", "file": "docker.yml", "url": "url", "run_number": 1}]
+                    mock_trigger.return_value = [
+                        {"name": "Docker", "file": "docker.yml", "url": "url", "run_number": 1}
+                    ]
                     main()
 
         mock_trigger.assert_called_once_with(mock_event, "feature-branch", ["docker.yml"], None)

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from actions.dispatch_actions import (
+    RUN_DOCKER_KEYWORD,
     RUN_CI_KEYWORD,
     get_pr_branch,
     main,
@@ -79,8 +80,8 @@ def test_trigger_and_get_workflow_info():
     mock_event.get.side_effect = get_side_effect
 
     # Use patch to skip time.sleep and limit to one workflow
-    with patch("time.sleep"), patch("actions.dispatch_actions.WORKFLOW_FILES", ["ci.yml"]):
-        results = trigger_and_get_workflow_info(mock_event, "feature-branch")
+    with patch("time.sleep"):
+        results = trigger_and_get_workflow_info(mock_event, "feature-branch", ["ci.yml"])
 
     # Check results
     assert len(results) == 1
@@ -113,8 +114,7 @@ def test_trigger_and_get_workflow_info_with_temp_branch():
     mock_event.get.side_effect = get_side_effect
 
     with patch("time.sleep"):
-        with patch("actions.dispatch_actions.WORKFLOW_FILES", ["ci.yml"]):
-            trigger_and_get_workflow_info(mock_event, "temp-ci-123-456", temp_branch="temp-ci-123-456")
+        trigger_and_get_workflow_info(mock_event, "temp-ci-123-456", ["ci.yml"], temp_branch="temp-ci-123-456")
 
     # Verify temp branch was deleted
     mock_event.delete.assert_called_once_with("https://api.github.com/repos/test/repo/git/refs/heads/temp-ci-123-456")
@@ -140,7 +140,7 @@ def test_update_comment_function():
     with patch("actions.dispatch_actions.datetime") as mock_datetime:
         mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
         # Call without capturing return value
-        update_comment(mock_event, comment_body, triggered_actions)
+        update_comment(mock_event, comment_body, RUN_CI_KEYWORD, triggered_actions)
 
     # Check that patch was called with expected content
     mock_event.patch.assert_called_once()
@@ -181,7 +181,30 @@ def test_main_triggers_workflows():
         # Verify main component calls were made
         mock_event.is_org_member.assert_called_once_with("testuser")
         mock_get_branch.assert_called_once()
-        mock_trigger.assert_called_once()
+        mock_trigger.assert_called_once_with(mock_event, "feature-branch", ["ci.yml", "docker.yml"], None)
+
+
+def test_main_triggers_docker_only():
+    """Test main function triggers only docker workflow for docker command."""
+    with patch("actions.dispatch_actions.Action") as MockAction:
+        mock_event = MockAction.return_value
+        mock_event.event_name = "issue_comment"
+        mock_event.repository = "test/repo"
+        mock_event.event_data = {
+            "action": "created",
+            "issue": {"pull_request": {}},
+            "comment": {"body": f"Please run Docker {RUN_DOCKER_KEYWORD}", "user": {"login": "testuser"}, "id": 789},
+        }
+        mock_event.is_org_member.return_value = True
+
+        with patch("actions.dispatch_actions.get_pr_branch") as mock_get_branch:
+            with patch("actions.dispatch_actions.trigger_and_get_workflow_info") as mock_trigger:
+                with patch("actions.dispatch_actions.update_comment"):
+                    mock_get_branch.return_value = ("feature-branch", None)
+                    mock_trigger.return_value = [{"name": "Docker", "file": "docker.yml", "url": "url", "run_number": 1}]
+                    main()
+
+        mock_trigger.assert_called_once_with(mock_event, "feature-branch", ["docker.yml"], None)
 
 
 def test_main_skips_non_pr_comments():


### PR DESCRIPTION
## Summary
- keep the existing PR comment dispatcher and extend its command map
- run `@ultralytics/run-ci` for `ci.yml`, `@ultralytics/run-all` for `ci.yml` + `docker.yml`, and `@ultralytics/run-docker` for `docker.yml`
- add a minimal usage line to the posted GitHub comment and keep tests narrow

## Testing
- PYTHONPATH=$PWD pytest -q tests/test_dispatch_actions.py
- PYTHONPATH=$PWD python -m py_compile actions/dispatch_actions.py tests/test_dispatch_actions.py
- ruff check actions/dispatch_actions.py tests/test_dispatch_actions.py
- `bun run knip` not applicable in this repo: no `package.json`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR adds more flexible PR comment commands for manually triggering GitHub Actions, letting Ultralytics team members run CI only, Docker only, or both workflows as needed 🚀

### 📊 Key Changes
- Added two new comment commands alongside `@ultralytics/run-ci`:
  - `@ultralytics/run-all` to run both CI and Docker
  - `@ultralytics/run-docker` to run only Docker 🐳
- Replaced the fixed workflow list with a command-to-workflow mapping, so each command triggers the correct workflow set.
- Updated workflow dispatch logic to accept a selected list of workflow files instead of always running everything.
- Improved comment updates so the bot:
  - shows which command was used
  - lists all available commands
  - replaces the exact command in the PR comment with a run summary 📝
- Kept the safeguard that ignores commands inside backticks, helping avoid accidental triggers in replies or examples.
- Expanded tests to cover:
  - CI-only triggering
  - Docker-only triggering
  - running all workflows
  - updated comment output and temp branch cleanup ✅

### 🎯 Purpose & Impact
- Gives maintainers more control over PR checks, so they can run only what’s needed instead of always launching every workflow ⚡
- Helps save CI time and compute resources by avoiding unnecessary workflow runs.
- Makes the PR workflow clearer for contributors by showing available commands directly in bot responses.
- Improves reliability through broader test coverage, reducing the chance of command handling regressions.
- Overall, this makes manual GitHub Actions dispatch in `ultralytics/actions` more flexible, efficient, and easier to use for reviewers and maintainers 🙌