### PR TITLE
Fix simple docstring formatter idempotence

### DIFF
--- a/actions/format_python_docstrings.py
+++ b/actions/format_python_docstrings.py
@@ -377,12 +377,7 @@ def format_docstring(
     text = content.strip()
     has_section = any(f"{s}:" in text for s in SECTIONS)
     has_list = any(is_list_item(line) for line in text.splitlines())
-    single_ok = (
-        ("\n" not in text)
-        and not has_section
-        and not has_list
-        and (indent + len(prefix) + len(quotes) * 2 + len(text) <= width)
-    )
+    single_ok = ("\n" not in text) and not has_section and not has_list
     if single_ok:
         words = text.split()
         if words and not words[0].startswith(("http://", "https://")) and not words[0][0].isupper():

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -3,6 +3,7 @@
 # Import CLI command modules
 from actions import (
     first_interaction,
+    format_python_docstrings,
     summarize_pr,
     summarize_release,
     update_markdown_code_blocks,
@@ -16,3 +17,10 @@ def test_importable_modules():
     assert hasattr(summarize_pr, "main")
     assert hasattr(summarize_release, "main")
     assert hasattr(update_markdown_code_blocks, "main")
+
+
+def test_docstring_formatter_keeps_simple_docstrings_single_line():
+    """Test simple docstrings stay single-line to match Ruff D200 fixes."""
+    text = "Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."
+
+    assert format_python_docstrings.format_docstring(text, 8, 120, '"""', "") == f'"""{text}"""'


### PR DESCRIPTION
## Summary
- keep sectionless one-line docstrings on one line in the custom formatter
- add a regression test for the Ruff D200 boundary that caused format/docs automation churn

## Validation
- ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py39 --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 actions/format_python_docstrings.py tests/test_cli_commands.py
- ruff format --line-length 120 actions/format_python_docstrings.py tests/test_cli_commands.py
- python -m pytest tests/test_cli_commands.py
- reproduced against ultralytics PR 22870 tests/test_engine.py: formatter left the file unchanged and ruff check --select D200 passed

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the Python docstring formatter to preserve simple docstrings as single-line strings more reliably, and adds a test to ensure that behavior stays consistent.

### 📊 Key Changes
- Simplified the `single_ok` logic in `actions/format_python_docstrings.py`.
- Removed the line-length check from the decision about whether a docstring can remain single-line.
- Kept the existing safeguards that prevent single-line formatting for docstrings containing:
  - multiple lines
  - named sections like `Args:` or similar
  - list-style content
- Added a new test in `tests/test_cli_commands.py` to verify that a simple docstring remains on one line.
- Imported `format_python_docstrings` in the CLI command tests so its formatter behavior is explicitly covered. ✅

### 🎯 Purpose & Impact
- Helps the formatter better align with Ruff’s `D200` style expectations for one-line docstrings. 📏
- Reduces unnecessary reformatting of simple docstrings, making automated formatting more predictable. 🔄
- Improves developer experience by avoiding formatting changes that may conflict with linting or code style tools. 👨‍💻
- Adds test coverage to prevent regressions, making future updates safer and more reliable. 🧪