### PR TITLE
Add GitHub daily report action

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,21 @@ List open PRs across an organization and auto-merge eligible GitHub Actions upda
 
 [**📖 Full Documentation →**](scan-prs/README.md)
 
-### 4. Dependabot Action
+### 4. GitHub Report Action
+
+Summarize open PRs and failed scheduled GitHub Actions across organization repositories.
+
+```yaml
+- uses: ultralytics/actions/github-report@main
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    org: ultralytics # Optional: defaults to ultralytics
+    visibility: all # Optional: public, private, internal, all, or comma-separated
+```
+
+[**📖 Full Documentation →**](github-report/README.md)
+
+### 5. Dependabot Action
 
 Update GitHub Actions versions across organization repositories with cached release resolution.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,7 +158,21 @@ jobs:
 
 [**📖 完整文档 →**](scan-prs/README.md)
 
-### 4. Dependabot Action
+### 4. GitHub Report Action
+
+汇总组织仓库中的开放 PR 和失败的定时 GitHub Actions。
+
+```yaml
+- uses: ultralytics/actions/github-report@main
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    org: ultralytics # Optional: defaults to ultralytics
+    visibility: all # Optional: public, private, internal, all, or comma-separated
+```
+
+[**📖 完整文档 →**](github-report/README.md)
+
+### 5. Dependabot Action
 
 使用缓存的 release 解析，批量更新组织仓库中的 GitHub Actions 版本。
 

--- a/actions/failed_scheduled_actions.py
+++ b/actions/failed_scheduled_actions.py
@@ -57,7 +57,9 @@ def paginate(path, params=None, key=None, max_pages=100, token=None):
     return items
 
 
