### PR TITLE
Switch loop guard to author-based to survive interleaving auto-commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -346,11 +346,11 @@ runs:
       run: |
         echo "::group::Commit and Push Changes"
         COMMIT_MSG="Auto-format by https://ultralytics.com/actions"
-        # Skip when HEAD was authored by the same bot to break recursive loops with sibling auto-commit workflows.
-        # Match name AND email so a contributor cannot spoof the bot identity by setting only --author name.
-        HEAD_AUTHOR=$(git log -1 --pretty=format:'%an|%ae' 2>/dev/null)
-        if [ "$HEAD_AUTHOR" = "$GITHUB_USERNAME|$GITHUB_EMAIL" ]; then
-          echo "Skipping commit: HEAD was authored by $GITHUB_USERNAME <$GITHUB_EMAIL>"
+        # Skip when this workflow run was triggered by the bot itself to break recursive loops with sibling
+        # auto-commit workflows (Auto-format <-> Auto-update Docs). GITHUB_ACTOR / GITHUB_TRIGGERING_ACTOR are
+        # set by GitHub from the auth token used to push and cannot be spoofed via local git author fields.
+        if [ "$GITHUB_ACTOR" = "$GITHUB_USERNAME" ] || [ "$GITHUB_TRIGGERING_ACTOR" = "$GITHUB_USERNAME" ]; then
+          echo "Skipping commit: workflow triggered by $GITHUB_USERNAME (sibling bot push)"
           echo "::endgroup::"
           exit 0
         fi

--- a/action.yml
+++ b/action.yml
@@ -346,11 +346,10 @@ runs:
       run: |
         echo "::group::Commit and Push Changes"
         COMMIT_MSG="Auto-format by https://ultralytics.com/actions"
-        # Check if last two commits were both auto-format to prevent recursive loops
-        LAST_TWO=$(git log -2 --pretty=format:'%s' 2>/dev/null || echo "")
-        MATCH_COUNT=$(printf '%s\n' "$LAST_TWO" | grep -Fxc "$COMMIT_MSG" || true)
-        if [ "$MATCH_COUNT" -ge 2 ]; then
-          echo "Skipping commit: last two commits were auto-format"
+        # Skip when HEAD was authored by the same bot to break recursive loops with sibling auto-commit workflows.
+        # Author-based instead of message-based so interleaving auto-commits (docs reference rebuilds, etc.) do not bypass the guard.
+        if [ "$(git log -1 --pretty=format:'%an' 2>/dev/null)" = "$GITHUB_USERNAME" ]; then
+          echo "Skipping commit: HEAD was authored by $GITHUB_USERNAME"
           echo "::endgroup::"
           exit 0
         fi

--- a/action.yml
+++ b/action.yml
@@ -343,14 +343,21 @@ runs:
       env:
         GITHUB_USERNAME: ${{ inputs.github_username }}
         GITHUB_EMAIL: ${{ inputs.github_email }}
+        GH_TOKEN: ${{ inputs.token }}
       run: |
         echo "::group::Commit and Push Changes"
         COMMIT_MSG="Auto-format by https://ultralytics.com/actions"
         # Skip when this workflow run was triggered by the bot itself to break recursive loops with sibling
-        # auto-commit workflows (Auto-format <-> Auto-update Docs). GITHUB_ACTOR / GITHUB_TRIGGERING_ACTOR are
-        # set by GitHub from the auth token used to push and cannot be spoofed via local git author fields.
-        if [ "$GITHUB_ACTOR" = "$GITHUB_USERNAME" ] || [ "$GITHUB_TRIGGERING_ACTOR" = "$GITHUB_USERNAME" ]; then
-          echo "Skipping commit: workflow triggered by $GITHUB_USERNAME (sibling bot push)"
+        # auto-commit workflows (Auto-format <-> Auto-update Docs). Derive the bot login from the token owner
+        # (single source of truth) so the guard works regardless of how callers configure github_username.
+        # GITHUB_ACTOR / GITHUB_TRIGGERING_ACTOR are set by GitHub from the push auth token and cannot be
+        # spoofed via local git author fields. Falls back to GITHUB_USERNAME if the API call fails.
+        BOT_LOGIN="$GITHUB_USERNAME"
+        if RESPONSE=$(gh api /user --jq '.login // empty' 2>/dev/null) && [ -n "$RESPONSE" ]; then
+          BOT_LOGIN="$RESPONSE"
+        fi
+        if [ "$GITHUB_ACTOR" = "$BOT_LOGIN" ] || [ "$GITHUB_TRIGGERING_ACTOR" = "$BOT_LOGIN" ]; then
+          echo "Skipping commit: workflow triggered by $BOT_LOGIN (sibling bot push)"
           echo "::endgroup::"
           exit 0
         fi

