### PR TITLE
Run PR reviews synchronously

### DIFF
--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -267,8 +267,7 @@ def generate_pr_review(
                 }
             ],
             retries=0,
-            # Keep reviews synchronous; background responses can stay queued until the 900s poll timeout.
-            # background=True,
+            # Do not pass background=True; queued background reviews can consume the full 900s poll timeout.
         )
 
         # Sanitize leaked tool-citation tokens from model output

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -267,7 +267,8 @@ def generate_pr_review(
                 }
             ],
             retries=0,
-            background=True,
+            # Keep reviews synchronous; background responses can stay queued until the 900s poll timeout.
+            # background=True,
         )
 
         # Sanitize leaked tool-citation tokens from model output

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from actions import review_pr
 from actions.first_interaction import get_event_content, get_first_interaction_response, get_relevant_labels
 
 
@@ -96,3 +97,24 @@ def test_get_first_interaction_response(mock_get_response):
 
     assert response == "Thank you for your issue"
     mock_get_response.assert_called_once()
+
+
+@patch("actions.review_pr.get_response")
+def test_generate_pr_review_uses_synchronous_response(mock_get_response):
+    """Test PR reviews avoid background polling for code diffs."""
+    mock_get_response.return_value = {"comments": [], "summary": "LGTM"}
+    diff = """diff --git a/test.py b/test.py
+--- a/test.py
++++ b/test.py
+@@ -1 +1 @@
+-old = True
++old = False
+"""
+
+    review = review_pr.generate_pr_review("ultralytics/actions", diff, "Test PR", "")
+
+    assert review["summary"] == "LGTM"
+    mock_get_response.assert_called_once()
+    kwargs = mock_get_response.call_args.kwargs
+    assert "background" not in kwargs
+    assert kwargs["tools"][0]["type"] == "web_search"


### PR DESCRIPTION
## Summary
- keep PR review generation synchronous instead of using OpenAI background polling
- leave web search tools unchanged for review prompts
- add a regression test that prevents re-enabling background polling for PR reviews

## Root cause
In ultralytics/annotate#150, the PR-open automation finished formatting and first interaction quickly, then the automatic review created a background OpenAI response that stayed queued until the 900s polling timeout. The action still exited green after posting the timeout traceback as a COMMENTED review.

Evidence: https://github.com/ultralytics/annotate/actions/runs/28579202758/job/84735091912

## Tests
- PYTHONPATH=. pytest tests/test_first_interaction.py tests/test_openai_utils.py -q
- PYTHONPATH=. pytest tests -q
- PYTHONPATH=. ruff check actions/review_pr.py tests/test_first_interaction.py
- PYTHONPATH=. ruff format --check actions/review_pr.py tests/test_first_interaction.py
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves PR review reliability by switching AI review generation from background polling to a synchronous response flow 🚀

### 📊 Key Changes
- Removed the `background=True` option from `generate_pr_review()` in `actions/review_pr.py` 🛠️
- Added a test to confirm PR reviews do **not** use background polling for code diffs ✅
- Verified that review generation still uses the `web_search` tool as expected 🔍

### 🎯 Purpose & Impact
- Prevents queued background reviews from consuming the full 900-second poll timeout ⏱️
- Makes automated PR reviews more predictable and less likely to stall 🧩
- Improves CI/action reliability for contributors and maintainers reviewing code changes 🤝