### PR TITLE
Allow auto-format commits on bot-opened PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -345,16 +345,13 @@ runs:
 
     # Commit Changes ---------------------------------------------------------------------------------------------------
     - name: Commit and Push Changes
-      # Skip when the triggering push came from the bot itself (a prior Auto-format push, or a sibling
-      # auto-commit workflow sharing the same token such as Auto-update Docs). github.actor is set by GitHub
-      # from the pushing token and cannot be spoofed via git config, so this breaks recursive auto-commit loops
-      # even when sibling bot commits or merge commits interleave between Auto-format pushes. Human pushes have a
-      # different actor and are always formatted. Default-GITHUB_TOKEN pushes never re-trigger workflows, so only
-      # PAT-authored bot pushes (actor == github_username) can recurse here.
+      # Generated PRs may be opened by github_username (for example analytics data updates) and still need one
+      # Auto-format commit on the opened event. The recursion risk starts after that commit pushes a synchronize
+      # event as github_username, so keep the bot guard only for synchronize events.
       if: |
         (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
         (github.event.action == 'opened' || github.event.action == 'synchronize') &&
-        github.actor != inputs.github_username
+        (github.event.action == 'opened' || github.actor != inputs.github_username)
       env:
         GITHUB_USERNAME: ${{ inputs.github_username }}
         GITHUB_EMAIL: ${{ inputs.github_email }}


### PR DESCRIPTION
## Summary
- allow the commit/push step to run on initial PR opened events, including PRs opened by UltralyticsAssistant
- keep the bot guard for synchronize events so auto-format pushes do not recurse

## Why
The current actor-only guard skips every PR opened by UltralyticsAssistant. In ultralytics/stars analytics PRs, Prettier runs but cannot push its JSON formatting commit before the workflow auto-merges the PR, leaving data/*.json compact and hard to review.

## Tests
- npx --yes prettier@3.6.2 --check --print-width 120 action.yml
- actionlint .github/workflows/*.yml
- python YAML parse smoke test for action.yml and .github/workflows/*.yml
- local truth table for opened/synchronize actor behavior

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔁 This PR refines the auto-format action so bot-created pull requests can receive an initial formatting commit, while still preventing recursive bot-triggered commit loops.

### 📊 Key Changes
- Updated the **"Commit and Push Changes"** condition in `action.yml`.
- Changed the bot-skip logic to apply **only on `synchronize` events**, instead of blocking all PR events from the configured bot user.
- Kept auto-formatting enabled for PRs opened by the bot on the **`opened`** event.
- Revised the inline comments to clarify the new behavior and the reasoning behind it, especially for generated PRs such as analytics data updates.

### 🎯 Purpose & Impact
- ✅ Allows **bot-generated PRs** to still get their first auto-format commit when the PR is opened.
- 🛡️ Prevents **infinite auto-commit recursion** after that first bot commit triggers later `synchronize` events.
- 🤖 Improves support for automated workflows that open PRs, making formatting behavior more reliable.
- 👥 Reduces confusion for maintainers by better matching expected behavior for both human-created and bot-created PRs.