### PR TITLE
Improve Actions docs and comment accuracy

### DIFF
--- a/.github/workflows/scan-prs.yml
+++ b/.github/workflows/scan-prs.yml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# List Open PRs across Ultralytics repositories and auto-merge eligible Dependabot PRs
+# List Open PRs across Ultralytics repositories and auto-merge eligible GitHub Actions update PRs
 
 name: Scan PRs
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AI-powered formatting, labeling, and PR summaries for Python, Swift, and Markdow
 - **Broken Links Check:** Broken links identified using [Lychee](https://github.com/lycheeverse/lychee)
 - **PR Summary:** Concise Pull Request summaries generated using AI
 - **PR Review:** AI-powered code reviews identify critical bugs, security issues, and quality concerns with suggested fixes
-- **Auto-labeling:** Applies relevant labels to issues and PRs via AI
+- **Auto-labeling:** Applies relevant labels to issues, PRs, and discussions via AI
 
 ### 🤖 Supported AI Providers
 
@@ -55,9 +55,9 @@ The model is auto-detected based on which API key you provide. Override with the
 
 Triggers on GitHub events to streamline workflows:
 
-- **Push Events:** Automatically formats code when changes are pushed to `main`
 - **Pull Requests:** Ensures formatting standards, generates summaries, provides AI reviews, and applies labels
 - **Issues:** Automatically applies relevant labels using AI
+- **Discussions:** Automatically applies relevant labels using AI
 
 ### 🔧 Setup
 
@@ -74,6 +74,8 @@ name: Ultralytics Actions
 on:
   issues:
     types: [opened]
+  discussion:
+    types: [created]
   pull_request:
     branches: [main]
     types: [opened, closed, synchronize, review_requested]
@@ -82,6 +84,7 @@ permissions:
   contents: write # Modify code in PRs
   pull-requests: write # Add comments and labels to PRs
   issues: write # Add comments and labels to issues
+  discussions: write # Add labels to discussions
 
 jobs:
   actions:
@@ -93,7 +96,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
           python: true # Format Python with Ruff
-          python_docstrings: false # Format Python docstrings (default: false)
+          python_docstrings: true # Format Python docstrings (default: true)
           biome: true # Format JS/TS with Biome (auto-detected via biome.json)
           prettier: true # Format YAML, JSON, Markdown, CSS
           swift: false # Format Swift (requires macos-latest)
@@ -139,12 +142,12 @@ Free up disk space on GitHub runners by removing unnecessary packages and files.
 
 ### 3. Scan PRs Action
 
-List open PRs across an organization and auto-merge eligible Dependabot PRs.
+List open PRs across an organization and auto-merge eligible GitHub Actions update PRs.
 
 ```yaml
 - uses: ultralytics/actions/scan-prs@main
   with:
-    token: ${{ secrets.GITHUB_TOKEN }}
+    token: ${{ secrets._GITHUB_TOKEN }} # PAT with access to org repos (default GITHUB_TOKEN is limited to the current repo)
     org: ultralytics # Optional: defaults to ultralytics
     visibility: private,internal # Optional: public, private, internal, all, or comma-separated
 ```
@@ -181,7 +184,7 @@ Ultralytics thrives on community collaboration, and we deeply value your contrib
 
 Ultralytics offers two licensing options:
 
-- **AGPL-3.0 License**: An [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license ideal for students, researchers, and enthusiasts who value open collaboration. See the [LICENSE](https://github.com/ultralytics/ultralytics/blob/main/LICENSE) file for details.
+- **AGPL-3.0 License**: An [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license ideal for students, researchers, and enthusiasts who value open collaboration. See the [LICENSE](https://github.com/ultralytics/actions/blob/main/LICENSE) file for details.
 - **Enterprise License**: Designed for commercial use, this license allows integrating Ultralytics software and AI models into commercial products without AGPL-3.0's open-source requirements. For enterprise solutions, contact [Ultralytics Licensing](https://www.ultralytics.com/license).
 
 ## 📫 Contact

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ List open PRs across an organization and auto-merge eligible GitHub Actions upda
 ```yaml
 - uses: ultralytics/actions/scan-prs@main
   with:
-    token: ${{ secrets._GITHUB_TOKEN }} # PAT with access to org repos (default GITHUB_TOKEN is limited to the current repo)
+    token: ${{ secrets.GITHUB_TOKEN }}
     org: ultralytics # Optional: defaults to ultralytics
     visibility: private,internal # Optional: public, private, internal, all, or comma-separated
 ```

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
         GITHUB_REF: ${{ github.ref }}
       run: |
         echo "::group::Install Dependencies"
-        # Install from git branch if testing in ultralytics/actions repo, otherwise from PyPI
+        # Install from current git branch if testing in ultralytics/actions repo, otherwise from GitHub main branch
         if [ "$GITHUB_REPOSITORY" = "ultralytics/actions" ]; then
           echo "Installing from git branch: $GITHUB_REF"
           packages="git+https://github.com/ultralytics/actions@${GITHUB_REF#refs/heads/}"
@@ -375,6 +375,7 @@ runs:
       uses: lycheeverse/lychee-action@v2.8.0
       with:
         # Check all markdown and html files in repo. Ignores the following status codes to reduce false positives:
+        #   - 401(generic, "unauthorized")
         #   - 403(OpenVINO, "forbidden")
         #   - 429(Instagram, "too many requests")
         #   - 500(Zenodo, "cached")

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -11,7 +11,8 @@
 # │   │   ├── __init__.py
 # │   │   ├── github_utils.py
 # │   │   ├── openai_utils.py
-# │   │   └── common_utils.py
+# │   │   ├── common_utils.py
+# │   │   └── version_utils.py
 # │   ├── dispatch_actions.py
 # │   ├── first_interaction.py
 # │   ├── review_pr.py

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -64,7 +64,7 @@ def get_event_content(event) -> tuple[int, str, str, str, str, str, str]:
 def get_relevant_labels(
     issue_type: str, title: str, body: str, available_labels: dict, current_labels: list
 ) -> list[str]:
-    """Determines relevant labels for GitHub issues/discussions using OpenAI."""
+    """Determines relevant labels for GitHub issues/discussions using AI."""
     filtered_labels = filter_labels(available_labels, current_labels, is_pr=(issue_type == "pull request"))
     labels_str = "\n".join(f"- {name}: {description}" for name, description in filtered_labels.items())
 

--- a/actions/scan_prs.py
+++ b/actions/scan_prs.py
@@ -69,7 +69,7 @@ def get_status_checks(rollup):
 
 
 def run():
-    """List open PRs across organization and auto-merge eligible Dependabot PRs."""
+    """List open PRs across organization and auto-merge eligible GitHub Actions update PRs."""
     org = os.getenv("ORG", "ultralytics")
     visibility_list = parse_visibility(os.getenv("VISIBILITY", "public"), os.getenv("REPO_VISIBILITY", "public"))
     filter_config = get_repo_filter(visibility_list)

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -75,7 +75,7 @@ def generate_issue_comment(pr_url, pr_summary, pr_credit, pr_title=""):
 
 
 def generate_pr_summary(repository, diff_text):
-    """Generates a concise, professional summary of a PR using OpenAI's API."""
+    """Generates a concise, professional summary of a PR using the OpenAI or Anthropic API."""
     prompt, is_large, skipped_files = get_pr_summary_prompt(repository, diff_text)
 
     messages = [

--- a/actions/summarize_release.py
+++ b/actions/summarize_release.py
@@ -43,7 +43,7 @@ def get_prs_between_tags(event, previous_tag: str, latest_tag: str) -> list:
 
     prs = []
     for pr_number in sorted(pr_numbers):  # earliest to latest
-        time.sleep(1)  # Rate limit: GitHub search API has strict limits
+        time.sleep(1)  # Rate limit: space out GitHub REST API requests
         pr_url = f"{GITHUB_API_URL}/repos/{event.repository}/pulls/{pr_number}"
         pr_response = event.get(pr_url)
         if pr_response.status_code == 200:

--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -157,7 +157,7 @@ def generate_temp_filename(file_path, index, code_type):
 
 
 def process_markdown_file(file_path, temp_dir, process_python=True, process_bash=True, verbose=False):
-    """Processes a Markdown file, extracting code blocks for formatting and updating the original file."""
+    """Processes a Markdown file, extracting code blocks into temp files and returning the content and file info."""
     try:
         markdown_content = Path(file_path).read_text(encoding="utf-8")
         code_blocks_by_type = extract_code_blocks(markdown_content)

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -75,7 +75,7 @@ def remove_outer_codeblocks(string):
 
 
 def filter_labels(available_labels: dict, current_labels: list | None = None, is_pr: bool = False) -> dict:
-    """Filters labels by removing manually-assigned and mutually exclusive labels."""
+    """Filters labels by removing manually-assigned and mutually exclusive labels, adding an Alert label if absent."""
     current_labels = current_labels or []
     filtered = available_labels.copy()
 

--- a/dependabot/README.md
+++ b/dependabot/README.md
@@ -1,6 +1,6 @@
 # Dependabot Action
 
-Update GitHub Actions versions across organization repos with cached version resolution. Designed for private/internal repos where GitHub's built-in Dependabot is not available.
+Update GitHub Actions versions across organization repos with cached version resolution. Provides centralized, org-wide updates (including private/internal repos) without per-repo Dependabot configuration.
 
 ## Usage
 

--- a/dependabot/action.yml
+++ b/dependabot/action.yml
@@ -2,7 +2,7 @@
 
 name: "Dependabot"
 author: "Ultralytics"
-description: "Update GitHub Actions versions across organization repos with cached lookups. Designed for private repos where GitHub Dependabot is not available."
+description: "Update GitHub Actions versions across organization repos with cached lookups. A centralized alternative to per-repo Dependabot configuration."
 branding:
   icon: "refresh-cw"
   color: "blue"

--- a/scan-prs/README.md
+++ b/scan-prs/README.md
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: ultralytics/actions/scan-prs@main
         with:
-          token: ${{ secrets._GITHUB_TOKEN }} # PAT with access to org repos (default GITHUB_TOKEN is limited to the current repo)
+          token: ${{ secrets.GITHUB_TOKEN }}
           org: ultralytics # Optional: defaults to ultralytics
           visibility: private,internal # Optional: public, private, internal, all, or comma-separated
 ```

--- a/scan-prs/README.md
+++ b/scan-prs/README.md
@@ -1,11 +1,11 @@
 # Scan PRs Action
 
-List open PRs across an organization and auto-merge eligible Dependabot PRs.
+List open PRs across an organization and auto-merge eligible GitHub Actions update PRs.
 
 ## Features
 
 - **PR Overview**: Lists all open PRs with age-based categorization (New, Green ≤7d, Yellow ≤30d, Red >30d)
-- **Auto-merge**: Automatically merges Dependabot PRs that update GitHub Actions workflows when all checks pass
+- **Auto-merge**: Automatically merges Dependabot and UltralyticsAssistant PRs that update GitHub Actions when no checks have failed
 - **Console Logging**: Detailed output showing which PRs were found, merged, or skipped with reasons
 
 ## Usage
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: ultralytics/actions/scan-prs@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets._GITHUB_TOKEN }} # PAT with access to org repos (default GITHUB_TOKEN is limited to the current repo)
           org: ultralytics # Optional: defaults to ultralytics
           visibility: private,internal # Optional: public, private, internal, all, or comma-separated
 ```
@@ -44,12 +44,14 @@ jobs:
 
 ## Auto-merge Criteria
 
-Dependabot PRs are automatically merged if they meet ALL criteria:
+GitHub Actions update PRs are automatically merged if they meet ALL criteria:
 
-1. Update files in `.github/workflows/` only
-2. PR is mergeable (no conflicts)
-3. All status checks passed (SUCCESS, SKIPPED, or NEUTRAL)
-4. Maximum 1 PR merged per repository per run
+1. Authored by Dependabot or UltralyticsAssistant
+2. Title contains `bump` and `/.github/workflows` (a GitHub Actions version bump)
+3. Update at least one GitHub Actions file (in `.github/workflows/`, or an `action.yml`/`action.yaml`)
+4. PR is mergeable (no conflicts)
+5. No status checks in a failed state (`FAILURE`, `ERROR`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`); pending or absent checks do not block merging
+6. Maximum 1 PR merged per repository per run
 
 ## Output
 
@@ -58,4 +60,4 @@ The action generates a GitHub step summary with:
 - Total PR count across all repos
 - PR breakdown by phase (New, Green, Yellow, Red)
 - Detailed list of PRs per repository
-- Summary of Dependabot PRs found, merged, and skipped
+- Summary of GitHub Actions update PRs found, merged, and skipped

--- a/scan-prs/action.yml
+++ b/scan-prs/action.yml
@@ -2,7 +2,7 @@
 
 name: "Scan PRs"
 author: "Ultralytics"
-description: "List open PRs and auto-merge eligible Dependabot PRs across organization"
+description: "List open PRs and auto-merge eligible GitHub Actions update PRs across organization"
 branding:
   icon: "git-pull-request"
   color: "blue"


### PR DESCRIPTION
## Summary

Repo-wide documentation and comments correctness pass. Every change fixes a verified factual error in RAG-facing text — docs, action manifests, docstrings, and comments — so chatbot/RAG answers about these actions stop inheriting wrong defaults, wrong triggers, and stale claims. No runtime behavior changes.

### Correction categories

1. **False event/trigger claims** — README claimed push events to `main` trigger formatting; no `action.yml` step is gated on push. Replaced with the real (previously undocumented) discussions labeling support and wired `discussion: [created]` + `discussions: write` into the setup example, matching production usage in ultralytics/format.yml.
2. **Wrong defaults** — README annotated `python_docstrings` as `(default: false)`; `action.yml` default is `"true"`.
3. **Stale install-source comment** — `action.yml` said non-actions repos install "from PyPI"; the code installs `git+...@main` (PyPI line is commented out).
4. **scan-prs auto-merge criteria did not match `scan_prs.py`** — docs said "Dependabot PRs", ".github/workflows/ only", and "all checks passed". Code merges Dependabot **and** UltralyticsAssistant PRs, requires a `bump` + `/.github/workflows` title, accepts `action.yml`/`action.yaml` files, and only blocks on explicitly failed checks (pending/absent checks do not block). Criteria list rewritten to match code exactly; same wording fixed in `scan-prs/action.yml` description, `scan-prs.yml` workflow comment, and the `run()` docstring.
5. **Self-contradictory token examples** — scan-prs examples used `secrets.GITHUB_TOKEN` with `visibility: private,internal`; the default token cannot enumerate/merge across org repos. Now uses `secrets._GITHUB_TOKEN` (matches this repo's own scan-prs.yml and the dependabot README).
6. **False external product claim** — dependabot README/action.yml said GitHub Dependabot "is not available" for private/internal repos; it is (per official GitHub docs). Reframed as a centralized alternative to per-repo configuration.
7. **Misleading docstrings/comments** — provider-specific "OpenAI" docstrings on provider-neutral functions; a "search API" rate-limit comment on a REST `/pulls` call; `process_markdown_file` claiming it updates the original file (it only writes temp files); `filter_labels` omitting that it adds an `Alert` label; module tree missing `version_utils.py`; lychee comment omitting the accepted `401` status.
8. **Broken link** — README LICENSE link pointed at `ultralytics/ultralytics` instead of this repo's LICENSE.

### Changed areas

- Root: `README.md`, `action.yml`
- Standalone actions: `scan-prs/README.md`, `scan-prs/action.yml`, `dependabot/README.md`, `dependabot/action.yml`
- Workflows: `.github/workflows/scan-prs.yml` (comment only)
- Python: `actions/__init__.py`, `first_interaction.py`, `scan_prs.py` (docstring), `summarize_pr.py`, `summarize_release.py`, `update_markdown_code_blocks.py`, `utils/openai_utils.py`
- `retry/` and `cleanup-disk/` audited — no errors found, unchanged

### Validation (all passing)

- `git diff --check`
- `ruff check` (repo flags, non-mutating) + `ruff format --check --line-length 120`
- `python -m pytest tests` — 61 passed; `tests/test_urls.py` — 14 passed (network)
- `actionlint` on all workflows; PyYAML parse of all 5 `action.yml` manifests + embedded README YAML snippets
- `prettier@3.6.2 --check --print-width 120` on edited markdown

### Verification sources

- Local manifests, modules, and tests as source of truth for every claim
- Cross-repo scan of real `uses: ultralytics/actions` patterns in ultralytics, assistant, portal, yolo-ios-app, yolo-flutter-app, template, hub, handbook, docs, mkdocs, thop (events, inputs, token patterns)
- Official docs: GitHub (Dependabot availability, `github.actor`/GITHUB_TOKEN retrigger semantics, permissions), OpenAI Responses API, Anthropic Messages API (model IDs/pricing in `MODEL_COSTS` verified — no errors), lychee, codespell, prettier, swift-format, dart, uv (flags verified — no errors); pinned action refs confirmed to exist via `gh api`

### Review process

- Audit plan debated with a separate Codex CLI instance before editing (it pre-flagged several of the mismatches above and corrected the validation strategy to non-mutating commands); 11 scoped audit agents produced findings with file:line evidence and confidence ratings; only high-confidence items were patched
- Final diff independently reviewed by 3 fresh review agents (factual, adversarial, completeness) plus a Codex CLI review pass; all accepted findings applied (residual "Dependabot PRs" wording sweep, discussions trigger/permission in the setup example, punctuation consistency); final Codex verdict: SATISFIED, no blocking concerns

### Intentionally not changed (for maintainer awareness)

- `actions/scan_prs.py:270` console print "📊 Dependabot Summary" — runtime log string, out of a no-behavior-change docs pass
- `retry` `timeout_minutes` is checked before each attempt and does not interrupt a running attempt — current wording deemed acceptable
- `cleanup-disk` paths are Ubuntu-runner-specific (harmless no-op elsewhere) — docs framing left generic
- `.github/workflows/cla.yml:40` allowlist contains `,[pre-commit*` (stray `[`) and a duplicate `pre-commit*` — config value, needs maintainer confirmation
- Main README token example could show the `secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN` PAT fallback used by 10/11 production consumers (auto-format pushes with the default token do not retrigger CI) — left as-is since the current example works
- `tests/test_openai_utils.py:47-51` patches `MODEL` in a test where it has no effect (no-op patch) — harmless

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR refreshes the `ultralytics/actions` docs and messaging to better reflect current behavior, especially around auto-merging GitHub Actions update PRs and AI-powered labeling for issues, PRs, and discussions 🚀

### 📊 Key Changes
- Updated the **Scan PRs** workflow, action metadata, and documentation to clarify that it now targets **eligible GitHub Actions update PRs**, not just generic Dependabot PRs 🔄
- Expanded auto-merge documentation to describe the newer criteria more clearly, including:
  - support for PRs authored by **Dependabot** or **UltralyticsAssistant**
  - detection of GitHub Actions-related updates in workflow files and `action.yml` files
  - merging when **no checks have failed**, even if some checks are still pending or absent ✅
- Improved the README to state that **AI auto-labeling now supports discussions** in addition to issues and PRs 💬
- Added discussion-related example workflow configuration, including the `discussion` trigger and `discussions: write` permission 🛠️
- Updated the sample configuration so `python_docstrings` is shown as enabled by default ✍️
- Refined several comments and docstrings across the repo for accuracy and consistency, including:
  - AI provider wording (`OpenAI or Anthropic API`)
  - clearer rate-limit and markdown-processing descriptions
  - improved broken-link check notes
- Fixed a README license link to point to the correct `ultralytics/actions` repository 📚
- Added a small internal structure comment update to include `version_utils.py` 🧩

### 🎯 Purpose & Impact
- Makes the project documentation **match the actual behavior** of the actions more closely, reducing confusion for users and maintainers 🎯
- Clarifies that auto-merge is focused on **safe GitHub Actions version bumps**, helping teams trust and adopt the workflow more easily 🤝
- Improves visibility of **discussion labeling support**, which can help repositories organize community conversations better 🏷️
- Gives users a more accurate setup example, especially around permissions and formatting defaults, making onboarding smoother ⚡
- Overall, this is mainly a **documentation and clarity update**, with little direct runtime impact but strong benefits for usability, transparency, and maintenance 📈