### PR TITLE
Fix flaky URL TLD test

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -2,6 +2,7 @@
 
 # Continuous Integration (CI) GitHub Actions tests
 
+from unittest.mock import patch
 
 import pytest
 
@@ -119,9 +120,18 @@ def test_urls_with_paths_and_queries(verbose):
 def test_urls_with_different_tlds(verbose):
     """Test URLs with various top-level domains (TLDs) to ensure correct identification and handling."""
     text = "Different TLDs: https://err.ml https://err.eu https://err.net https://err.io https://err.ai"
-    result, urls = check_links_in_string(text, verbose, return_bad=True)
+    valid_urls = {"https://err.net"}
+
+    def fake_is_url(url, session=None, check=True, max_attempts=3, timeout=3, return_url=False, redirect=False):
+        valid = url in valid_urls
+        return (valid, url) if return_url else valid
+
+    with patch("actions.utils.common_utils.is_url", side_effect=fake_is_url) as mock_is_url:
+        result, urls = check_links_in_string(text, verbose, return_bad=True)
+
     assert result is False
     assert set(urls) == {"https://err.ml", "https://err.eu", "https://err.io", "https://err.ai"}
+    assert mock_is_url.call_count == 5
 
 
 def test_case_sensitivity(verbose):


### PR DESCRIPTION
## Summary
- replace the live-network assertion in `test_urls_with_different_tlds` with a mocked `is_url()` response
- keep coverage on mixed TLD extraction while removing the dependency on `err.net` resolving consistently on GitHub runners
- assert all five URLs are still checked by `check_links_in_string()`

## Testing
- python -m pytest tests/test_urls.py -q
- python -m pytest tests/test_urls.py -k different_tlds -vv
- python -m ruff check tests/test_urls.py

## Notes
- local full-suite runs still show the pre-existing `tests/test_file_headers.py::test_main_real_files` environment-dependent failure; this change is scoped to the CI URL-test regression from April 23, 2026.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧪 This PR makes the URL TLD test more reliable by mocking link validation instead of depending on real network behavior.

### 📊 Key Changes
- Updated `tests/test_urls.py` to import `patch` from Python’s `unittest.mock`.
- Refactored `test_urls_with_different_tlds()` to use a mocked `is_url()` function.
- Defined a controlled set of valid URLs so the test no longer relies on external URL availability.
- Added an assertion to confirm `is_url()` is called 5 times, ensuring each test URL is checked.

### 🎯 Purpose & Impact
- Improves test stability ✅ by removing dependence on live internet responses and changing domain behavior.
- Makes CI results more consistent 🔁, reducing flaky failures caused by external sites or DNS issues.
- Increases confidence in URL-checking logic 🔍 by verifying both the returned bad links and the number of validation calls.
- Helps maintainers and contributors work faster 🚀 since tests are now more deterministic and easier to debug.