### PR TITLE
Prefer uv pip install in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ After opening a PR:
 ## Commands
 
 ```bash
-pip install -e ".[dev]" # install for development (or: uv pip install --system -e ".[dev]")
+uv pip install -e ".[dev]" # install for development
 
 pytest tests -v                                             # run all tests
 pytest tests/test_common_utils.py -v                        # run one test file

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ This repository provides three main components:
 
 ## Ultralytics Actions (Main Action)
 
-AI-powered formatting, labeling, and PR summaries for Python, Swift, Dart, and Markdown files.
+AI-powered formatting, labeling, and PR summaries for Python, JavaScript/TypeScript, Swift, Dart, and web/docs files.
 
 ### 📄 Features
 
 - **Python Code:** Formatted using [Ruff](https://github.com/astral-sh/ruff), an extremely fast Python linter and formatter
 - **Python Docstrings:** Google-style formatting enforced with Ultralytics Python docstring formatter (optional)
-- **JavaScript/TypeScript:** Formatted with [Biome](https://biomejs.dev/), an extremely fast formatter for JS, TS, JSX, TSX, and JSON (optional, auto-detected via `biome.json`)
+- **JavaScript/TypeScript:** Formatted with [Biome](https://biomejs.dev/), an extremely fast formatter for JS, TS, JSX, TSX, and JSON (optional, auto-detected via `biome.json` or `biome.jsonc`)
 - **Web and Docs Files:** Styled with [Prettier](https://github.com/prettier/prettier) for JS, TS, CSS, HTML, JSON, YAML, Markdown, and shell scripts
 - **Swift Code:** Formatted with [`swift-format`](https://github.com/swiftlang/swift-format) _(requires `macos-latest` runner)_
 - **Dart Code:** Formatted with [`dart format`](https://dart.dev/tools/dart-format) for Dart and Flutter projects
@@ -101,7 +101,7 @@ jobs:
           python: true # Format Python with Ruff
           # python-version: "3.14" # Optional: set up a specific Python version (default: runner Python)
           python_docstrings: true # Format Python docstrings (default: true)
-          biome: true # Format JS/TS with Biome (auto-detected via biome.json)
+          biome: true # Format JS/TS with Biome (auto-detected via biome.json or biome.jsonc)
           prettier: true # Format YAML, JSON, Markdown, CSS
           swift: false # Format Swift (requires macos-latest)
           dart: false # Format Dart/Flutter
@@ -178,7 +178,7 @@ Install the `ultralytics-actions` package for programmatic access to action util
 [![PyPI - Version](https://img.shields.io/pypi/v/ultralytics-actions?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics-actions/) [![Ultralytics Downloads](https://static.pepy.tech/badge/ultralytics-actions)](https://clickpy.clickhouse.com/dashboard/ultralytics-actions) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics-actions?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics-actions/)
 
 ```bash
-pip install ultralytics-actions
+uv pip install ultralytics-actions
 ```
 
 **Available Modules:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,13 +27,13 @@
 
 ## Ultralytics Actions 主 Action
 
-面向 Python、Swift、Dart 和 Markdown 文件的 AI 驱动格式化、标签和 PR 摘要工具。
+面向 Python、JavaScript/TypeScript、Swift、Dart 和网页/文档文件的 AI 驱动格式化、标签和 PR 摘要工具。
 
 ### 📄 功能
 
 - **Python 代码：** 使用极快的 Python linter 和 formatter [Ruff](https://github.com/astral-sh/ruff) 格式化
 - **Python Docstrings：** 使用 Ultralytics Python docstring formatter 强制 Google 风格格式（可选）
-- **JavaScript/TypeScript：** 使用极快的 JS、TS、JSX、TSX 和 JSON formatter [Biome](https://biomejs.dev/) 格式化（可选，通过 `biome.json` 自动检测）
+- **JavaScript/TypeScript：** 使用极快的 JS、TS、JSX、TSX 和 JSON formatter [Biome](https://biomejs.dev/) 格式化（可选，通过 `biome.json` 或 `biome.jsonc` 自动检测）
 - **Web 和文档文件：** 使用 [Prettier](https://github.com/prettier/prettier) 格式化 JS、TS、CSS、HTML、JSON、YAML、Markdown 和 shell 脚本
 - **Swift 代码：** 使用 [`swift-format`](https://github.com/swiftlang/swift-format) 格式化（需要 `macos-latest` runner）
 - **Dart 代码：** 使用 [`dart format`](https://dart.dev/tools/dart-format) 格式化 Dart 和 Flutter 项目
@@ -101,7 +101,7 @@ jobs:
           python: true # Format Python with Ruff
           # python-version: "3.14" # Optional: set up a specific Python version (default: runner Python)
           python_docstrings: true # Format Python docstrings (default: true)
-          biome: true # Format JS/TS with Biome (auto-detected via biome.json)
+          biome: true # Format JS/TS with Biome (auto-detected via biome.json or biome.jsonc)
           prettier: true # Format YAML, JSON, Markdown, CSS
           swift: false # Format Swift (requires macos-latest)
           dart: false # Format Dart/Flutter
@@ -178,7 +178,7 @@ jobs:
 [![PyPI - Version](https://img.shields.io/pypi/v/ultralytics-actions?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics-actions/) [![Ultralytics Downloads](https://static.pepy.tech/badge/ultralytics-actions)](https://clickpy.clickhouse.com/dashboard/ultralytics-actions) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics-actions?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics-actions/)
 
 ```bash
-pip install ultralytics-actions
+uv pip install ultralytics-actions
 ```
 
 **可用模块：**


### PR DESCRIPTION
Use `uv pip install` instead of bare `pip install` in AGENTS.md commands for speed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Documentation updates clarify expanded JavaScript/TypeScript support, Biome config detection, and recommend `uv pip` for installs 🚀

### 📊 Key Changes
- Updated README descriptions to include **JavaScript/TypeScript** and broader **web/docs file** support.
- Clarified that **Biome** auto-detection now covers both `biome.json` and `biome.jsonc` configuration files.
- Replaced `pip install` examples with `uv pip install` in development and package installation instructions.
- Applied the same documentation improvements to both English and Chinese READMEs 🌐

### 🎯 Purpose & Impact
- Makes the repository’s capabilities clearer for users working with Python, JS/TS, Swift, Dart, and documentation files.
- Helps developers using `biome.jsonc` understand their projects are supported automatically ✅
- Promotes faster, more consistent installation workflows with `uv pip`.
- Improves multilingual documentation consistency for a broader global user base.