### PR TITLE
Simplify GitHub report repo headings

### DIFF
--- a/actions/failed_scheduled_actions.py
+++ b/actions/failed_scheduled_actions.py
@@ -145,14 +145,12 @@ def format_report(failures, org="ultralytics"):
         grouped[failure["repo"]].append(failure)
 
     for repo, repo_failures in grouped.items():
-        count = len(repo_failures)
         lines.extend(
             [
                 "",
                 format_repo_heading(
                     repo,
                     repo_failures[0].get("repo_url") or f"https://github.com/{repo}",
-                    f"{count} failed run{'s' if count != 1 else ''}",
                 ),
             ]
         )

--- a/actions/scan_prs.py
+++ b/actions/scan_prs.py
@@ -60,9 +60,10 @@ def get_repo_filter(visibility_list):
     }
 
 
-def format_repo_heading(repo_name, repo_url, detail):
+def format_repo_heading(repo_name, repo_url, detail=None):
     """Format a repository section heading for GitHub report Markdown."""
-    return f"## 📦 [{repo_name}]({repo_url}) - {detail}"
+    heading = f"## 📦 [{repo_name.rsplit('/', 1)[-1]}]({repo_url})"
+    return f"{heading} - {detail}" if detail else heading
 
 
 def get_status_checks(rollup):

--- a/tests/test_github_report.py
+++ b/tests/test_github_report.py
@@ -178,7 +178,8 @@ def test_format_report_links_failures():
     assert "# Failed Default Branch Actions" in report
     assert "**1 failing default-branch workflow run** across **1 repository**." in report
     assert "**By Event:** `push` 1" in report
-    assert "## 📦 [ultralytics/private-repo](https://github.com/ultralytics/private-repo) - 1 failed run" in report
+    assert "## 📦 [private-repo](https://github.com/ultralytics/private-repo)" in report
+    assert "failed run" not in report
     assert "(private)" not in report
     assert "**Nightly** (`push`) on `main` failed at 2026-06-30 01:02:03 UTC" in report
     assert "[Run #7](https://github.com/ultralytics/private-repo/actions/runs/7)" in report


### PR DESCRIPTION
## Summary
- normalize GitHub report repo headings to short linked repo names
- remove failed-run counts from failed-action repo headings

## Tests
- ruff format --check actions/scan_prs.py actions/failed_scheduled_actions.py tests/test_github_report.py
- ruff check actions/scan_prs.py actions/failed_scheduled_actions.py tests/test_github_report.py
- python -m pytest tests/test_github_report.py -q
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR simplifies GitHub report headings by shortening repository names and removing failed-run counts from section titles for cleaner, more readable action reports.

### 📊 Key Changes
- Updated `format_repo_heading()` in `actions/scan_prs.py` to make the `detail` argument optional.
- Changed repository headings to display only the repo name, not the full `owner/repo` path.
  - Example: `ultralytics/private-repo` now appears as `private-repo`.
- Adjusted heading formatting so extra details are only shown when explicitly provided.
- Removed the failed-run count text from scheduled action failure reports in `actions/failed_scheduled_actions.py`.
  - Example: headings no longer include text like `- 1 failed run`.
- Updated tests in `tests/test_github_report.py` to match the new, cleaner output and confirm old failure-count text is no longer present.

### 🎯 Purpose & Impact
- 🧹 Makes generated GitHub reports easier to scan by reducing clutter in repository section headers.
- 👀 Improves readability for both technical and non-technical users by showing simpler repo labels.
- 📝 Creates more flexible heading formatting that can be reused with or without extra detail.
- ✅ Keeps test coverage aligned with the new output, helping prevent formatting regressions.
- 🔧 Likely has minimal functional impact, but users who rely on the exact previous report text may notice the updated formatting.