--- a/action.yml
+++ b/action.yml
@@ -339,23 +339,22 @@ runs:
 
     # Commit Changes ---------------------------------------------------------------------------------------------------
     - name: Commit and Push Changes
-      if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (github.event.action == 'opened' || github.event.action == 'synchronize')
+      # Skip when the triggering push came from the bot itself (a prior Auto-format push, or a sibling
+      # auto-commit workflow sharing the same token such as Auto-update Docs). github.actor is set by GitHub
+      # from the pushing token and cannot be spoofed via git config, so this breaks recursive auto-commit loops
+      # even when sibling bot commits or merge commits interleave between Auto-format pushes. Human pushes have a
+      # different actor and are always formatted. Default-GITHUB_TOKEN pushes never re-trigger workflows, so only
+      # PAT-authored bot pushes (actor == github_username) can recurse here.
+      if: |
+        (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
+        (github.event.action == 'opened' || github.event.action == 'synchronize') &&
+        github.actor != inputs.github_username
       env:
         GITHUB_USERNAME: ${{ inputs.github_username }}
         GITHUB_EMAIL: ${{ inputs.github_email }}
       run: |
         echo "::group::Commit and Push Changes"
         COMMIT_MSG="Auto-format by https://ultralytics.com/actions"
-        # Skip when HEAD is this action's own auto-format commit. Narrow scope: only catches direct self-recursion
-        # of this step (e.g. manual re-run on a SHA we just pushed). Interleaving loops with sibling auto-commit
-        # workflows (e.g. Auto-update Docs) should be prevented at the caller's workflow `if:` level, since the
-        # set of sibling bots is consumer-specific.
-        HEAD_MSG=$(git log -1 --pretty=format:'%s' 2>/dev/null || echo "")
-        if [ "$HEAD_MSG" = "$COMMIT_MSG" ]; then
-          echo "Skipping commit: HEAD is already an auto-format commit"
-          echo "::endgroup::"
-          exit 0
-        fi
         git config --global user.name "$GITHUB_USERNAME"
         git config --global user.email "$GITHUB_EMAIL"
         git add .

--- a/action.yml
+++ b/action.yml
@@ -343,21 +343,16 @@ runs:
       env:
         GITHUB_USERNAME: ${{ inputs.github_username }}
         GITHUB_EMAIL: ${{ inputs.github_email }}
-        GH_TOKEN: ${{ inputs.token }}
       run: |
         echo "::group::Commit and Push Changes"
         COMMIT_MSG="Auto-format by https://ultralytics.com/actions"
-        # Skip when this workflow run was triggered by the bot itself to break recursive loops with sibling
-        # auto-commit workflows (Auto-format <-> Auto-update Docs). Derive the bot login from the token owner
-        # (single source of truth) so the guard works regardless of how callers configure github_username.
-        # GITHUB_ACTOR / GITHUB_TRIGGERING_ACTOR are set by GitHub from the push auth token and cannot be
-        # spoofed via local git author fields. Falls back to GITHUB_USERNAME if the API call fails.
-        BOT_LOGIN="$GITHUB_USERNAME"
-        if RESPONSE=$(gh api /user --jq '.login // empty' 2>/dev/null) && [ -n "$RESPONSE" ]; then
-          BOT_LOGIN="$RESPONSE"
-        fi
-        if [ "$GITHUB_ACTOR" = "$BOT_LOGIN" ] || [ "$GITHUB_TRIGGERING_ACTOR" = "$BOT_LOGIN" ]; then
-          echo "Skipping commit: workflow triggered by $BOT_LOGIN (sibling bot push)"
+        # Skip when HEAD is this action's own auto-format commit. Narrow scope: only catches direct self-recursion
+        # of this step (e.g. manual re-run on a SHA we just pushed). Interleaving loops with sibling auto-commit
+        # workflows (e.g. Auto-update Docs) should be prevented at the caller's workflow `if:` level, since the
+        # set of sibling bots is consumer-specific.
+        HEAD_MSG=$(git log -1 --pretty=format:'%s' 2>/dev/null || echo "")
+        if [ "$HEAD_MSG" = "$COMMIT_MSG" ]; then
+          echo "Skipping commit: HEAD is already an auto-format commit"
           echo "::endgroup::"
           exit 0
         fi

--- a/action.yml
+++ b/action.yml
@@ -347,9 +347,10 @@ runs:
         echo "::group::Commit and Push Changes"
         COMMIT_MSG="Auto-format by https://ultralytics.com/actions"
         # Skip when HEAD was authored by the same bot to break recursive loops with sibling auto-commit workflows.
-        # Author-based instead of message-based so interleaving auto-commits (docs reference rebuilds, etc.) do not bypass the guard.
-        if [ "$(git log -1 --pretty=format:'%an' 2>/dev/null)" = "$GITHUB_USERNAME" ]; then
-          echo "Skipping commit: HEAD was authored by $GITHUB_USERNAME"
+        # Match name AND email so a contributor cannot spoof the bot identity by setting only --author name.
+        HEAD_AUTHOR=$(git log -1 --pretty=format:'%an|%ae' 2>/dev/null)
+        if [ "$HEAD_AUTHOR" = "$GITHUB_USERNAME|$GITHUB_EMAIL" ]; then
+          echo "Skipping commit: HEAD was authored by $GITHUB_USERNAME <$GITHUB_EMAIL>"
           echo "::endgroup::"
           exit 0
         fi


### PR DESCRIPTION
## summary

The "Commit and Push Changes" step in `action.yml` defends against recursive Auto-format loops by counting the last two commits whose message equals `Auto-format by https://ultralytics.com/actions`. The guard fires only when both top commits match that literal string, which fails to fire whenever a sibling auto-commit workflow interleaves a different message between two Auto-format pushes.

Observed live in ultralytics/ultralytics PR #24629: `.github/workflows/docs.yml` auto-commits `Auto-update Ultralytics Docs Reference by https://ultralytics.com/actions` on every PR push, and rebase merges produced by `pull_request: synchronize` pushes add `Merge ... into ...` commits. Both interleave between every Auto-format commit, so the message counter never reaches 2 and the loop ran 5+ cycles in 10 minutes before the PR was closed.

Replays of the actual `git log` show the message-based guard says RUN on all 9 sampled positions (loop survives); switching to `if [ "$(git log -1 --pretty=format:'%an')" = "$GITHUB_USERNAME" ]` says SKIP on every bot-authored HEAD and RUN only on the 3 legitimate human merge commits. The `GITHUB_USERNAME` env var is already set in this step (`env: GITHUB_USERNAME: ${{ inputs.github_username }}`), so the gate stays portable across orgs that configure a different bot user.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔁 This PR makes the auto-format GitHub Action smarter by preventing bot-triggered recursive commit loops while still formatting human-authored pull request updates as expected.

### 📊 Key Changes
- Added a new safety check to the **Commit and Push Changes** step in `action.yml`.
- The action now skips auto-committing when `github.actor` matches `inputs.github_username`, meaning the workflow was triggered by the same bot account.
- Replaced the older logic that checked whether the last two commit messages were both `"Auto-format by https://ultralytics.com/actions"`.
- Updated inline comments to clearly explain why bot-authored pushes can cause recursive workflow loops and why checking the GitHub actor is more reliable.

### 🎯 Purpose & Impact
- 🛑 **Prevents infinite or repeated auto-format commit loops** caused by bot-triggered pushes.
- ✅ **Improves reliability** by using the actual GitHub-triggering actor instead of guessing based on recent commit messages.
- 👤 **Preserves normal behavior for human contributors**, so PRs opened or updated by people still get auto-formatted.
- 🤝 **Reduces interference between related automation workflows**, such as formatting and docs update workflows that may use the same token.
- ⚡ **Makes CI behavior more predictable and efficient**, avoiding unnecessary reruns and extra bot commits.