### PR TITLE
Fix Codecov OIDC upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read # Read code in PRs
+  id-token: write # Required for Codecov OIDC uploads
 
 jobs:
   Test:
@@ -56,4 +57,5 @@ jobs:
           files: ./coverage.xml
           disable_search: true
           plugins: noop
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Welcome to [Ultralytics Actions](https://github.com/ultralytics/actions) - a col
 [![Actions CI](https://github.com/ultralytics/actions/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/actions/actions/workflows/ci.yml)
 [![Ultralytics Actions](https://github.com/ultralytics/actions/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/actions/actions/workflows/format.yml)
 [![Scan PRs](https://github.com/ultralytics/actions/actions/workflows/scan-prs.yml/badge.svg)](https://github.com/ultralytics/actions/actions/workflows/scan-prs.yml)
-[![codecov](https://codecov.io/github/ultralytics/actions/graph/badge.svg?token=DoizJ1WS6j)](https://codecov.io/github/ultralytics/actions)
+[![codecov](https://codecov.io/github/ultralytics/actions/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/actions)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)


### PR DESCRIPTION
## Summary
- switch Codecov upload from secret token auth to OIDC
- keep explicit coverage file upload with search/plugins disabled
- update README Codecov badge to the non-token main branch badge

## Validation
- ruby YAML parse for .github/workflows/*.yml
- actionlint .github/workflows/*.yml
- git diff --check
- .venv/bin/python -m pytest tests -v --cov=actions --cov-report=xml:coverage.xml (79 passed)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR updates CI coverage reporting to use Codecov OIDC authentication and refreshes the README badge link for cleaner, more reliable coverage tracking.

### 📊 Key Changes
- Added `id-token: write` permission in `.github/workflows/ci.yml` to support Codecov uploads via OIDC authentication.
- Replaced the Codecov upload token setup with `use_oidc: true`, removing the need for a `CODECOV_TOKEN` secret in CI.
- Enabled `fail_ci_if_error: true` so CI now fails if the Codecov upload step has an error.
- Updated the README Codecov badge:
  - Switched to the branch-specific badge URL for `main`
  - Removed the token from the badge URL
  - Updated the link target to the newer Codecov app URL

### 🎯 Purpose & Impact
- 🔒 **Improves security** by avoiding secret-based Codecov authentication in CI and using GitHub OIDC instead.
- 🛠️ **Makes failures more visible** since coverage upload issues will now fail CI instead of being silently ignored.
- 🧹 **Cleans up repository configuration** by removing dependency on a stored Codecov token for this workflow.
- 📈 **Improves README accuracy and presentation** with a cleaner coverage badge and updated Codecov link.
- 👥 **Benefits maintainers and contributors** by making CI behavior more trustworthy and easier to debug.