### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ AI-powered formatting, labeling, and PR summaries for Python, Swift, Dart, and M
 
 ### 🤖 Supported AI Providers
 
-Choose between [OpenAI](https://openai.com/) or [Anthropic](https://www.anthropic.com/) for AI-powered features:
+Choose between [OpenAI](https://developers.openai.com/) or [Anthropic](https://www.anthropic.com/) for AI-powered features:
 
 | Provider  | Default Model       | API Key             |
 | --------- | ------------------- | ------------------- |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 [![Actions CI](https://github.com/ultralytics/actions/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/actions/actions/workflows/ci.yml)
 [![Ultralytics Actions](https://github.com/ultralytics/actions/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/actions/actions/workflows/format.yml)
 [![Scan PRs](https://github.com/ultralytics/actions/actions/workflows/scan-prs.yml/badge.svg)](https://github.com/ultralytics/actions/actions/workflows/scan-prs.yml)
-[![codecov](https://codecov.io/github/ultralytics/actions/graph/badge.svg?token=DoizJ1WS6j)](https://codecov.io/github/ultralytics/actions)
+[![codecov](https://codecov.io/github/ultralytics/actions/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/actions)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
@@ -45,7 +45,7 @@
 
 ### 🤖 支持的 AI 提供商
 
-可选择 [OpenAI](https://openai.com/) 或 [Anthropic](https://www.anthropic.com/) 启用 AI 功能：
+可选择 [OpenAI](https://developers.openai.com/) 或 [Anthropic](https://www.anthropic.com/) 启用 AI 功能：
 
 | 提供商    | 默认模型            | API Key             |
 | --------- | ------------------- | ------------------- |
@@ -98,8 +98,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
-          python-version: "3.14" # Optional: set up a specific Python version
           python: true # Format Python with Ruff
+          # python-version: "3.14" # Optional: set up a specific Python version (default: runner Python)
           python_docstrings: true # Format Python docstrings (default: true)
           biome: true # Format JS/TS with Biome (auto-detected via biome.json)
           prettier: true # Format YAML, JSON, Markdown, CSS


### PR DESCRIPTION
## Summary
- replaces the bot-blocked OpenAI homepage link with the official OpenAI developer docs link
- aligns the Chinese README Codecov badge and setup snippet with the English README

## Validation
- git diff --check
- lychee README.md README.zh-CN.md

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes small but useful documentation updates by fixing external links and clarifying the optional Python version setting in the Chinese README.

### 📊 Key Changes
- 🔗 Updated the OpenAI documentation link in both `README.md` and `README.zh-CN.md` from the main OpenAI site to the more relevant [OpenAI developer portal](https://developers.openai.com/).
- 📈 Fixed the Codecov badge and link in `README.zh-CN.md` to use the main branch badge and point to the newer [Codecov app page](https://app.codecov.io/github/ultralytics/actions).
- 💬 Improved the example workflow comments in `README.zh-CN.md` by clarifying that `python-version` is optional and that the default is the runner’s Python version.
- 🧹 Slightly reordered the Python-related example settings in the Chinese README to make the configuration easier to follow.

### 🎯 Purpose & Impact
- ✅ Helps users reach the correct developer-focused OpenAI docs faster when setting up AI features.
- ✅ Improves documentation accuracy and reduces confusion, especially for Chinese-speaking users.
- ✅ Makes repository badges more reliable and up to date, improving project visibility and trust.
- ✅ Clarifies workflow setup behavior so users are less likely to misunderstand how Python is selected in GitHub Actions.