### PR TITLE
Update default OpenAI model to GPT-5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Choose between [OpenAI](https://developers.openai.com/) or [Anthropic](https://w
 
 | Provider  | Default Model       | API Key             |
 | --------- | ------------------- | ------------------- |
-| OpenAI    | `gpt-5.4`           | `openai_api_key`    |
+| OpenAI    | `gpt-5.5`           | `openai_api_key`    |
 | Anthropic | `claude-sonnet-4-6` | `anthropic_api_key` |
 
-The model is auto-detected based on which API key you provide. Override with the `model` input, for example `gpt-5.5`, or use `review_model` to override PR review only.
+The model is auto-detected based on which API key you provide. Override with the `model` input, or use `review_model` to override PR review only.
 
 ### 🛠️ How It Works
 
@@ -111,7 +111,7 @@ jobs:
           # AI API keys - provide OpenAI OR Anthropic (model auto-detected from key)
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # model: gpt-5.5  # Optional: override default model
+          # model: gpt-5.5  # Optional: set model explicitly
           # review_model: claude-opus-4-7  # Optional: override PR review model
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,10 +49,10 @@
 
 | 提供商    | 默认模型            | API Key             |
 | --------- | ------------------- | ------------------- |
-| OpenAI    | `gpt-5.4`           | `openai_api_key`    |
+| OpenAI    | `gpt-5.5`           | `openai_api_key`    |
 | Anthropic | `claude-sonnet-4-6` | `anthropic_api_key` |
 
-模型会根据提供的 API key 自动检测。可通过 `model` 输入覆盖默认模型，例如 `gpt-5.5`；也可使用 `review_model` 仅覆盖 PR review 模型。
+模型会根据提供的 API key 自动检测。可通过 `model` 输入覆盖默认模型，也可使用 `review_model` 仅覆盖 PR review 模型。
 
 ### 🛠️ 工作方式
 
@@ -111,7 +111,7 @@ jobs:
           # AI API keys - provide OpenAI OR Anthropic (model auto-detected from key)
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # model: gpt-5.5  # Optional: override default model
+          # model: gpt-5.5  # Optional: set model explicitly
           # review_model: claude-opus-4-7  # Optional: override PR review model
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution
 ```

--- a/action.yml
+++ b/action.yml
@@ -76,10 +76,10 @@ inputs:
     description: "Anthropic API Key"
     required: false
   model:
-    description: "AI Model - defaults to GPT-5.4 or Sonnet 4.6 based on API key"
+    description: "AI Model - defaults to GPT-5.5 or Sonnet 4.6 based on API key"
     required: false
   review_model:
-    description: "AI Model for PR reviews (optional, defaults to gpt-5.4)"
+    description: "AI Model for PR reviews (optional, defaults to gpt-5.5)"
     required: false
   first_issue_response:
     description: "Example response to a new issue"

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.17"
+__version__ = "0.2.18"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -252,7 +252,6 @@ def generate_pr_review(
 
         response = get_response(
             messages,
-            reasoning_effort="medium",
             text_format={"format": {"type": "json_schema", "name": "pr_review", "strict": True, "schema": schema}},
             model=review_model,
             tools=[

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -18,9 +18,9 @@ REVIEW_MODEL = os.getenv("REVIEW_MODEL")  # Optional override for PR reviews
 MAX_PROMPT_CHARS = round(128000 * 3.3 * 0.5)  # Max characters for prompt (50% of 128k context)
 
 # Default models (single source of truth)
-OPENAI_MODEL_DEFAULT = "gpt-5.4"
+OPENAI_MODEL_DEFAULT = "gpt-5.5"
 ANTHROPIC_MODEL_DEFAULT = "claude-sonnet-4-6"
-PR_REVIEW_MODEL_DEFAULT = "gpt-5.4"
+PR_REVIEW_MODEL_DEFAULT = "gpt-5.5"
 
 MODEL_COSTS = {  # (input, output) per 1M tokens
     # OpenAI models

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -14,8 +14,8 @@ from actions.utils.openai_utils import (
 
 def test_default_models():
     """Test canonical default models."""
-    assert OPENAI_MODEL_DEFAULT == "gpt-5.4"
-    assert PR_REVIEW_MODEL_DEFAULT == "gpt-5.4"
+    assert OPENAI_MODEL_DEFAULT == "gpt-5.5"
+    assert PR_REVIEW_MODEL_DEFAULT == "gpt-5.5"
 
 
 def test_is_anthropic_model():


### PR DESCRIPTION
## Summary
- default OpenAI and PR review model selection now uses `gpt-5.5`
- remove the PR review medium reasoning override so GPT-5 uses the shared low default
- update action metadata, docs, tests, and package version

## Tests
- `python -m pytest tests/test_openai_utils.py -v`
- `python -m pytest tests -v`
- `ruff check actions/utils/openai_utils.py actions/review_pr.py actions/__init__.py tests/test_openai_utils.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the default OpenAI model from `gpt-5.4` to `gpt-5.5` across the Ultralytics Actions codebase and documentation 🚀

### 📊 Key Changes
- Updated default OpenAI model constants to `gpt-5.5` for general AI usage and PR reviews 🤖
- Refreshed `action.yml` input descriptions to reflect the new default model 🛠️
- Updated English and Chinese README documentation with the new model default and clearer wording 🌐
- Removed the explicit `reasoning_effort="medium"` setting from PR review generation, simplifying review model calls ⚙️
- Bumped package version from `0.2.17` to `0.2.18` 📦
- Updated tests to validate the new `gpt-5.5` defaults ✅

### 🎯 Purpose & Impact
- Ensures users automatically benefit from the newer default OpenAI model without changing their workflows ✨
- Keeps documentation, configuration, and tests aligned to reduce confusion and maintenance overhead 📚
- Simplifies PR review behavior by relying on model/provider defaults where applicable 🔍
- Maintains backward flexibility: users can still explicitly set `model` or `review_model` when needed 🎛️