-def collect_failed_scheduled_actions(org="ultralytics", visibility="public", repo_visibility="public", max_run_pages=3, token=None):
+def collect_failed_scheduled_actions(
+    org="ultralytics", visibility="public", repo_visibility="public", max_run_pages=3, token=None
+):
     """Collect latest failed scheduled workflow runs on each non-archived repo's default branch."""
     filter_config = get_repo_filter(parse_visibility(visibility, repo_visibility))
     repos = [

--- a/actions/failed_scheduled_actions.py
+++ b/actions/failed_scheduled_actions.py
@@ -1,0 +1,158 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+"""Report failed scheduled GitHub Actions on default branches across an organization."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from actions.scan_prs import get_repo_filter, parse_visibility
+
+
+def github_get(path, params=None, token=None):
+    """Fetch JSON from the GitHub REST API."""
+    token = token or os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is required")
+
+    url = f"https://api.github.com{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as e:
+        if e.code in {403, 404}:
+            print(f"Skipping {path}: {e.code}")
+            return None
+        raise
+
+
+def paginate(path, params=None, key=None, max_pages=100, token=None):
+    """Collect paginated GitHub API results."""
+    items = []
+    for page in range(1, max_pages + 1):
+        data = github_get(path, {**(params or {}), "per_page": 100, "page": page}, token=token)
+        if not data:
+            break
+        page_items = data[key] if key else data
+        items.extend(page_items)
+        if len(page_items) < 100:
+            break
+        time.sleep(0.2)
+    return items
+
+
+def collect_failed_scheduled_actions(org="ultralytics", visibility="public", repo_visibility="public", max_run_pages=3, token=None):
+    """Collect latest failed scheduled workflow runs on each non-archived repo's default branch."""
+    filter_config = get_repo_filter(parse_visibility(visibility, repo_visibility))
+    repos = [
+        r
+        for r in paginate(f"/orgs/{org}/repos", {"type": "all"}, token=token)
+        if not r.get("archived") and (not filter_config["filter"] or r["visibility"].lower() in filter_config["filter"])
+    ]
+    failures = []
+    for repo in repos:
+        full_name = repo["full_name"]
+        branch = repo.get("default_branch") or "main"
+        runs = paginate(
+            f"/repos/{full_name}/actions/runs",
+            {"event": "schedule", "branch": branch},
+            key="workflow_runs",
+            max_pages=max_run_pages,
+            token=token,
+        )
+        latest = {}
+        for run in runs:
+            key = run.get("workflow_id") or run.get("name")
+            current = latest.get(key)
+            started = run.get("run_started_at") or run.get("created_at") or ""
+            current_started = (current or {}).get("run_started_at") or (current or {}).get("created_at") or ""
+            if not current or started > current_started:
+                latest[key] = run
+
+        for run in latest.values():
+            if run.get("conclusion") == "failure":
+                failures.append(
+                    {
+                        "repo": full_name,
+                        "visibility": repo.get("visibility", "private" if repo.get("private") else "public"),
+                        "workflow": run.get("name") or run.get("display_title") or "Workflow",
+                        "branch": branch,
+                        "run_number": run.get("run_number"),
+                        "failed_at": run.get("updated_at") or run.get("created_at") or "",
+                        "sha": (run.get("head_sha") or "")[:7],
+                        "title": run.get("display_title") or "",
+                        "url": run.get("html_url"),
+                    }
+                )
+    return sorted(failures, key=lambda x: (x["repo"].lower(), x["workflow"].lower()))
+
+
+def format_report(failures, org="ultralytics"):
+    """Format failed scheduled workflow runs as Markdown."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        "# Failed Scheduled Actions",
+        "",
+        f"Failed scheduled workflow runs on default branches for `{org}` repositories as of {now}.",
+        "",
+    ]
+    if not failures:
+        lines.append("No failed scheduled workflow runs found.")
+        return "\n".join(lines) + "\n"
+
+    repo_count = len({failure["repo"] for failure in failures})
+    lines.append(f"**{len(failures)} failing scheduled workflow runs** across **{repo_count} repositories**.")
+    grouped = defaultdict(list)
+    for failure in failures:
+        grouped[failure["repo"]].append(failure)
+
+    for repo, repo_failures in grouped.items():
+        lines.extend(["", f"## `{repo}` ({repo_failures[0]['visibility']})"])
+        for failure in repo_failures:
+            failed_at = failure["failed_at"].replace("T", " ").replace("Z", " UTC")
+            details = f" @ `{failure['sha']}`" if failure["sha"] else ""
+            details += f" - {failure['title']}" if failure["title"] else ""
+            lines.append(
+                f"- **{failure['workflow']}** on `{failure['branch']}` failed at {failed_at}{details}. "
+                f"[Run #{failure['run_number']}]({failure['url']})"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def run():
+    """Write failed scheduled Actions report to stdout and the GitHub step summary."""
+    org = os.getenv("ORG", "ultralytics")
+    max_run_pages = int(os.getenv("MAX_RUN_PAGES", "3"))
+    report = format_report(
+        collect_failed_scheduled_actions(
+            org,
+            visibility=os.getenv("VISIBILITY", "public"),
+            repo_visibility=os.getenv("REPO_VISIBILITY", "public"),
+            max_run_pages=max_run_pages,
+        ),
+        org,
+    )
+    print(report)
+    if summary_file := os.getenv("GITHUB_STEP_SUMMARY"):
+        with open(summary_file, "a") as f:
+            f.write(report)
+
+
+if __name__ == "__main__":
+    run()

--- a/actions/failed_scheduled_actions.py
+++ b/actions/failed_scheduled_actions.py
@@ -14,8 +14,10 @@ from datetime import datetime, timezone
 
 from actions.scan_prs import get_repo_filter, parse_visibility
 
+FAILED_CONCLUSIONS = {"failure", "timed_out", "action_required", "startup_failure", "cancelled"}
 
-def github_get(path, params=None, token=None):
+
+def github_get(path, params=None, token=None, allow_skip=False):
     """Fetch JSON from the GitHub REST API."""
     token = token or os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
     if not token:
@@ -36,17 +38,19 @@ def github_get(path, params=None, token=None):
         with urllib.request.urlopen(request, timeout=60) as response:
             return json.loads(response.read())
     except urllib.error.HTTPError as e:
-        if e.code in {403, 404}:
+        body = e.read().decode(errors="ignore").lower()
+        rate_limited = e.code == 403 and (e.headers.get("X-RateLimit-Remaining") == "0" or "rate limit" in body)
+        if allow_skip and e.code in {403, 404} and not rate_limited:
             print(f"Skipping {path}: {e.code}")
             return None
         raise
 
 
-def paginate(path, params=None, key=None, max_pages=100, token=None):
+def paginate(path, params=None, key=None, max_pages=100, token=None, allow_skip=False):
     """Collect paginated GitHub API results."""
     items = []
     for page in range(1, max_pages + 1):
-        data = github_get(path, {**(params or {}), "per_page": 100, "page": page}, token=token)
+        data = github_get(path, {**(params or {}), "per_page": 100, "page": page}, token=token, allow_skip=allow_skip)
         if not data:
             break
         page_items = data[key] if key else data
@@ -77,6 +81,7 @@ def collect_failed_scheduled_actions(
             key="workflow_runs",
             max_pages=max_run_pages,
             token=token,
+            allow_skip=True,
         )
         latest = {}
         for run in runs:
@@ -88,7 +93,7 @@ def collect_failed_scheduled_actions(
                 latest[key] = run
 
         for run in latest.values():
-            if run.get("conclusion") == "failure":
+            if run.get("conclusion") in FAILED_CONCLUSIONS:
                 failures.append(
                     {
                         "repo": full_name,
@@ -153,7 +158,7 @@ def run():
     print(report)
     if summary_file := os.getenv("GITHUB_STEP_SUMMARY"):
         with open(summary_file, "a") as f:
-            f.write(report)
+            f.write("\n" + report)
 
 
 if __name__ == "__main__":

--- a/actions/github_report.py
+++ b/actions/github_report.py
@@ -1,0 +1,23 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+"""Generate GitHub organization reports."""
+
+from actions import failed_scheduled_actions, scan_prs
+
+
+def enabled(value):
+    """Return whether a string environment-style value is enabled."""
+    return str(value).lower() == "true"
+
+
+def run():
+    """Run enabled GitHub report sections."""
+    import os
+
+    if enabled(os.getenv("REPORT_PRS", "true")):
+        scan_prs.run()
+    if enabled(os.getenv("REPORT_FAILED_SCHEDULED_ACTIONS", "true")):
+        failed_scheduled_actions.run()
+
+
+if __name__ == "__main__":
+    run()

--- a/actions/scan_prs.py
+++ b/actions/scan_prs.py
@@ -73,6 +73,7 @@ def run():
     org = os.getenv("ORG", "ultralytics")
     visibility_list = parse_visibility(os.getenv("VISIBILITY", "public"), os.getenv("REPO_VISIBILITY", "public"))
     filter_config = get_repo_filter(visibility_list)
+    auto_merge = os.getenv("AUTO_MERGE_ACTIONS_PRS", "true").lower() == "true"
 
     print(f"🔍 Scanning {filter_config['str']} repositories in {org} organization...")
 
@@ -156,6 +157,13 @@ def run():
         if len(repo_prs) > 30:
             summary.append(f"- ... {len(repo_prs) - 30} more PRs")
         summary.append("")
+
+    if not auto_merge:
+        summary.append("\n# 🤖 Auto-Merge GitHub Actions Update PRs\n\nAuto-merge disabled for this run.")
+        if summary_file := os.getenv("GITHUB_STEP_SUMMARY"):
+            with open(summary_file, "a") as f:
+                f.write("\n".join(summary))
+        return
 
     # Auto-merge GitHub Actions update PRs
     print("\n🤖 Checking for GitHub Actions update PRs to auto-merge...")

--- a/actions/scan_prs.py
+++ b/actions/scan_prs.py
@@ -162,7 +162,7 @@ def run():
         summary.append("\n# 🤖 Auto-Merge GitHub Actions Update PRs\n\nAuto-merge disabled for this run.")
         if summary_file := os.getenv("GITHUB_STEP_SUMMARY"):
             with open(summary_file, "a") as f:
-                f.write("\n".join(summary))
+                f.write("\n".join(summary) + "\n")
         return
 
     # Auto-merge GitHub Actions update PRs
@@ -279,7 +279,7 @@ def run():
 
     if summary_file := os.getenv("GITHUB_STEP_SUMMARY"):
         with open(summary_file, "a") as f:
-            f.write("\n".join(summary))
+            f.write("\n".join(summary) + "\n")
 
 
 if __name__ == "__main__":

--- a/github-report/README.md
+++ b/github-report/README.md
@@ -1,0 +1,47 @@
+# GitHub Report Action
+
+Summarize open pull requests and failed scheduled GitHub Actions across organization repositories.
+
+## Usage
+
+```yaml
+name: GitHub Daily Report
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  github-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ultralytics/actions/github-report@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          org: ultralytics
+          visibility: private,internal
+```
+
+## Inputs
+
+| Input                      | Description                                                                    | Required | Default       |
+| -------------------------- | ------------------------------------------------------------------------------ | -------- | ------------- |
+| `token`                    | GitHub token with access to scanned repositories                               | Yes      | -             |
+| `org`                      | GitHub organization name                                                       | No       | `ultralytics` |
+| `visibility`               | Repository visibility for PR scanning: `public`, `private`, `internal`, `all` | No       | `public`      |
+| `prs`                      | Include open PR summary                                                        | No       | `true`        |
+| `failed_scheduled_actions` | Include failed scheduled Actions summary                                       | No       | `true`        |
+| `auto_merge_actions_prs`   | Auto-merge eligible GitHub Actions update PRs in the PR section                | No       | `true`        |
+| `max_run_pages`            | Pages of scheduled workflow runs to inspect per repository                     | No       | `3`           |
+
+## Output
+
+The action writes a GitHub step summary with:
+
+- Open PR totals and age buckets
+- Eligible GitHub Actions update PR merge results
+- Latest failed scheduled workflow runs on each repository's default branch

--- a/github-report/README.md
+++ b/github-report/README.md
@@ -28,15 +28,15 @@ jobs:
 
 ## Inputs
 
-| Input                      | Description                                                                    | Required | Default       |
-| -------------------------- | ------------------------------------------------------------------------------ | -------- | ------------- |
-| `token`                    | GitHub token with access to scanned repositories                               | Yes      | -             |
-| `org`                      | GitHub organization name                                                       | No       | `ultralytics` |
+| Input                      | Description                                                                   | Required | Default       |
+| -------------------------- | ----------------------------------------------------------------------------- | -------- | ------------- |
+| `token`                    | GitHub token with access to scanned repositories                              | Yes      | -             |
+| `org`                      | GitHub organization name                                                      | No       | `ultralytics` |
 | `visibility`               | Repository visibility for PR scanning: `public`, `private`, `internal`, `all` | No       | `public`      |
-| `prs`                      | Include open PR summary                                                        | No       | `true`        |
-| `failed_scheduled_actions` | Include failed scheduled Actions summary                                       | No       | `true`        |
-| `auto_merge_actions_prs`   | Auto-merge eligible GitHub Actions update PRs in the PR section                | No       | `true`        |
-| `max_run_pages`            | Pages of scheduled workflow runs to inspect per repository                     | No       | `3`           |
+| `prs`                      | Include open PR summary                                                       | No       | `true`        |
+| `failed_scheduled_actions` | Include failed scheduled Actions summary                                      | No       | `true`        |
+| `auto_merge_actions_prs`   | Auto-merge eligible GitHub Actions update PRs in the PR section               | No       | `true`        |
+| `max_run_pages`            | Pages of scheduled workflow runs to inspect per repository                    | No       | `3`           |
 
 ## Output
 

--- a/github-report/README.md
+++ b/github-report/README.md
@@ -35,7 +35,7 @@ jobs:
 | `visibility`               | Repository visibility for PR scanning: `public`, `private`, `internal`, `all` | No       | `public`      |
 | `prs`                      | Include open PR summary                                                       | No       | `true`        |
 | `failed_scheduled_actions` | Include failed scheduled Actions summary                                      | No       | `true`        |
-| `auto_merge_actions_prs`   | Auto-merge eligible GitHub Actions update PRs in the PR section               | No       | `true`        |
+| `auto_merge_actions_prs`   | Auto-merge eligible GitHub Actions update PRs in the PR section               | No       | `false`       |
 | `max_run_pages`            | Pages of scheduled workflow runs to inspect per repository                    | No       | `3`           |
 
 ## Output

--- a/github-report/action.yml
+++ b/github-report/action.yml
@@ -29,7 +29,7 @@ inputs:
   auto_merge_actions_prs:
     description: "Auto-merge eligible GitHub Actions update PRs in the PR section"
     required: false
-    default: "true"
+    default: "false"
   max_run_pages:
     description: "Pages of scheduled workflow runs to inspect per repository"
     required: false

--- a/github-report/action.yml
+++ b/github-report/action.yml
@@ -1,23 +1,39 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-name: "Scan PRs"
+name: "GitHub Report"
 author: "Ultralytics"
-description: "List open PRs and auto-merge eligible GitHub Actions update PRs across organization"
+description: "Summarize open PRs and failed scheduled GitHub Actions across organization repositories"
 branding:
-  icon: "git-pull-request"
+  icon: "activity"
   color: "blue"
 inputs:
   token:
-    description: "GitHub token with admin permissions for merging"
+    description: "GitHub token with access to scanned repositories"
     required: true
   org:
     description: "GitHub organization name"
     required: false
     default: "ultralytics"
   visibility:
-    description: "Repository visibility to scan: public, private, internal, all, or comma-separated (e.g., 'private,internal')"
+    description: "Repository visibility for PR scanning: public, private, internal, all, or comma-separated"
     required: false
     default: "public"
+  prs:
+    description: "Include open PR summary"
+    required: false
+    default: "true"
+  failed_scheduled_actions:
+    description: "Include failed scheduled Actions summary"
+    required: false
+    default: "true"
+  auto_merge_actions_prs:
+    description: "Auto-merge eligible GitHub Actions update PRs in the PR section"
+    required: false
+    default: "true"
+  max_run_pages:
+    description: "Pages of scheduled workflow runs to inspect per repository"
+    required: false
+    default: "3"
 runs:
   using: "composite"
   steps:
@@ -33,7 +49,6 @@ runs:
         GITHUB_SHA: ${{ github.sha }}
       run: |
         echo "::group::Install ultralytics-actions"
-        # Install from git commit if testing in ultralytics/actions repo, otherwise from main
         if [ "$GITHUB_REPOSITORY" = "ultralytics/actions" ]; then
           echo "Installing from commit: $GITHUB_SHA"
           packages="git+https://github.com/ultralytics/actions@${GITHUB_SHA}"
@@ -48,16 +63,18 @@ runs:
         echo "::endgroup::"
       shell: bash
 
-    - name: Scan PRs
+    - name: GitHub Report
       env:
         GH_TOKEN: ${{ inputs.token }}
         ORG: ${{ inputs.org }}
         VISIBILITY: ${{ inputs.visibility }}
         REPO_VISIBILITY: ${{ github.event.repository.visibility }}
-        REPORT_PRS: "true"
-        REPORT_FAILED_SCHEDULED_ACTIONS: "false"
+        REPORT_PRS: ${{ inputs.prs }}
+        REPORT_FAILED_SCHEDULED_ACTIONS: ${{ inputs.failed_scheduled_actions }}
+        AUTO_MERGE_ACTIONS_PRS: ${{ inputs.auto_merge_actions_prs }}
+        MAX_RUN_PAGES: ${{ inputs.max_run_pages }}
       run: |
-        echo "::group::Scan PRs"
+        echo "::group::GitHub Report"
         python -m actions.github_report
         echo "::endgroup::"
       shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ ultralytics-actions-update-markdown-code-blocks = "actions.update_markdown_code_
 ultralytics-actions-headers = "actions.update_file_headers:main"
 ultralytics-actions-format-python-docstrings = "actions.format_python_docstrings:main"
 ultralytics-actions-dependabot = "actions.dependabot:run"
+ultralytics-actions-failed-scheduled-actions = "actions.failed_scheduled_actions:run"
+ultralytics-actions-github-report = "actions.github_report:run"
 ultralytics-actions-info = "actions.utils:ultralytics_actions_info"
 
 [tool.setuptools]

--- a/tests/test_github_report.py
+++ b/tests/test_github_report.py
@@ -3,10 +3,30 @@
 from actions import failed_scheduled_actions, github_report
 
 
+def test_paginate_only_skips_http_errors_when_allowed(monkeypatch):
+    """Org-level auth failures should raise, while allowed per-repo misses can be skipped."""
+
+    def fake_get(path, params=None, token=None, allow_skip=False):
+        if allow_skip:
+            return None
+        raise PermissionError(path)
+
+    monkeypatch.setattr(failed_scheduled_actions, "github_get", fake_get)
+
+    assert failed_scheduled_actions.paginate("/repos/ultralytics/repo/actions/runs", allow_skip=True) == []
+
+    try:
+        failed_scheduled_actions.paginate("/orgs/ultralytics/repos")
+    except PermissionError as e:
+        assert str(e) == "/orgs/ultralytics/repos"
+    else:
+        raise AssertionError("Expected org listing failure to raise")
+
+
 def test_collect_failed_scheduled_actions_latest_run_per_workflow(monkeypatch):
     """Only the latest scheduled run for each workflow should determine whether it is reported."""
 
-    def fake_paginate(path, params=None, key=None, max_pages=100, token=None):
+    def fake_paginate(path, params=None, key=None, max_pages=100, token=None, allow_skip=False):
         if path == "/orgs/ultralytics/repos":
             return [
                 {
@@ -39,7 +59,7 @@ def test_collect_failed_scheduled_actions_latest_run_per_workflow(monkeypatch):
                 {
                     "workflow_id": 2,
                     "name": "Links",
-                    "conclusion": "failure",
+                    "conclusion": "timed_out",
                     "run_started_at": "2026-06-30T04:00:00Z",
                     "run_number": 42,
                     "updated_at": "2026-06-30T04:10:00Z",
@@ -62,6 +82,41 @@ def test_collect_failed_scheduled_actions_latest_run_per_workflow(monkeypatch):
     assert failures[0]["repo"] == "ultralytics/private-repo"
     assert failures[0]["workflow"] == "Links"
     assert failures[0]["sha"] == "abcdef1"
+
+
+def test_collect_failed_scheduled_actions_ignores_latest_success(monkeypatch):
+    """Older failed scheduled runs should not be reported after a newer success."""
+
+    def fake_paginate(path, params=None, key=None, max_pages=100, token=None, allow_skip=False):
+        if path == "/orgs/ultralytics/repos":
+            return [
+                {
+                    "full_name": "ultralytics/repo",
+                    "default_branch": "main",
+                    "visibility": "public",
+                    "archived": False,
+                }
+            ]
+        if path == "/repos/ultralytics/repo/actions/runs":
+            return [
+                {
+                    "workflow_id": 1,
+                    "name": "Nightly",
+                    "conclusion": "success",
+                    "run_started_at": "2026-06-30T03:00:00Z",
+                },
+                {
+                    "workflow_id": 1,
+                    "name": "Nightly",
+                    "conclusion": "failure",
+                    "run_started_at": "2026-06-29T03:00:00Z",
+                },
+            ]
+        raise AssertionError(path)
+
+    monkeypatch.setattr(failed_scheduled_actions, "paginate", fake_paginate)
+
+    assert failed_scheduled_actions.collect_failed_scheduled_actions(token="token") == []
 
 
 def test_format_report_links_failures():
@@ -98,3 +153,15 @@ def test_github_report_runs_enabled_sections(monkeypatch):
     github_report.run()
 
     assert calls == ["prs"]
+
+
+def test_failed_scheduled_actions_summary_appends_section_break(tmp_path, monkeypatch):
+    """Appending after the PR section should not concatenate Markdown headings."""
+    summary = tmp_path / "summary.md"
+    summary.write_text("**Summary:** Found 0 | Merged 0 | Skipped 0\n")
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr(failed_scheduled_actions, "collect_failed_scheduled_actions", lambda *args, **kwargs: [])
+
+    failed_scheduled_actions.run()
+
+    assert "Skipped 0\n\n# Failed Scheduled Actions" in summary.read_text()

--- a/tests/test_github_report.py
+++ b/tests/test_github_report.py
@@ -1,0 +1,100 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+from actions import failed_scheduled_actions, github_report
+
+
+def test_collect_failed_scheduled_actions_latest_run_per_workflow(monkeypatch):
+    """Only the latest scheduled run for each workflow should determine whether it is reported."""
+
+    def fake_paginate(path, params=None, key=None, max_pages=100, token=None):
+        if path == "/orgs/ultralytics/repos":
+            return [
+                {
+                    "full_name": "ultralytics/private-repo",
+                    "default_branch": "main",
+                    "visibility": "private",
+                    "archived": False,
+                },
+                {
+                    "full_name": "ultralytics/public-repo",
+                    "default_branch": "main",
+                    "visibility": "public",
+                    "archived": False,
+                },
+            ]
+        if path == "/repos/ultralytics/private-repo/actions/runs":
+            return [
+                {
+                    "workflow_id": 1,
+                    "name": "Nightly",
+                    "conclusion": "success",
+                    "run_started_at": "2026-06-30T03:00:00Z",
+                },
+                {
+                    "workflow_id": 1,
+                    "name": "Nightly",
+                    "conclusion": "failure",
+                    "run_started_at": "2026-06-29T03:00:00Z",
+                },
+                {
+                    "workflow_id": 2,
+                    "name": "Links",
+                    "conclusion": "failure",
+                    "run_started_at": "2026-06-30T04:00:00Z",
+                    "run_number": 42,
+                    "updated_at": "2026-06-30T04:10:00Z",
+                    "head_sha": "abcdef123456",
+                    "display_title": "Links",
+                    "html_url": "https://github.com/ultralytics/private-repo/actions/runs/42",
+                },
+            ]
+        if path == "/repos/ultralytics/public-repo/actions/runs":
+            return []
+        raise AssertionError(path)
+
+    monkeypatch.setattr(failed_scheduled_actions, "paginate", fake_paginate)
+
+    failures = failed_scheduled_actions.collect_failed_scheduled_actions(
+        visibility="all", repo_visibility="private", token="token"
+    )
+
+    assert len(failures) == 1
+    assert failures[0]["repo"] == "ultralytics/private-repo"
+    assert failures[0]["workflow"] == "Links"
+    assert failures[0]["sha"] == "abcdef1"
+
+
+def test_format_report_links_failures():
+    """Report output includes concise failure details and backlinks."""
+    report = failed_scheduled_actions.format_report(
+        [
+            {
+                "repo": "ultralytics/private-repo",
+                "visibility": "private",
+                "workflow": "Nightly",
+                "branch": "main",
+                "run_number": 7,
+                "failed_at": "2026-06-30T01:02:03Z",
+                "sha": "abcdef1",
+                "title": "Nightly",
+                "url": "https://github.com/ultralytics/private-repo/actions/runs/7",
+            }
+        ]
+    )
+
+    assert "# Failed Scheduled Actions" in report
+    assert "**Nightly** on `main` failed at 2026-06-30 01:02:03 UTC" in report
+    assert "[Run #7](https://github.com/ultralytics/private-repo/actions/runs/7)" in report
+
+
+def test_github_report_runs_enabled_sections(monkeypatch):
+    """The shared report driver gates PR and failed scheduled Actions sections by env flags."""
+    calls = []
+    monkeypatch.setenv("REPORT_PRS", "true")
+    monkeypatch.setenv("REPORT_FAILED_SCHEDULED_ACTIONS", "false")
+    monkeypatch.setattr(github_report.scan_prs, "run", lambda: calls.append("prs"))
+    monkeypatch.setattr(github_report.failed_scheduled_actions, "run", lambda: calls.append("actions"))
+
+    github_report.run()
+
+    assert calls == ["prs"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -56,6 +56,8 @@ def test_all_modules_importable():
         "actions.summarize_release",
         "actions.update_markdown_code_blocks",
         "actions.dispatch_actions",
+        "actions.failed_scheduled_actions",
+        "actions.github_report",
     ]
 
     for module_name in modules:
@@ -77,6 +79,7 @@ def test_cli_entry_points():
         "ultralytics-actions-summarize-pr",
         "ultralytics-actions-summarize-release",
         "ultralytics-actions-update-markdown-code-blocks",
+        "ultralytics-actions-github-report",
         "ultralytics-actions-info",
     ]
 


### PR DESCRIPTION
## Summary
- add a reusable GitHub report action for open PRs and failed scheduled Actions
- route scan-prs through the shared report entrypoint while preserving PR-only behavior
- add focused tests and documentation

## Tests
- ruff check actions/failed_scheduled_actions.py actions/github_report.py actions/scan_prs.py tests/test_github_report.py tests/test_init.py
- python -m pytest tests/test_github_report.py tests/test_init.py -q
- ruby -e 'require "yaml"; %w[scan-prs/action.yml github-report/action.yml].each { |f| YAML.load_file(f); puts "#{f} ok" }'

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR adds a new **GitHub Report Action** that combines open PR reporting with failed scheduled workflow reporting across organization repositories, while also making PR auto-merge behavior more configurable.

### 📊 Key Changes
- 🆕 Added a new `github-report` GitHub Action with its own `action.yml` and documentation.
- 📋 The new action can generate a combined report for:
  - open pull requests
  - failed scheduled GitHub Actions runs on default branches
- 🚨 Introduced `actions/failed_scheduled_actions.py` to scan org repositories and summarize the latest failed scheduled workflows per repo.
- 🧩 Added `actions/github_report.py` as a shared report runner that can enable or disable PR reporting and failed scheduled action reporting via environment flags.
- ⚙️ Updated `scan_prs.py` so auto-merging GitHub Actions update PRs can be turned off cleanly using `AUTO_MERGE_ACTIONS_PRS`.
- 🔄 Updated the existing `scan-prs` action to use the new shared report entrypoint, with only PR reporting enabled there.
- 📚 Updated both English and Chinese main READMEs to list the new GitHub Report Action.
- ✅ Added tests for:
  - failed scheduled workflow detection
  - report formatting
  - section enable/disable behavior
  - summary file formatting and newline handling
- 🛠️ Added new CLI entry points for `failed-scheduled-actions` and `github-report`.

### 🎯 Purpose & Impact
- 👀 Gives teams a clearer daily view of repository health by surfacing both open PRs and broken scheduled workflows in one place.
- ⏱️ Helps maintainers spot failing automation faster, especially for nightly or scheduled jobs that might otherwise go unnoticed.
- 🤖 Improves control over automation by allowing PR scanning without automatically merging dependency-related GitHub Actions PRs.
- 🧱 Reuses a shared reporting flow, which should make future reporting features easier to add and maintain.
- 📈 Overall, this makes organization-wide GitHub monitoring more convenient and actionable for both developers and maintainers.