### PR TITLE
Skip shell formatter when no shell snippets exist

### DIFF
--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -98,6 +98,9 @@ def format_code_with_ruff(temp_dir):
 
 def format_bash_with_prettier(temp_dir):
     """Formats bash script files in the specified directory using prettier."""
+    if not next(Path(temp_dir).rglob("*.sh"), None):
+        return
+
     try:
         # Run prettier with explicit config path
         result = subprocess.run(

--- a/tests/test_update_markdown_codeblocks.py
+++ b/tests/test_update_markdown_codeblocks.py
@@ -7,6 +7,7 @@ from unittest.mock import mock_open, patch
 from actions.update_markdown_code_blocks import (
     add_indentation,
     extract_code_blocks,
+    format_bash_with_prettier,
     generate_temp_filename,
     main,
     process_markdown_file,
@@ -106,6 +107,16 @@ def test():
     assert len(temp_files) == 1
     assert temp_files[0][1] == "def test():\n    return True"
     mock_file.assert_called_once()
+
+
+def test_format_bash_skips_when_no_shell_files(tmp_path):
+    """Test bash formatter skips Prettier when no shell snippets were extracted."""
+    (tmp_path / "snippet.py").write_text("print('ok')", encoding="utf-8")
+
+    with patch("subprocess.run") as mock_run:
+        format_bash_with_prettier(tmp_path)
+
+    mock_run.assert_not_called()
 
 
 def test_main_real_files():


### PR DESCRIPTION
## Summary
- skip the markdown shell formatter when no extracted shell snippets exist
- add a focused regression test so markdown-only repos do not log false prettier-plugin-sh errors

## Validation
- uv run --extra dev python -m pytest tests/test_update_markdown_codeblocks.py -q
- uv run ruff check actions/update_markdown_code_blocks.py tests/test_update_markdown_codeblocks.py
- uv run ruff format --check actions/update_markdown_code_blocks.py tests/test_update_markdown_codeblocks.py
- independent Codex review: no issues found

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚡ This PR makes the Markdown code-block updater smarter by skipping Prettier when no shell script files are present, improving reliability and avoiding unnecessary formatting steps.

### 📊 Key Changes
- Added a guard in `format_bash_with_prettier()` to check whether any `*.sh` files exist before running Prettier.
- If no shell script snippets are found in the temporary directory, the function now exits early instead of invoking `subprocess.run`.
- Added a new test, `test_format_bash_skips_when_no_shell_files`, to verify that Prettier is not called when only non-shell files are present.
- Updated test imports to include `format_bash_with_prettier` for direct coverage of this behavior. ✅

### 🎯 Purpose & Impact
- Prevents unnecessary Prettier executions when Markdown files contain no bash code blocks. 🚀
- Reduces the chance of avoidable errors or wasted work in automation workflows.
- Makes the `update_markdown_code_blocks` action more efficient and robust, especially in repositories with mixed or non-shell code examples.
- Improves test coverage for this edge case, helping maintain stable CI behavior over time. 🧪