### PR TITLE
Simplify Slack notification messages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,16 +125,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - name: Extract PR Details
+      - name: Get release title
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.check.outputs.current_tag }}
         run: |
-          PR_JSON=$(gh pr list --search "${GITHUB_SHA}" --state merged --json number,title --jq '.[0]')
-          PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')
-          PR_TITLE=$(echo "${PR_JSON}" | jq -r '.title' | sed 's/"/\\"/g')
-          echo "PR_NUMBER=${PR_NUMBER}" >> "${GITHUB_ENV}"
-          echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
+          TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'
         uses: slackapi/slack-github-action@v3.0.3
@@ -142,7 +141,7 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_LLM }}
           payload: |
-            text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `${{ github.repository }} ${{ needs.check.outputs.current_tag }}` pip package published 😃\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "*${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
         if: needs.publish.result != 'success'
         uses: slackapi/slack-github-action@v3.0.3
@@ -150,4 +149,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_LLM }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "*${{ github.workflow }}* ❌ `${{ github.repository }}` ${{ needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"


### PR DESCRIPTION
Replaces the verbose multi-line Slack notifications with a single dense line — bold workflow name, status emoji, `${{ github.repository }}`, and a *Run* backlink — matching the format used in `ultralytics/portal`.

- `#llm-projects` posts stay mention-less (no `<!channel>` ping).
- Publish notifications surface the GitHub release title + *Release* link; the now-dead `Extract PR Details` step is replaced by a lean `gh release view` step.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Simplified the release notification workflow by replacing PR-based metadata lookup with direct release-title retrieval, making Slack publish alerts cleaner and more reliable 🚀

### 📊 Key Changes
- Removed the `actions/checkout@v7` step from the notification job, reducing unnecessary workflow work ⚡
- Replaced the old “Extract PR Details” logic with a new `Get release title` step that:
  - uses `gh release view` to read the release name from the current tag
  - stores the result as a step output instead of environment variables
- Deleted the PR lookup flow that previously searched merged PRs by commit SHA and parsed PR number/title with `jq` 🧹
- Updated the success Slack message to:
  - show the workflow name, repository, and release title when available
  - fall back to the tag if no release title exists
  - link directly to the GitHub release and workflow run 🔗
- Simplified the failure Slack message to include only the workflow name, repository, tag, and run link instead of PR details ❌

### 🎯 Purpose & Impact
- Makes notifications more accurate for release publishing, since they now reference the actual GitHub release instead of trying to infer a related PR 🎯
- Improves reliability by avoiding PR search/parsing logic that can fail or return incomplete results 🛠️
- Speeds up the workflow slightly and reduces maintenance by removing an unnecessary checkout step and extra JSON parsing ⏱️
- Produces shorter, clearer Slack alerts that are easier for teams to scan quickly 👀
- Better matches release-driven workflows, especially when a published package does not map cleanly to a single pull request 📦