### PR TITLE
Support python-version input

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
+          python-version: "3.13" # Optional: set up a specific Python version
           python: true # Format Python with Ruff
           python_docstrings: false # Format Python docstrings (default: false)
           biome: true # Format JS/TS with Biome (auto-detected via biome.json)

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Run Python formatting"
     required: false
     default: "false"
+  python-version:
+    description: "Python version to set up before running Python tooling"
+    required: false
+    default: ""
   python_docstrings:
     description: "Run Python docstring formatting"
     required: false
@@ -100,6 +104,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Setup Python
+      if: inputs.python-version != ''
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
     - uses: astral-sh/setup-uv@v7
       with:
         ignore-empty-workdir: true


### PR DESCRIPTION
## Summary
- add an optional `python-version` input to the composite action
- run `actions/setup-python@v6` when the input is provided
- document the input in the README example

## Context
`ultralytics/yolo-flutter-app` passes `python-version: "3.13"` to `ultralytics/actions@main`, which currently triggers GitHub's unexpected input warning before the action runs:
https://github.com/ultralytics/yolo-flutter-app/actions/runs/26905764508/job/79370112173?pr=504

## Validation
- `python - <<'PY' ... yaml.safe_load(Path("action.yml").read_text()) ... PY`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `uv run pytest`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
➕ This PR adds an optional `python-version` input to the `ultralytics/actions` GitHub Action, allowing workflows to set up a specific Python version before running Python-related tooling.

### 📊 Key Changes
- Added a new optional `python-version` input in `action.yml`.
- Introduced a new **Setup Python** step using [`actions/setup-python`](https://github.com/actions/setup-python) when `python-version` is provided.
- Updated the `README.md` example to show how to use `python-version: "3.13"` in workflows.
- Kept the feature fully optional, so existing workflows continue working without changes ✅

### 🎯 Purpose & Impact
- Makes the action more flexible by letting users choose the Python version used for formatting and other Python tooling 🐍
- Improves consistency across CI environments, especially for projects that depend on a specific Python release
- Helps avoid version-related issues when running tools like Ruff or docstring formatting
- Adds capability without breaking backward compatibility, so current users can adopt it smoothly 🚀