### PR TITLE
Restore empty python-version default to fix custom-runner failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
           python: true # Format Python with Ruff
-          # python-version: "3.15" # Optional: override default Python version
+          # python-version: "3.14" # Optional: set up a specific Python version (default: runner Python)
           python_docstrings: true # Format Python docstrings (default: true)
           biome: true # Format JS/TS with Biome (auto-detected via biome.json)
           prettier: true # Format YAML, JSON, Markdown, CSS

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,9 @@ inputs:
     required: false
     default: "false"
   python-version:
-    description: "Python version to set up before running Python tooling"
+    description: "Python version to set up before running Python tooling (empty = runner default)"
     required: false
-    default: "3.14"
+    default: ""
   python_docstrings:
     description: "Run Python docstring formatting"
     required: false


### PR DESCRIPTION
## Summary

Partial revert of #762: restore `python-version` default to `""` so `actions/setup-python` is skipped unless a repo opts in. The `inputs.python == 'true'` setup guard from #762 is kept.

## Why

#762 (merged today 11:45 UTC) made every consumer run `actions/setup-python@v6` with `3.14`. That hard-fails on runners whose image has no matching `python-versions` manifest entry:

- `ultralytics/portal` `format.yml` runs on the custom `cpu-latest` pool → every run since the merge fails in seconds with `The version '3.14' with architecture 'x64' was not found for this operating system` (deterministic — re-run reproduced; multiple branches affected). This also blocks the AI review/labeling for all portal PRs since the job dies at setup.
- `ultralytics/ultralytics` (`ubuntu-latest`) is unaffected — 5 green runs after the merge — confirming the failure is runner-image-specific, not a 3.14 problem in general.

The action runs across heterogeneous runners org-wide, so the default must not depend on a specific interpreter being available in the setup-python manifest. Pre-#762 behavior (runner's Python) had been working everywhere; repos that want a pinned interpreter can still pass `python-version: "3.14"` explicitly.

## Re-land path

If a pinned default is still wanted, either default to `"3.x"` (resolves per-runner) or first ensure custom runner images carry the pinned version in their tool cache.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the `python-version` input in the `ultralytics/actions` GitHub Action so it now defaults to the runner’s existing Python version instead of forcing Python 3.14.

### 📊 Key Changes
- Changed the `python-version` input description in `action.yml` to clarify that an empty value means “use the runner default” 📝
- Updated the default value of `python-version` from `"3.14"` to `""` in `action.yml` ⚙️
- Revised the README example comment to reflect the new behavior:
  - optional explicit version example is now `"3.14"`
  - default behavior is clearly documented as using the runner’s Python 🐍
- Improved wording in the README to make configuration behavior easier to understand for users 📚

### 🎯 Purpose & Impact
- Reduces unnecessary Python setup by using the GitHub runner’s existing Python unless a specific version is requested 🚀
- Makes the action more flexible for different workflows and environments 🔄
- Helps avoid confusion caused by implying that Python 3.14 is always the default 🤝
- Keeps configuration simpler for most users, while still allowing explicit version pinning when needed ✅