### PR TITLE
Default action Python version to 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
-          python-version: "3.14" # Optional: set up a specific Python version
           python: true # Format Python with Ruff
+          # python-version: "3.13" # Optional: override default Python version
           python_docstrings: true # Format Python docstrings (default: true)
           biome: true # Format JS/TS with Biome (auto-detected via biome.json)
           prettier: true # Format YAML, JSON, Markdown, CSS

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
           python: true # Format Python with Ruff
-          # python-version: "3.13" # Optional: override default Python version
+          # python-version: "3.15" # Optional: override default Python version
           python_docstrings: true # Format Python docstrings (default: true)
           biome: true # Format JS/TS with Biome (auto-detected via biome.json)
           prettier: true # Format YAML, JSON, Markdown, CSS

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   python-version:
     description: "Python version to set up before running Python tooling"
     required: false
-    default: ""
+    default: "3.14"
   python_docstrings:
     description: "Run Python docstring formatting"
     required: false
@@ -102,7 +102,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      if: inputs.python-version != ''
+      if: inputs.python == 'true' && inputs.python-version != ''
       uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
## Summary
- default the shared action python-version input to Python 3.14
- only run setup-python when Python formatting is enabled
- update the README example so callers only pass python-version when overriding the default

## Tests
- ruby -e 'require "yaml"; YAML.load_file("action.yml"); puts "action.yml OK"'\n- actionlint .github/workflows/*.yml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR makes Python setup automatic for Python formatting workflows by giving the action a default Python version and only enabling it when Python tooling is requested.

### 📊 Key Changes
- Changed the `python-version` input default in `action.yml` from empty to `3.14`.
- Updated the Python setup step so it only runs when `python: true` **and** a Python version is available.
- Refreshed the `README.md` example to reflect the new behavior:
  - `python: true` is now the main switch for Python formatting.
  - `python-version` is shown as an optional override instead of a required example setting.
  - Example override was updated to `3.15`.

### 🎯 Purpose & Impact
- 🚀 Simplifies configuration for users by removing the need to manually specify a Python version in common cases.
- 🧹 Makes the action behavior clearer: Python is only set up when Python formatting is actually enabled.
- ✅ Reduces setup mistakes and improves out-of-the-box usability for repositories using Ruff and Python docstring formatting.
- 📘 Keeps the documentation aligned with the action’s real behavior, making adoption easier for new users.