### PR TITLE
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           ultralytics-actions-info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage.xml
           disable_search: true


### PR DESCRIPTION
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions workflow to use `codecov/codecov-action@v7` instead of `@v6` for uploading test coverage reports.

### 📊 Key Changes
- ⬆️ Upgraded the Codecov GitHub Action in `.github/workflows/ci.yml`
- 🔁 Replaced `codecov/codecov-action@v6` with `codecov/codecov-action@v7`
- 📦 Kept the existing coverage upload configuration unchanged, including `files: ./coverage.xml` and `disable_search: true`

### 🎯 Purpose & Impact
- ✅ Keeps the repository’s CI workflow up to date with the latest Codecov action version
- 🔒 May improve security, reliability, and compatibility by using a newer maintained release
- 🛠️ Minimizes change risk since only the action version was updated, with no workflow logic changes
- 👥 Helps maintainers ensure coverage reporting continues to work smoothly in GitHub Actions