### PR TITLE
fix: switch PR review model from gpt-5.4 to Claude Opus 4.8

### DIFF
--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -20,7 +20,7 @@ MAX_PROMPT_CHARS = round(128000 * 3.3 * 0.5)  # Max characters for prompt (50% o
 # Default models (single source of truth)
 OPENAI_MODEL_DEFAULT = "gpt-5.4"
 ANTHROPIC_MODEL_DEFAULT = "claude-sonnet-4-6"
-PR_REVIEW_MODEL_DEFAULT = "gpt-5.4"
+PR_REVIEW_MODEL_DEFAULT = "claude-opus-4-8"
 
 MODEL_COSTS = {  # (input, output) per 1M tokens
     # OpenAI models
@@ -41,6 +41,7 @@ MODEL_COSTS = {  # (input, output) per 1M tokens
     "claude-opus-4-5-20251101": (5.00, 25.00),
     "claude-opus-4-6": (5.00, 25.00),
     "claude-opus-4-7": (5.00, 25.00),
+    "claude-opus-4-8": (5.00, 25.00),
 }
 SYSTEM_PROMPT_ADDITION = """Guidance:
   - Ultralytics Branding: Use YOLO11, YOLO26, etc., not YOLOv11, YOLOv26 (only older versions like YOLOv10 have a v).
@@ -227,12 +228,21 @@ def get_response(
 
     for attempt in range(retries + 1):
         if is_anthropic:
+            # Opus 4.7+ and Fable/Mythos reject sampling params (temperature) and use adaptive thinking instead.
+            adaptive = any(
+                model.startswith(p) for p in ("claude-opus-4-7", "claude-opus-4-8", "claude-fable", "claude-mythos")
+            )
             data = {
                 "model": model,
-                "max_tokens": 8192,
-                "temperature": temperature,
+                "max_tokens": 16000 if adaptive else 8192,
                 "messages": user_messages,
             }
+            if adaptive:
+                data["thinking"] = {"type": "adaptive"}
+                effort = reasoning_effort if reasoning_effort in {"low", "medium", "high", "xhigh", "max"} else "high"
+                data["output_config"] = {"effort": effort}
+            else:
+                data["temperature"] = temperature
             if system_content:
                 data["system"] = system_content
             # Tools (web_search) are not forwarded to Anthropic (caused empty responses with JSON schema)


### PR DESCRIPTION
## What

Switches the **PR-review** model default off OpenAI (`gpt-5.4`) onto **Claude Opus 4.8** (`claude-opus-4-8`).

## Why

OpenAI tokens are exhausted — PR reviews have been failing with OpenAI-side timeouts (`OpenAI background response … ended with {'code': 'server_error', 'message': 'The request timed out.'}`). The repo already has full Anthropic support; only the review default still pointed at OpenAI.

## Changes

- `PR_REVIEW_MODEL_DEFAULT`: `gpt-5.4` → `claude-opus-4-8`
- `get_response()` Anthropic branch: Opus 4.7+ / Fable / Mythos **reject sampling params** (sending `temperature` 400s) and **leak chain-of-thought into the visible response when thinking is off** — so for those models drop `temperature` and enable **adaptive thinking** + `output_config.effort` (mapped from the existing `reasoning_effort`, defaulting to `high`). Older Claude models (Sonnet 4.6, Opus 4.6, Haiku) keep `temperature` unchanged. The response parser already concatenates only `text` blocks, so thinking blocks are transparently skipped — the structured-JSON review path is unaffected.
- Add `claude-opus-4-8` to `MODEL_COSTS` for accurate cost logging.

## Notes

- Requires `ANTHROPIC_API_KEY` in CI (already used for other Claude calls in this repo).
- OpenAI is still selectable via an explicit `MODEL` / `REVIEW_MODEL` env override — only the default changed.
- `py_compile` + `ruff check` + `ruff format --check` all pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Switch the default PR review model from `gpt-5.4` to `claude-opus-4-8` and update Anthropic request handling to support newer adaptive-thinking models more reliably. 🤖

### 📊 Key Changes
- Changed `PR_REVIEW_MODEL_DEFAULT` from `gpt-5.4` to `claude-opus-4-8` in `actions/utils/openai_utils.py`.
- Added `claude-opus-4-8` to `MODEL_COSTS` with the existing Opus pricing entry.
- Updated Anthropic request construction to detect adaptive-thinking models such as `claude-opus-4-7`, `claude-opus-4-8`, `claude-fable`, and `claude-mythos`.
- Increased `max_tokens` for adaptive Anthropic models from `8192` to `16000`.
- Stopped sending `temperature` to adaptive models that reject sampling parameters.
- Added adaptive request settings with `thinking` and `output_config.effort`, using validated `reasoning_effort` values and a safe fallback. ⚙️

### 🎯 Purpose & Impact
- Improves PR review quality by making `claude-opus-4-8` the default review model. ✨
- Prevents request failures for newer Anthropic models that do not accept `temperature`.
- Better aligns the integration with current Anthropic model behavior and capabilities.
- Enables more robust long-form review responses with higher token limits and adaptive reasoning controls.
- Reduces maintenance risk by keeping model defaults and cost tracking in sync. 🛠️