### PR TITLE
Improve docs, comments, and correctness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -32,6 +32,7 @@ body:
         - "Retry Action"
         - "Cleanup Disk Action"
         - "Scan PRs Action"
+        - "Dependabot Action"
         - "Python package (`ultralytics-actions`)"
         - "Repository documentation / README"
         - "Other"

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -32,6 +32,7 @@ body:
         - "Retry Action"
         - "Cleanup Disk Action"
         - "Scan PRs Action"
+        - "Dependabot Action"
         - "Python package (`ultralytics-actions`)"
         - "Repository documentation / README"
         - "Other"

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -30,6 +30,7 @@ body:
         - "Retry Action"
         - "Cleanup Disk Action"
         - "Scan PRs Action"
+        - "Dependabot Action"
         - "Python package (`ultralytics-actions`)"
         - "Repository documentation / README"
         - "Other"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           token: ${{ secrets._GITHUB_TOKEN || github.token }} # Auto-generated fallback
           labels: true # Auto-label issues/PRs using AI
+          python-version: "3.14" # Use Python 3.14 for faster tooling
           python: true # Format Python with Ruff
           python_docstrings: true # Format Python docstrings
           prettier: true # Format YAML, JSON, Markdown, CSS

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           token: ${{ secrets._GITHUB_TOKEN || github.token }} # Auto-generated fallback
           labels: true # Auto-label issues/PRs using AI
-          python-version: "3.14" # Use Python 3.14 for faster tooling
           python: true # Format Python with Ruff
           python_docstrings: true # Format Python docstrings
           prettier: true # Format YAML, JSON, Markdown, CSS

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
-          python-version: "3.13" # Optional: set up a specific Python version
+          python-version: "3.14" # Optional: set up a specific Python version
           python: true # Format Python with Ruff
           python_docstrings: true # Format Python docstrings (default: true)
           biome: true # Format JS/TS with Biome (auto-detected via biome.json)
@@ -172,11 +172,9 @@ Update GitHub Actions versions across organization repositories with cached rele
 
 ## Python Package
 
