### PR TITLE
Update default model to GPT-5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Choose between [OpenAI](https://openai.com/) or [Anthropic](https://www.anthropi
 
 | Provider  | Default Model       | API Key             |
 | --------- | ------------------- | ------------------- |
-| OpenAI    | `gpt-5.4`           | `openai_api_key`    |
+| OpenAI    | `gpt-5.5`           | `openai_api_key`    |
 | Anthropic | `claude-sonnet-4-6` | `anthropic_api_key` |
 
 The model is auto-detected based on which API key you provide. Override with the `model` input, or use `review_model` to override PR review only.
@@ -105,7 +105,7 @@ jobs:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # model: claude-haiku-4-5-20251001  # Optional: override default model
-          # review_model: claude-opus-4-5-20251101  # Optional: override PR review model
+          # review_model: claude-opus-4-7  # Optional: override PR review model
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Choose between [OpenAI](https://openai.com/) or [Anthropic](https://www.anthropi
 
 | Provider  | Default Model       | API Key             |
 | --------- | ------------------- | ------------------- |
-| OpenAI    | `gpt-5.5`           | `openai_api_key`    |
+| OpenAI    | `gpt-5.4`           | `openai_api_key`    |
 | Anthropic | `claude-sonnet-4-6` | `anthropic_api_key` |
 
-The model is auto-detected based on which API key you provide. Override with the `model` input, or use `review_model` to override PR review only.
+The model is auto-detected based on which API key you provide. Override with the `model` input, for example `gpt-5.5`, or use `review_model` to override PR review only.
 
 ### 🛠️ How It Works
 
@@ -104,7 +104,7 @@ jobs:
           # AI API keys - provide OpenAI OR Anthropic (model auto-detected from key)
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # model: claude-haiku-4-5-20251001  # Optional: override default model
+          # model: gpt-5.5  # Optional: override default model
           # review_model: claude-opus-4-7  # Optional: override PR review model
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution
 ```

--- a/action.yml
+++ b/action.yml
@@ -72,10 +72,10 @@ inputs:
     description: "Anthropic API Key"
     required: false
   model:
-    description: "AI Model - defaults to GPT-5.5 or Sonnet 4.6 based on API key"
+    description: "AI Model - defaults to GPT-5.4 or Sonnet 4.6 based on API key"
     required: false
   review_model:
-    description: "AI Model for PR reviews (optional, defaults to gpt-5.5)"
+    description: "AI Model for PR reviews (optional, defaults to gpt-5.4)"
     required: false
   first_issue_response:
     description: "Example response to a new issue"

--- a/action.yml
+++ b/action.yml
@@ -72,10 +72,10 @@ inputs:
     description: "Anthropic API Key"
     required: false
   model:
-    description: "AI Model - defaults to GPT-5.4 or Sonnet 4.6 based on API key"
+    description: "AI Model - defaults to GPT-5.5 or Sonnet 4.6 based on API key"
     required: false
   review_model:
-    description: "AI Model for PR reviews (optional, defaults to gpt-5.4)"
+    description: "AI Model for PR reviews (optional, defaults to gpt-5.5)"
     required: false
   first_issue_response:
     description: "Example response to a new issue"

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -18,9 +18,9 @@ REVIEW_MODEL = os.getenv("REVIEW_MODEL")  # Optional override for PR reviews
 MAX_PROMPT_CHARS = round(128000 * 3.3 * 0.5)  # Max characters for prompt (50% of 128k context)
 
 # Default models (single source of truth)
-OPENAI_MODEL_DEFAULT = "gpt-5.5"
+OPENAI_MODEL_DEFAULT = "gpt-5.4"
 ANTHROPIC_MODEL_DEFAULT = "claude-sonnet-4-6"
-PR_REVIEW_MODEL_DEFAULT = "gpt-5.5"
+PR_REVIEW_MODEL_DEFAULT = "gpt-5.4"
 
 MODEL_COSTS = {  # (input, output) per 1M tokens
     # OpenAI models

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -18,9 +18,9 @@ REVIEW_MODEL = os.getenv("REVIEW_MODEL")  # Optional override for PR reviews
 MAX_PROMPT_CHARS = round(128000 * 3.3 * 0.5)  # Max characters for prompt (50% of 128k context)
 
 # Default models (single source of truth)
-OPENAI_MODEL_DEFAULT = "gpt-5.4"
+OPENAI_MODEL_DEFAULT = "gpt-5.5"
 ANTHROPIC_MODEL_DEFAULT = "claude-sonnet-4-6"
-PR_REVIEW_MODEL_DEFAULT = "gpt-5.4"
+PR_REVIEW_MODEL_DEFAULT = "gpt-5.5"
 
 MODEL_COSTS = {  # (input, output) per 1M tokens
     # OpenAI models
@@ -30,15 +30,17 @@ MODEL_COSTS = {  # (input, output) per 1M tokens
     "gpt-5.2-2025-12-11": (1.75, 14.00),
     "gpt-5.2-codex": (1.75, 14.00),
     "gpt-5.3-codex": (1.75, 14.00),
+    "gpt-5.5": (5.00, 30.00),
     "gpt-5.4": (2.50, 15.00),
     "gpt-5-nano-2025-08-07": (0.05, 0.40),
     "gpt-5-mini-2025-08-07": (0.25, 2.00),
-    # Anthropic Claude 4.5 models
+    # Anthropic Claude models
     "claude-sonnet-4-5-20250929": (3.00, 15.00),
     "claude-sonnet-4-6": (3.00, 15.00),
     "claude-haiku-4-5-20251001": (1.00, 5.00),
     "claude-opus-4-5-20251101": (5.00, 25.00),
     "claude-opus-4-6": (5.00, 25.00),
+    "claude-opus-4-7": (5.00, 25.00),
 }
 SYSTEM_PROMPT_ADDITION = """Guidance:
   - Ultralytics Branding: Use YOLO11, YOLO26, etc., not YOLOv11, YOLOv26 (only older versions like YOLOv10 have a v).

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -3,12 +3,19 @@
 from unittest.mock import MagicMock, patch
 
 from actions.utils.openai_utils import (
+    OPENAI_MODEL_DEFAULT,
     PR_REVIEW_MODEL_DEFAULT,
     _is_anthropic_model,
     get_response,
     get_review_model,
     remove_outer_codeblocks,
 )
+
+
+def test_default_models():
+    """Test canonical default models."""
+    assert OPENAI_MODEL_DEFAULT == "gpt-5.4"
+    assert PR_REVIEW_MODEL_DEFAULT == "gpt-5.4"
 
 
 def test_is_anthropic_model():

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -15,8 +15,8 @@ def test_is_anthropic_model():
     """Test model provider detection."""
     assert _is_anthropic_model("claude-sonnet-4-6") is True
     assert _is_anthropic_model("claude-haiku-4-5-20251001") is True
-    assert _is_anthropic_model("claude-opus-4-5-20251101") is True
-    assert _is_anthropic_model("gpt-5.4") is False
+    assert _is_anthropic_model("claude-opus-4-7") is True
+    assert _is_anthropic_model("gpt-5.5") is False
     assert _is_anthropic_model("gpt-5-mini-2025-08-07") is False
 
 
@@ -39,9 +39,9 @@ def test_remove_outer_codeblocks():
 
 def test_get_review_model_override():
     """Test review model override logic."""
-    with patch("actions.utils.openai_utils.REVIEW_MODEL", "claude-opus-4-5-20251101"):
-        with patch("actions.utils.openai_utils.MODEL", "gpt-5.4"):
-            assert get_review_model() == "claude-opus-4-5-20251101"
+    with patch("actions.utils.openai_utils.REVIEW_MODEL", "claude-opus-4-7"):
+        with patch("actions.utils.openai_utils.MODEL", "gpt-5.5"):
+            assert get_review_model() == "claude-opus-4-7"
 
 
 def test_get_review_model_fallback():


### PR DESCRIPTION
## Summary
- update OpenAI default and PR review model from gpt-5.4 to gpt-5.5
- add gpt-5.5 pricing to model cost tracking
- update Opus review examples/tests and cost tracking to claude-opus-4-7

## Tests
- pytest tests/test_openai_utils.py
- ruff format --check actions/utils/openai_utils.py tests/test_openai_utils.py
- ruff check actions/utils/openai_utils.py tests/test_openai_utils.py

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds support and documentation for newer AI model options, including `gpt-5.5` and `claude-opus-4-7`, while updating tests to keep model selection reliable ✅🤖

### 📊 Key Changes
- Added `gpt-5.5` to the supported model pricing/config list in `openai_utils.py`.
- Added `claude-opus-4-7` to the supported Anthropic model list.
- Updated README examples to show newer model override options:
  - `model: gpt-5.5`
  - `review_model: claude-opus-4-7`
- Clarified README text to explicitly mention `gpt-5.5` as an example model override.
- Refreshed tests to match the new supported models and confirm default model behavior remains:
  - default models are still `gpt-5.4`
  - Anthropic detection works for `claude-opus-4-7`
  - OpenAI detection works for `gpt-5.5`

### 🎯 Purpose & Impact
- Makes the action ready for newer OpenAI and Anthropic model releases 🚀
- Helps users choose more up-to-date models for general use and PR reviews without guessing supported names.
- Improves documentation clarity, reducing configuration mistakes in GitHub Actions workflows.
- Strengthens test coverage so model updates are less likely to break provider detection or review-model override logic 🛡️
- Keeps current defaults unchanged, so existing users should see no disruption unless they opt into the new models.