### PR TITLE
Prevent format pushes after PR branch deletion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -355,6 +355,8 @@ runs:
       env:
         GITHUB_USERNAME: ${{ inputs.github_username }}
         GITHUB_EMAIL: ${{ inputs.github_email }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         echo "::group::Commit and Push Changes"
         COMMIT_MSG="Auto-format by https://ultralytics.com/actions"
@@ -364,7 +366,7 @@ runs:
         git reset HEAD -- .github/workflows/  # workflow changes are not permitted with default token
         if ! git diff --staged --quiet; then
           git commit -m "$COMMIT_MSG"
-          git push
+          git push --force-with-lease="refs/heads/${PR_HEAD_REF}:${PR_HEAD_SHA}" origin "HEAD:${PR_HEAD_REF}"
         else
           echo "No changes to commit"
         fi

--- a/action.yml
+++ b/action.yml
@@ -366,7 +366,7 @@ runs:
         git reset HEAD -- .github/workflows/  # workflow changes are not permitted with default token
         if ! git diff --staged --quiet; then
           git commit -m "$COMMIT_MSG"
-          git push --force-with-lease="refs/heads/${PR_HEAD_REF}:${PR_HEAD_SHA}" origin "HEAD:${PR_HEAD_REF}"
+          git push --force-with-lease="refs/heads/${PR_HEAD_REF}:${PR_HEAD_SHA}" origin "HEAD:refs/heads/${PR_HEAD_REF}"
         else
           echo "No changes to commit"
         fi


### PR DESCRIPTION
## Summary
- use the PR head SHA from the event payload as a push lease for auto-format commits
- avoid recreating PR branches that GitHub already deleted after merge
- keep the guard API-free by relying on existing event metadata

## Testing
- PYTHONPATH=. pytest tests -v
- ruff check .
- ruff format --check .
- local git simulation confirmed the lease-protected push refuses to recreate a deleted branch

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves auto-format pushes in `ultralytics/actions` by safely targeting the pull request source branch with lease protection 🚀

### 📊 Key Changes
- Added PR branch metadata to the action environment:
  - `PR_HEAD_REF` for the pull request source branch name
  - `PR_HEAD_SHA` for the expected branch commit SHA
- Replaced a plain `git push` with a targeted push to the PR head branch.
- Added `--force-with-lease` protection to ensure the action only pushes if the branch still matches the expected PR commit.

### 🎯 Purpose & Impact
- Prevents accidental pushes to the wrong branch during automated formatting workflows 🛡️
- Makes auto-format commits safer for pull requests, especially when branches are updated concurrently.
- Reduces the risk of overwriting contributor changes by using lease-based push protection.
- Improves reliability of Ultralytics GitHub Actions automation for maintainers and contributors ✅