### PR TITLE
Request compressed responses in link checks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -383,6 +383,7 @@ runs:
           --scheme https
           --timeout 60
           --insecure
+          --header "Accept-Encoding: br, gzip"
           --accept 100..=103,200..=299,401,403,429,500,502,999
           --exclude-all-private
           --exclude "https?://(www\.)?(github\.com|linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)"


### PR DESCRIPTION
## Summary
- request Brotli or gzip responses from Lychee link checks

## Validation
- python YAML parse for action.yml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds an `Accept-Encoding: br, gzip` header to link-check requests so responses can be compressed during validation. 📦🔗

### 📊 Key Changes
- Updated `action.yml` to include `--header "Accept-Encoding: br, gzip"` in the link checker configuration.
- Keeps all existing link-check behavior intact, including HTTPS enforcement, timeout settings, accepted status codes, and exclusions.
- Applies the change specifically to outbound HTTP requests made during automated link validation.

### 🎯 Purpose & Impact
- Improves compatibility with servers that expect or prefer compressed responses.
- Can reduce bandwidth usage and potentially speed up link checks for large responses. ⚡
- Helps make CI link validation more efficient and resilient without changing user-facing functionality.