### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ["3.8", "3.14"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       current_tag: ${{ steps.check_pypi.outputs.current_tag }}
       previous_tag: ${{ steps.check_pypi.outputs.previous_tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -99,7 +99,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -125,7 +125,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Extract PR Details
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -14,7 +14,7 @@ jobs:
   test-bash:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cleanup any leftover test files
         run: rm -f /tmp/retry_attempt /tmp/retry_attempt_py
@@ -181,7 +181,7 @@ jobs:
   test-python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cleanup any leftover test files
         run: rm -f /tmp/retry_attempt /tmp/retry_attempt_py

--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
     # Checkout Repository ----------------------------------------------------------------------------------------------
     - name: Checkout Repository
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'review_requested'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         token: ${{ inputs.token }}


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates all GitHub workflow and action references from `actions/checkout@v6` to `actions/checkout@v7` across the repository.

### 📊 Key Changes
- Upgraded `actions/checkout` from `@v6` to `@v7` in the main CI workflow: `.github/workflows/ci.yml` ⚙️
- Updated the same checkout action in all publish pipeline jobs within `.github/workflows/publish.yml` 📦
- Switched test workflow references in `.github/workflows/test-retry.yml` to `@v7` 🧪
- Updated the reusable action definition in `action.yml` so pull request checkout steps also use `@v7` 🔧
- No logic, feature, or behavior changes were introduced beyond the dependency version bump ✅

### 🎯 Purpose & Impact
- Keeps the repository aligned with the latest GitHub Action version for repository checkout 🔒
- Helps maintain compatibility, security, and long-term support for CI/CD workflows 🚀
- Reduces the risk of using outdated workflow dependencies across testing and publishing pipelines 🛠️
- Likely low-risk for users and contributors, since this is a maintenance update rather than a functional change 👍