-Install `ultralytics-actions` for programmatic access to action utilities.
+Install the `ultralytics-actions` package for programmatic access to action utilities, including all [requirements](https://github.com/ultralytics/actions/blob/main/pyproject.toml), in a [**Python>=3.8**](https://www.python.org/) environment.
 
-[![PyPI - Version](https://img.shields.io/pypi/v/ultralytics-actions?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics-actions/)
-[![Ultralytics Downloads](https://static.pepy.tech/badge/ultralytics-actions)](https://clickpy.clickhouse.com/dashboard/ultralytics-actions)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics-actions?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics-actions/)
+[![PyPI - Version](https://img.shields.io/pypi/v/ultralytics-actions?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics-actions/) [![Ultralytics Downloads](https://static.pepy.tech/badge/ultralytics-actions)](https://clickpy.clickhouse.com/dashboard/ultralytics-actions) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics-actions?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics-actions/)
 
 ```bash
 pip install ultralytics-actions

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository provides three main components:
 
 ## Ultralytics Actions (Main Action)
 
-AI-powered formatting, labeling, and PR summaries for Python, Swift, and Markdown files.
+AI-powered formatting, labeling, and PR summaries for Python, Swift, Dart, and Markdown files.
 
 ### 📄 Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -98,6 +98,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
+          python-version: "3.13" # Optional: set up a specific Python version
           python: true # Format Python with Ruff
           python_docstrings: true # Format Python docstrings (default: true)
           biome: true # Format JS/TS with Biome (auto-detected via biome.json)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -98,7 +98,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
-          python-version: "3.13" # Optional: set up a specific Python version
+          python-version: "3.14" # Optional: set up a specific Python version
           python: true # Format Python with Ruff
           python_docstrings: true # Format Python docstrings (default: true)
           biome: true # Format JS/TS with Biome (auto-detected via biome.json)
@@ -172,11 +172,9 @@ jobs:
 
 ## Python 包
 
-安装 `ultralytics-actions` 以便通过代码使用 action 工具。
+在 [**Python>=3.8**](https://www.python.org/) 环境中安装 `ultralytics-actions` 包及其全部[依赖项](https://github.com/ultralytics/actions/blob/main/pyproject.toml)，以便通过代码使用 action 工具。
 
-[![PyPI - Version](https://img.shields.io/pypi/v/ultralytics-actions?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics-actions/)
-[![Ultralytics Downloads](https://static.pepy.tech/badge/ultralytics-actions)](https://clickpy.clickhouse.com/dashboard/ultralytics-actions)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics-actions?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics-actions/)
+[![PyPI - Version](https://img.shields.io/pypi/v/ultralytics-actions?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics-actions/) [![Ultralytics Downloads](https://static.pepy.tech/badge/ultralytics-actions)](https://clickpy.clickhouse.com/dashboard/ultralytics-actions) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics-actions?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics-actions/)
 
 ```bash
 pip install ultralytics-actions

--- a/action.yml
+++ b/action.yml
@@ -84,9 +84,6 @@ inputs:
   first_issue_response:
     description: "Example response to a new issue"
     required: false
-  first_pr_response:
-    description: "Example response to a new PR"
-    required: false
   bun_update:
     description: "Run bun update to update bun.lock if bun project detected"
     required: false
@@ -269,7 +266,7 @@ runs:
         codespell \
           --builtin clear,rare,informal,en-GB_to_en-US \
           --write-changes \
-          --uri-ignore-words-list * \
+          --uri-ignore-words-list "*" \
           --ignore-regex '\b[a-z]+[A-Z][a-zA-Z]*\b' \
           --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,cann,CANN" \
           --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml"
@@ -296,7 +293,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         FIRST_ISSUE_RESPONSE: ${{ inputs.first_issue_response }}
-        FIRST_PR_RESPONSE: ${{ inputs.first_pr_response }}
         BRAVE_API_KEY: ${{ inputs.brave_api_key }}
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -29,4 +29,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.15"
+__version__ = "0.2.16"

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 from .utils import (
     ACTIONS_CREDIT,
     GITHUB_API_URL,
@@ -43,10 +45,11 @@ def generate_issue_comment(pr_url, pr_summary, pr_credit, pr_title=""):
     """Generates personalized issue comment based on PR context."""
     # pr_url is the GraphQL PullRequest.url HTML URL (https://github.com/owner/repo/pull/N) in production;
     # REST API URLs (https://api.github.com/repos/owner/repo/pulls/N) are also supported
+    parsed = urlparse(pr_url)
     if "/repos/" in pr_url and "/pulls/" in pr_url:
         repo_parts = pr_url.split("/repos/", 1)[1].split("/pulls/", 1)[0]
-    elif "github.com/" in pr_url and "/pull/" in pr_url:
-        repo_parts = pr_url.split("github.com/", 1)[1].split("/pull/", 1)[0]
+    elif parsed.hostname == "github.com" and "/pull/" in parsed.path:
+        repo_parts = parsed.path.lstrip("/").split("/pull/", 1)[0]
     else:
         repo_parts = ""
     owner_repo = repo_parts.split("/")

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -41,7 +41,14 @@ def generate_merge_message(pr_summary, pr_credit, pr_url):
 
 def generate_issue_comment(pr_url, pr_summary, pr_credit, pr_title=""):
     """Generates personalized issue comment based on PR context."""
-    repo_parts = pr_url.split("/repos/")[1].split("/pulls/")[0] if "/repos/" in pr_url else ""
+    # pr_url is the GraphQL PullRequest.url HTML URL (https://github.com/owner/repo/pull/N) in production;
+    # REST API URLs (https://api.github.com/repos/owner/repo/pulls/N) are also supported
+    if "/repos/" in pr_url and "/pulls/" in pr_url:
+        repo_parts = pr_url.split("/repos/", 1)[1].split("/pulls/", 1)[0]
+    elif "github.com/" in pr_url and "/pull/" in pr_url:
+        repo_parts = pr_url.split("github.com/", 1)[1].split("/pull/", 1)[0]
+    else:
+        repo_parts = ""
     owner_repo = repo_parts.split("/")
     repo_name = owner_repo[-1] if len(owner_repo) > 1 else "package"
 

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -235,7 +235,7 @@ def get_response(
             }
             if system_content:
                 data["system"] = system_content
-            # Skip web_search for Anthropic when using JSON schema (causes empty responses)
+            # Tools (web_search) are not forwarded to Anthropic (caused empty responses with JSON schema)
             # Handle structured JSON output for Anthropic
             if text_format and text_format.get("format", {}).get("type") == "json_schema":
                 schema = text_format["format"].get("schema", {})

--- a/dependabot/README.md
+++ b/dependabot/README.md
@@ -33,7 +33,7 @@ jobs:
 ## How It Works
 
 1. Lists all active repos in the org (filtered by visibility)
-2. Fetches workflow files (`.github/workflows/*.yml` and `action.yml`) from each repo
+2. Fetches GitHub Actions files (`.github/workflows/*.yml`/`*.yaml` and `action.yml`/`action.yaml`) from each repo
 3. Parses `uses:` lines and resolves the latest release for each action
 4. Creates one PR per outdated action per repo, updating all files that reference it
 5. Skips PRs that already exist (matches by title)

--- a/tests/test_summarize_pr.py
+++ b/tests/test_summarize_pr.py
@@ -35,7 +35,7 @@ def test_generate_issue_comment(mock_get_response):
     mock_get_response.return_value = "This issue is fixed in PR #123"
 
     comment = generate_issue_comment(
-        pr_url="https://api.github.com/repos/owner/repo/pulls/123",
+        pr_url="https://github.com/owner/repo/pull/123",
         pr_summary="Fixed bug",
         pr_credit="@testuser",
         pr_title="Bug fix PR",
@@ -43,3 +43,6 @@ def test_generate_issue_comment(mock_get_response):
 
     assert comment == "This issue is fixed in PR #123"
     mock_get_response.assert_called_once()
+    prompt = mock_get_response.call_args[0][0][1]["content"]
+    assert "pip install -U repo>=VERSION" in prompt
+    assert "pip install git+https://github.com/owner/repo.git@main" in prompt

--- a/tests/test_summarize_pr.py
+++ b/tests/test_summarize_pr.py
@@ -34,15 +34,17 @@ def test_generate_issue_comment(mock_get_response):
     """Test generating issue comments about PR fixes."""
     mock_get_response.return_value = "This issue is fixed in PR #123"
 
-    comment = generate_issue_comment(
-        pr_url="https://github.com/owner/repo/pull/123",
-        pr_summary="Fixed bug",
-        pr_credit="@testuser",
-        pr_title="Bug fix PR",
-    )
+    for pr_url in ("https://github.com/owner/repo/pull/123", "https://api.github.com/repos/owner/repo/pulls/123"):
+        comment = generate_issue_comment(
+            pr_url=pr_url,
+            pr_summary="Fixed bug",
+            pr_credit="@testuser",
+            pr_title="Bug fix PR",
+        )
 
-    assert comment == "This issue is fixed in PR #123"
-    mock_get_response.assert_called_once()
-    prompt = mock_get_response.call_args[0][0][1]["content"]
-    assert "pip install -U repo>=VERSION" in prompt
-    assert "pip install git+https://github.com/owner/repo.git@main" in prompt
+        assert comment == "This issue is fixed in PR #123"
+        prompt = mock_get_response.call_args[0][0][1]["content"]
+        assert "pip install -U repo>=VERSION" in prompt
+        assert "pip install git+https://github.com/owner/repo.git@main" in prompt
+
+    assert mock_get_response.call_count == 2


### PR DESCRIPTION
Third-pass correctness audit following #755 and #756: a full line-by-line inspection of all 53 tracked files, focused on what the first two passes and the four commits that landed after them (#754, #758, #759, #760) left behind. Only high-confidence, individually verified corrections are included; lower-confidence observations are listed at the bottom for visibility instead of being patched.

## Changes

**Behavior fixes (2)**

- `action.yml`: quote `--uri-ignore-words-list "*"` in the codespell step. The unquoted `*` was glob-expanded by bash, so codespell received the repo's alphabetically-first directory entry as the option value (that file was then never spell-checked, and the remaining top-level entries became the scan paths) instead of the documented `"*"` special value that suppresses URI/email misspellings. Verified empirically: a misspelling inside a URL is flagged with the old invocation and correctly ignored with the new one; running the full fixed invocation against this repo produces zero new findings. Consumer repos regain the intended "ignore all URI misspellings" semantics, and the previously swallowed first directory entry is spell-checked again.
- `actions/summarize_pr.py`: `generate_issue_comment()` parsed `pr_url` expecting the REST format (`.../repos/owner/repo/pulls/N`), but its only production caller passes `data["url"]` from the `GRAPHQL_PR_CONTRIBUTORS` query, where `PullRequest.url` is the HTML URL (`https://github.com/owner/repo/pull/N`). The parse therefore always fell back to `repo_name="package"`, telling issue reporters to run `pip install -U package>=VERSION` and the broken `pip install git+https://github.com/.git@main`. The parse now handles the HTML URL via `urlparse` with an exact `github.com` hostname check (resolving the CodeQL incomplete-URL-sanitization alert raised on the first iteration), the REST format remains supported, and the test now exercises both URL formats with assertions pinning the generated install commands.

**Interface cleanup (1)**

- `action.yml`: remove the `first_pr_response` input and its `FIRST_PR_RESPONSE` env mapping. No Python code has read this env var since PR-open handling moved to the unified `get_pr_open_response()` call (`first_interaction.py` reads only `FIRST_ISSUE_RESPONSE`), so the input promised behavior that was never implemented. GitHub-wide code search found no repository passing this input apart from vendored copies of `action.yml` itself, and neither README documents it.

**Release (1)**

- `actions/__init__.py`: bump version to 0.2.16 so the merged package fixes publish to PyPI (`should_publish("0.2.16", "0.2.15")` verified `True`).

**Docs corrections (5)**

- `README.md`: the main-action subtitle now lists Dart, matching the feature list directly below it, the `dart` input in `action.yml`, and the Chinese README.
- `README.zh-CN.md`: add the `python-version: "3.13"` example line that #754 added to the English setup example just before the Chinese README was created in #758 (the only divergence between the two setup blocks).
- `dependabot/README.md`: the action also fetches `.yaml` workflow files and `action.yaml` (`actions/dependabot.py` handles both extensions), matching the sibling scan-prs README's wording.
- `.github/ISSUE_TEMPLATE/{bug-report,feature-request,question}.yml`: add the missing "Dependabot Action" area option — the README documents four standalone actions but the dropdowns listed only three.
- `actions/utils/openai_utils.py`: fix a comment claiming tools (web_search) are skipped for Anthropic only "when using JSON schema"; they are never forwarded to the Anthropic branch at all.

## Validation

- `python -m pytest tests -v` — 65 passed (network-dependent `test_urls.py` deselected locally; runs in CI)
- `ruff check` with the repo's exact CI flags — clean; `ruff format --check --line-length 120` — clean
- `git diff --check` — clean
- `yaml.safe_load` parses all four edited YAML files
- Full codespell invocation (old vs new) exercised against this repo: no new findings, exit 0
- EN/ZH README setup blocks re-diffed after the edit: byte-identical
- `generate_issue_comment` URL parse exercised against GraphQL HTML, REST, and degenerate URL inputs: HTML URLs now resolve `owner/repo`; REST behavior unchanged; everything else falls back to `"package"` exactly as before

## Verification sources

- GitHub GraphQL `PullRequest.url` semantics confirmed against the live query in `github_utils.py` and GitHub's API docs
- codespell 2.4.1 `--help` documents `"*"` as the ignore-all special value; glob expansion reproduced in bash
- GitHub code search for `first_pr_response` usage across all public repositories and the ultralytics org
- `actions/dependabot.py:137-146` for the `.yaml`/`action.yaml` claim

## Review

Candidate fixes were consolidated from a line-by-line audit of all 53 tracked files and independently challenged in three review passes before any edit was made; the `first_pr_response` removal was a unanimous call, and the URL-parse fix was revised per review feedback to keep REST-format support. The final diff then cleared a second set of three independent review passes with no blocking findings. Two observations were deliberately left unchanged: the subtitle intentionally stays an abbreviated format list (expanding it past Dart would diverge from the Chinese README again), and the new URL parse does not host-validate inputs because `pr_url` comes exclusively from GitHub's own GraphQL API.

## CI

All checks green on the final commit: 4-leg test matrix (3.8/3.14 × ubuntu/macos, full suite including network URL tests), codecov/patch, CodeQL (zero open alerts after the exact-host hardening; alert #11 closed as fixed), CLA, and the self-dogfooding format run, which installed and executed this PR's own code — the quoted codespell invocation ran cleanly and formatters reported "No changes to commit". Job logs were inspected directly: the only non-success signal is the intentional `tomllib` skipif of `test_check_pypi_version` on Python 3.8; remaining grep hits are runner-internal noise (toolcache tar flags, a git default-branch hint, and the retry action echoing its own `::error::` script source).

## Deliberately not patched (for maintainer visibility)

- `summarize_pr.py:152` passes a REST API URL into the merge thank-you prompt (cosmetic prompt-quality nit; the URL is only embedded in prose, never parsed)
- `summarize_release.py:45` "# earliest to latest" — `sorted()` on string PR numbers is lexicographic, but the list is re-sorted by `merged_at` afterwards, so order is correct
- `common_utils.py` URL regex drops an uppercase `HTTPS://` scheme during capture (pre-existing edge case with negligible impact)
- `update_markdown_code_blocks.py`: `format_bash_with_prettier` docstring says "in the specified directory" but prettier globs the cwd (works because the temp dir lives under cwd); `process_markdown_string()` has no callers (possible dead public API — removal is an API decision)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves documentation, expands issue template coverage for the Dependabot Action, fixes PR summary comment handling for GitHub and API URLs, and makes a few small cleanup updates across the repo.

### 📊 Key Changes
- ➕ Added **"Dependabot Action"** as an option in all GitHub issue templates:
  - bug reports
  - feature requests
  - questions
- 📝 Updated the main `README.md` to:
  - include **Dart** in the supported file types for AI-powered formatting and summaries
  - change the example `python-version` from **3.13** to **3.14**
  - clarify Python package installation requirements as **Python >= 3.8**
  - streamline badge formatting
- 🌏 Applied similar documentation improvements to **`README.zh-CN.md`**, including the `python-version: "3.14"` example and clearer package install guidance
- 🔧 Fixed `generate_issue_comment()` in `actions/summarize_pr.py` so it correctly handles both:
  - standard GitHub PR links like `github.com/owner/repo/pull/123`
  - GitHub API PR links like `api.github.com/repos/owner/repo/pulls/123`
- ✅ Expanded tests to verify both PR URL formats work as expected and that generated prompts include correct install instructions
- 🧹 Removed the unused `first_pr_response` input from `action.yml`
- ✏️ Fixed a shell quoting issue in the `codespell` command by properly quoting `"*"`
- 📦 Bumped the package version from **`0.2.15`** to **`0.2.16`**
- 📚 Updated the Dependabot docs to clarify support for both `.yml`/`.yaml` workflow files and `action.yml`/`action.yaml`

### 🎯 Purpose & Impact
- 🚀 Makes the repo easier to use and support by exposing the **Dependabot Action** more clearly in issue intake forms
- 📖 Improves documentation accuracy, helping users configure the action with more up-to-date examples and clearer Python package requirements
- 🔗 Prevents PR summary and issue-comment workflows from breaking when different PR URL formats are passed in, improving reliability
- 🧪 Strengthens confidence in the PR summarization feature through better test coverage
- 🧼 Reduces minor maintenance overhead by removing an unused input and tightening command syntax
- 📦 Overall, this is a **quality-of-life and reliability update** rather than a major feature release, but it should make the actions smoother to use for both maintainers and end users ✨