### PR TITLE
Reduce Codecov upload log noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
+          files: ./coverage.xml
+          disable_search: true
+          plugins: noop
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary\n- upload the generated coverage.xml explicitly\n- disable Codecov's workspace search so it does not probe unrelated coverage formats\n\n## Validation\n- actionlint .github/workflows/ci.yml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes Codecov uploads in CI more explicit and reliable by directly specifying the coverage report file and disabling automatic file searching.

### 📊 Key Changes
- Added `files: ./coverage.xml` to the Codecov step in `.github/workflows/ci.yml` 📄
- Added `disable_search: true` so Codecov only uses the specified coverage file 🔍
- Added `plugins: noop` to simplify the upload behavior and avoid extra plugin-related processing ⚙️
- Kept the existing `CODECOV_TOKEN` authentication setup unchanged 🔐

### 🎯 Purpose & Impact
- Improves CI consistency by ensuring Codecov uploads the intended `coverage.xml` report every time ✅
- Reduces the chance of Codecov picking up the wrong files or failing due to auto-discovery issues 🛠️
- Makes the coverage upload step more predictable and easier to debug for maintainers 👀
- Helps keep reporting stable across workflow or environment changes, with minimal impact on users but better reliability for contributors and maintainers 🚀