### PR TITLE
Run cleanup-disk removals in parallel

### DIFF
--- a/cleanup-disk/action.yml
+++ b/cleanup-disk/action.yml
@@ -14,12 +14,19 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Remove Tool Cache and Swap"
-        # Remove tool cache to free up ~15GB of space per https://github.com/ultralytics/ultralytics/pull/15848
-        rm -rf /opt/hostedtoolcache || true
+        toolcache_pid=""
+        if [ -e /opt/hostedtoolcache ]; then
+          # Remove tool cache to free up ~15GB of space per https://github.com/ultralytics/ultralytics/pull/15848
+          rm -rf /opt/hostedtoolcache &
+          toolcache_pid=$!
+        fi
         # Remove swap space to free up ~4GB
         if [ -f /swapfile ]; then
           sudo swapoff -a
           sudo rm -f /swapfile
+        fi
+        if [ -n "$toolcache_pid" ]; then
+          wait "$toolcache_pid" || true
         fi
         echo "::endgroup::"
 


### PR DESCRIPTION
## Summary
- keep cleanup-disk's public interface and cleanup targets unchanged
- start  removal in the background so swap cleanup can run while that delete is in progress
- avoid new toolchain removals or new action inputs

## Validation
- git diff --check
- ruby -ryaml -e 'YAML.load_file("cleanup-disk/action.yml")'
- ruby -ryaml -e 'puts YAML.load_file("cleanup-disk/action.yml")["runs"]["steps"][0]["run"]' | bash -n
- ruby -ryaml -e 'puts YAML.load_file("cleanup-disk/action.yml")["runs"]["steps"][0]["run"]' | shellcheck -s bash -

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⚡ This PR improves the `cleanup-disk` GitHub Action by making tool cache removal run in the background, helping disk cleanup start faster while still safely completing before the action finishes.

### 📊 Key Changes
- 🚀 Updated `/opt/hostedtoolcache` deletion to run asynchronously in the background instead of blocking the script.
- 🛡️ Added a check to confirm `/opt/hostedtoolcache` exists before attempting removal.
- 🧵 Stored the background process ID in `toolcache_pid` so the workflow can track it.
- ⏳ Added a `wait` step to ensure the background tool cache removal finishes before moving on.
- 💾 Kept existing swap cleanup logic unchanged, including disabling swap and deleting `/swapfile` when present.

### 🎯 Purpose & Impact
- ⚡ Speeds up the cleanup step by overlapping tool cache deletion with other disk cleanup work.
- 🔒 Makes the action a bit more robust by only deleting the tool cache when it actually exists.
- 📦 Preserves the main benefit of the action: freeing a large amount of disk space on GitHub-hosted runners.
- 🤝 Reduces the chance of unnecessary delays while still ensuring cleanup completes reliably for downstream workflow steps.