### PR TITLE
Exclude bot commit users from PR credit

### DIFF
--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -37,7 +37,14 @@ query($owner: String!, $repo: String!, $pr_number: Int!) {
             author { login, __typename }
             reviews(first: 50) { nodes { author { login, __typename } } }
             comments(first: 50) { nodes { author { login, __typename } } }
-            commits(first: 100) { nodes { commit { author { user { login } }, committer { user { login } } } } }
+            commits(first: 100) {
+                nodes {
+                    commit {
+                        author { user { login, __typename } }
+                        committer { user { login, __typename } }
+                    }
+                }
+            }
         }
     }
 }
@@ -417,7 +424,7 @@ Thank you 🙏
                 commit_data = commit["commit"]
                 for user_type in ["author", "committer"]:
                     if user := commit_data[user_type].get("user"):
-                        if login := user.get("login"):
+                        if user["__typename"] != "Bot" and (login := user.get("login")):
                             contributors.add(login)
 
             contributors.discard(author)

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -53,6 +53,40 @@ def test_action_request_methods():
         mock_get.assert_called_once()
 
 
+def test_get_pr_contributors_excludes_bots():
+    """Test PR contributor credit excludes bot commit users."""
+    action = Action(
+        token="test-token",
+        event_data={"repository": {"full_name": "test/repo"}, "pull_request": {"number": 123}},
+    )
+    data = {
+        "author": {"login": "pr-author", "__typename": "User"},
+        "reviews": {"nodes": []},
+        "comments": {"nodes": []},
+        "commits": {
+            "nodes": [
+                {
+                    "commit": {
+                        "author": {"user": {"login": "github-actions[bot]", "__typename": "Bot"}},
+                        "committer": {"user": {"login": "teammate", "__typename": "User"}},
+                    }
+                },
+            ]
+        },
+    }
+    pr_response = MagicMock(
+        status_code=200,
+        json=lambda: {"data": {"repository": {"pullRequest": data}}},
+    )
+
+    with patch.object(action, "post", return_value=pr_response), patch.object(
+        action, "get_username", return_value="actions-user"
+    ):
+        pr_credit, _ = action.get_pr_contributors()
+
+    assert pr_credit == "@pr-author with contributions from @teammate"
+
+
 def test_load_event_data():
     """Test loading event data from file."""
     with patch("pathlib.Path.exists", return_value=True):


### PR DESCRIPTION
## Summary
- request commit user types in the PR contributor GraphQL query
- skip bot commit authors/committers using the existing GraphQL bot check path
- add a lightweight regression test for bot commit credit

## Tests
- python -m pytest tests/test_github_utils.py tests/test_summarize_pr.py
- python -m ruff check actions/utils/github_utils.py tests/test_github_utils.py
- python -m ruff format --check actions/utils/github_utils.py tests/test_github_utils.py

Note: full python -m pytest was also run and still has the existing unrelated failure in tests/test_file_headers.py::test_main_real_files.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🤖 This PR improves PR contributor detection by excluding bot accounts from commit attribution, ensuring contributor credit is cleaner and more accurate.

### 📊 Key Changes
- Updated the GitHub GraphQL query in `actions/utils/github_utils.py` to request each commit author and committer’s `__typename` alongside their login.
- Modified `get_pr_contributors()` to ignore commit users whose type is `Bot`, instead of treating them like human contributors.
- Added a new test in `tests/test_github_utils.py` to verify that bot accounts such as `github-actions[bot]` are excluded from contributor credit.
- Confirmed that valid human contributors, like teammates listed as committers, are still included in the PR credit output.

### 🎯 Purpose & Impact
- 🧹 Keeps PR contributor summaries more accurate by crediting real people instead of automation accounts.
- 🤝 Makes acknowledgments clearer and more meaningful for maintainers, reviewers, and contributors.
- ✅ Reduces noisy or misleading attribution in repositories that rely heavily on GitHub Actions or other bots.
- 🛡️ Improves reliability with a dedicated test, helping prevent regressions in future updates.