### PR TITLE
Improve Actions docs and comment accuracy (follow-up)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,7 +37,7 @@ jobs:
           path-to-document: "https://docs.ultralytics.com/help/CLA" # CLA document
           # Branch must not be protected
           branch: cla-signatures
-          allowlist: dependabot[bot],github-actions,[pre-commit*,pre-commit*,bot*
+          allowlist: dependabot[bot],github-actions,pre-commit*,bot*
 
           remote-organization-name: ultralytics
           remote-repository-name: cla

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -29,4 +29,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.14"
+__version__ = "0.2.15"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -430,7 +430,7 @@ def post_review_summary(event: Action, review_data: dict, review_number: int) ->
     comments = review_data.get("comments", [])
     summary = review_data.get("summary") or ""
 
-    # Don't approve if error occurred, inline comments exist, or critical/high severity issues
+    # Don't approve if error occurred, inline comments exist, or medium-or-higher severity issues
     has_error = not summary or ERROR_MARKER in summary
     has_inline_comments = review_data.get("comments_before_filtering", 0) > 0
     has_issues = any(c.get("severity") not in ["LOW", "SUGGESTION", None] for c in comments)

--- a/actions/scan_prs.py
+++ b/actions/scan_prs.py
@@ -267,7 +267,7 @@ def run():
                 total_skipped += 1
 
     summary.append(f"\n**Summary:** Found {total_found} | Merged {total_merged} | Skipped {total_skipped}")
-    print(f"\n📊 Dependabot Summary: Found {total_found} | Merged {total_merged} | Skipped {total_skipped}")
+    print(f"\n📊 Auto-Merge Summary: Found {total_found} | Merged {total_merged} | Skipped {total_skipped}")
 
     if summary_file := os.getenv("GITHUB_STEP_SUMMARY"):
         with open(summary_file, "a") as f:

--- a/actions/update_file_headers.py
+++ b/actions/update_file_headers.py
@@ -176,7 +176,7 @@ def update_file(file_path, prefix, block_start, block_end, base_header):
 
 
 def main(*args, **kwargs):
-    """Automates file header updates for all files in the specified directory."""
+    """Automates file header updates for supported file types under the current working directory."""
     event = Action(*args, **kwargs)
     current_year = datetime.now().year
     repository = (event.repository or "").lower()

--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -11,7 +11,7 @@ from urllib import parse
 
 import requests
 
-# Common directories to exclude when traversing file trees (used by docstring formatter, header updater, etc.)
+# Common directories to exclude when traversing file trees (used by the Python docstring formatter)
 COMMON_EXCLUDED_DIRS = frozenset(
     {
         ".git",
@@ -274,7 +274,7 @@ def clean_url(url):
 
 
 def allow_redirect(start="", end=""):
-    """Check if URL should be skipped based on simple rules."""
+    """Check if a redirect target should be applied based on simple allow rules."""
     start_lower = start.lower()
     end_lower = end.lower()
     return (

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -159,7 +159,7 @@ def _get_default_model() -> str:
 
 
 def get_review_model() -> str:
-    """Get model for PR reviews, using REVIEW_MODEL if set, otherwise default model."""
+    """Get model for PR reviews, using REVIEW_MODEL if set, otherwise PR_REVIEW_MODEL_DEFAULT."""
     return REVIEW_MODEL or PR_REVIEW_MODEL_DEFAULT
 
 

--- a/cleanup-disk/README.md
+++ b/cleanup-disk/README.md
@@ -2,7 +2,7 @@
 
 # 🧹 Disk Space Cleanup Action
 
-Cleans up disk space on GitHub Actions runners by removing unnecessary tool caches and swap space. Frees up ~19GB total space.
+Cleans up disk space on Ubuntu GitHub Actions runners by removing unnecessary tool caches and swap space. Frees up ~19GB total space.
 
 ## 🚀 Usage
 

--- a/retry/README.md
+++ b/retry/README.md
@@ -56,7 +56,7 @@ steps:
 | --------------------- | ------------------------------------------------------------ | -------- | ------------- |
 | `run`                 | Command to run                                               | Yes      | -             |
 | `retries`             | Number of retry attempts after initial run                   | No       | `3`           |
-| `timeout_minutes`     | Maximum total time in minutes for all attempts combined      | No       | `360`         |
+| `timeout_minutes`     | Maximum total time in minutes, checked between attempts      | No       | `360`         |
 | `retry_delay_seconds` | Base delay between retries in seconds                        | No       | `10`          |
 | `backoff`             | Backoff strategy: `exponential` (base \* 2^n) or `fixed`     | No       | `exponential` |
 | `jitter`              | Randomize delay to 80-120% of value to avoid thundering herd | No       | `true`        |

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -26,7 +26,7 @@ name: "Step-Level Retry"
 description: "Retries a step while preserving its full context"
 inputs:
   timeout_minutes:
-    description: "Maximum total time in minutes for all attempts"
+    description: "Maximum total time in minutes for all attempts (checked between attempts; does not interrupt a running attempt)"
     required: false
     default: "360"
   retries:


### PR DESCRIPTION
## Summary

Follow-up pass to #755. A fresh 11-agent audit swept the areas #755 did not touch (`tests/`, `review_pr.py`, `update_file_headers.py`, `dispatch_actions.py`, `format_python_docstrings.py`, `retry/`, `cleanup-disk/`, the remaining workflows, `pyproject.toml`) and re-adjudicated #755's deferred list. Result: 10 one-line corrections across 9 files. Every change fixes a verified factual error in RAG-facing text; the only two runtime-visible changes are a log label and a dead config token, both adjudicated below.

### Correction categories

1. **Inverted docstring** — `common_utils.allow_redirect` claimed to check whether a URL "should be skipped"; it returns `True` when the redirect should be **applied** (sole caller `is_url` does `url = response.url` on `True`).
2. **Wrong consumer claim** — `COMMON_EXCLUDED_DIRS` comment named the "header updater" as a consumer; `update_file_headers.py` uses its own `IGNORE_PATHS` and never imports it. Only the Python docstring formatter consumes it.
3. **Understated approval gate** — `review_pr.py` comment said "critical/high severity issues" block approval; `has_issues` blocks on anything not in `[LOW, SUGGESTION, None]`, i.e. **medium**-or-higher.
4. **Misleading fallback claim** — `get_review_model` docstring said fallback is the "default model" (suggesting the API-key-aware `_get_default_model()`); it falls back to the fixed `PR_REVIEW_MODEL_DEFAULT` constant.
5. **Wrong scope docstring** — `update_file_headers.main` claimed "all files in the specified directory"; there is no directory parameter (hardcoded `Path.cwd()`) and only `COMMENT_MAP` extensions are processed.
6. **Stale log label** (deferred from #755, now adjudicated PATCH) — `scan_prs.py` printed "📊 Dependabot Summary" for a scan covering Dependabot **and** UltralyticsAssistant PRs; renamed to "Auto-Merge Summary", matching the adjacent step-summary header. Log-string only; no logic change.
7. **Dead config token** (deferred from #755, now adjudicated PATCH) — `cla.yml` allowlist contained `[pre-commit*` (stray `[`; contributor-assistant escapes `[` via lodash `escapeRegExp`, so it could only ever match a literal `[pre-commit` substring — itself a strict subset of the retained `pre-commit*`) plus an exact duplicate `pre-commit*`. Removed both; provably behavior-preserving (verified against `checkAllowList.ts` at `v2.6.1` with regex simulation).
8. **Overstated timeout semantics** (deferred from #755, now adjudicated PATCH) — retry's `timeout_minutes` was described as a hard cap "for all attempts combined"; the check runs only between attempts (`retry/action.yml:131`) and never interrupts a running attempt. Clarified in the canonical input description and README table row; example-comment shorthand left untouched to avoid churn.
9. **Overstated portability** (deferred from #755, now adjudicated PATCH) — cleanup-disk claimed to clean "GitHub Actions runners" generically; `/opt/hostedtoolcache` and `/swapfile` are Ubuntu-hosted-runner paths (silent no-op elsewhere). Scoped to "Ubuntu GitHub Actions runners".

### Changed areas

- Python: `actions/review_pr.py`, `actions/scan_prs.py`, `actions/update_file_headers.py`, `actions/utils/common_utils.py`, `actions/utils/openai_utils.py`
- Standalone actions: `retry/README.md`, `retry/action.yml`, `cleanup-disk/README.md`
- Workflows: `.github/workflows/cla.yml`

### Validation (all passing)

- `git diff --check`
- `ruff check` (repo flags, non-mutating) + `ruff format --check --line-length 120` on edited Python files — clean
- `python -m pytest tests -q` — **75 passed** (includes the 14 network URL tests); post-run `git status` confirmed no repo mutation from the test suite
- `actionlint` on all workflows — clean
- PyYAML parse of edited `action.yml`/workflow files — clean
- `prettier --check --print-width 120` on edited markdown — clean (table alignment preserved by matching cell width)
- Constraint guard: `git diff -U0 | grep -E 'GITHUB_TOKEN|AGPL-3.0'` — empty (no token mentions or license banners touched)

### Verification sources

- Local manifests, modules, and tests as source of truth for every claim
- `contributor-assistant/github-action@v2.6.1` source (`src/checkAllowList.ts` and compiled `dist/index.js`) with regex simulation for the allowlist semantics
- Cross-repo scan of real `uses: ultralytics/actions` consumers (ultralytics, assistant, portal, docs, handbook, hub, yolo-ios-app, yolo-flutter-app — ~26 workflows): all README/input claims for the root and standalone actions check out; no doc contradicts real usage
- Official docs spot-checks for claims #755 had not covered: OpenAI Responses API background mode, Anthropic Messages API headers/fields, GitHub REST endpoints, Biome/Prettier language and flag claims, Brave Search API limits, `bun update --latest` — all repo text verified accurate, no changes needed
- All 11 `uses:` action pins across workflows confirmed to resolve via `gh api`

### Review process

- **Codex CLI planning debate (before editing):** Codex critiqued the audit plan and issued per-item verdicts on #755's deferred list — PATCH the scan_prs label, cla.yml allowlist, retry timeout wording, cleanup-disk scoping; DEFER the test `MODEL` patch (it acts as a regression guard against `MODEL` ever taking precedence in `get_review_model`). It also flagged that `pytest` can write to the working tree (added a post-pytest mutation gate, which passed) and set churn guards (no global "Dependabot" renames, no model-name updates, no README↔format.yml forced convergence) — all honored.
- **11 scoped read-only audit agents** produced findings with file:line evidence and confidence ratings; only high-confidence, code-verified items were patched. Root README, root action.yml, pyproject.toml, tests, cross-repo usage, and external claims came back clean.
- **3 independent review agents** (factual, adversarial, completeness) reviewed the final diff: all 10 changes verified CORRECT / SURVIVES; no missed sibling corrections; all deferrals endorsed.
- **Codex CLI final review:** zero findings at any severity. **VERDICT: SATISFIED.**

### Intentionally not changed (for maintainer awareness)

- `action.yml` `first_pr_response` input is dead: it is passed as `FIRST_PR_RESPONSE` (action.yml:289) but no Python code reads it — `first_interaction.py:139` only reads `FIRST_ISSUE_RESPONSE`, which applies to issues, PRs, and discussions alike. Fixing requires a product decision (wire it up for PR events, or remove the input), so it is out of scope for a docs pass.
- `tests/test_openai_utils.py:48-51` nested `MODEL` patch — kept: it guards against a future refactor making `MODEL` take precedence in `get_review_model()`.
- retry `README.md:32/:69` and `action.yml:19` "total timeout" example comments — left as shorthand; the canonical input description and table row now carry the precise semantics.
- `review_pr.py:435` `comments_before_filtering` naming nuance, `update_file_headers.py:128` "first few lines" comment — low-confidence/loose-but-not-wrong; left unchanged.
- Main README token-fallback example — token-related text was explicitly out of scope for this pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR mainly improves wording, documentation clarity, and review/automation messaging across the repository, with a small policy-related tweak to PR approval behavior.

### 📊 Key Changes
- 🔖 Bumped the package version from `0.2.14` to `0.2.15`.
- ✅ Updated the CLA workflow allowlist pattern to simplify bot matching and clean up the configuration.
- 🔍 Clarified PR review approval logic in comments: reviews should not be auto-approved when issues of **medium severity or higher** are present.
- 📈 Renamed the merge log output from **“Dependabot Summary”** to **“Auto-Merge Summary”** to better reflect broader usage.
- 📝 Improved several docstrings and README descriptions for accuracy, including:
  - file header updater behavior
  - excluded directory usage
  - redirect helper behavior
  - PR review model selection
  - cleanup action scope being specific to **Ubuntu** GitHub runners
  - retry action timeout behavior being checked **between attempts**, not during a running attempt
- ⚙️ Updated `retry/action.yml` and `retry/README.md` so the timeout setting is described more precisely and consistently.

### 🎯 Purpose & Impact
- 🙌 Makes the repository easier to understand and maintain by improving internal comments, help text, and documentation.
- 🚦 Reduces ambiguity around automation behavior, especially for PR review approvals and retry timeouts.
- 🤖 Better naming in logs and workflow settings helps users and maintainers understand what automation is actually doing.
- 📚 Improves user experience for action consumers by setting clearer expectations, especially for the `retry` and `cleanup-disk` actions.
- 🔒 The PR review note suggests a stricter approval standard, which can help prevent risky PRs from being auto-approved if non-trivial issues are detected.