### PR TITLE
Skip docstring first-word capitalization for code identifiers and URLs

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.19"
+__version__ = "0.2.20"

--- a/actions/format_python_docstrings.py
+++ b/actions/format_python_docstrings.py
@@ -380,7 +380,7 @@ def format_docstring(
     single_ok = ("\n" not in text) and not has_section and not has_list
     if single_ok:
         words = text.split()
-        if words and words[0][0].islower() and not any(c in words[0] for c in "_./`("):
+        if words and words[0].islower() and not any(c in words[0] for c in "_./`("):
             words[0] = words[0][0].upper() + words[0][1:]
         out = " ".join(words)
         if out and out[-1] not in ".!?":

--- a/actions/format_python_docstrings.py
+++ b/actions/format_python_docstrings.py
@@ -380,7 +380,8 @@ def format_docstring(
     single_ok = ("\n" not in text) and not has_section and not has_list
     if single_ok:
         words = text.split()
-        if words and words[0].islower() and not any(c in words[0] for c in "_./`("):
+        core = words[0].rstrip(".") if words else ""  # ignore terminal dots so only interior ones mark identifiers
+        if core.islower() and not any(c in core for c in "_./`("):
             words[0] = words[0][0].upper() + words[0][1:]
         out = " ".join(words)
         if out and out[-1] not in ".!?":

--- a/actions/format_python_docstrings.py
+++ b/actions/format_python_docstrings.py
@@ -380,7 +380,7 @@ def format_docstring(
     single_ok = ("\n" not in text) and not has_section and not has_list
     if single_ok:
         words = text.split()
-        if words and not words[0].startswith(("http://", "https://")) and not words[0][0].isupper():
+        if words and words[0][0].islower() and not any(c in words[0] for c in "_./`("):
             words[0] = words[0][0].upper() + words[0][1:]
         out = " ".join(words)
         if out and out[-1] not in ".!?":

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -26,3 +26,13 @@ def test_docstring_formatter_keeps_simple_docstrings_single_line():
     text = "Make the live fp32 EMA genuinely non-finite while the model stays finite (sticky-NaN on a finite-loss run)."
 
     assert format_python_docstrings.format_docstring(text, 8, 120, '"""', "") == f'"""{text}"""'
+
+
+def test_docstring_formatter_preserves_identifier_first_words():
+    """Test that code identifiers, dotted names, and URLs are not capitalized as first words."""
+    for text in (
+        "process_mask/process_mask_native/scale_masks must handle 0 detections without crashing.",
+        "np.array inputs are converted to tensors.",
+        "https://ultralytics.com hosts the docs.",
+    ):
+        assert format_python_docstrings.format_docstring(text, 8, 120, '"""', "") == f'"""{text}"""'

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -34,5 +34,6 @@ def test_docstring_formatter_preserves_identifier_first_words():
         "process_mask/process_mask_native/scale_masks must handle 0 detections without crashing.",
         "np.array inputs are converted to tensors.",
         "https://ultralytics.com hosts the docs.",
+        "iOS builds are not supported.",
     ):
         assert format_python_docstrings.format_docstring(text, 8, 120, '"""', "") == f'"""{text}"""'

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -37,3 +37,4 @@ def test_docstring_formatter_preserves_identifier_first_words():
         "iOS builds are not supported.",
     ):
         assert format_python_docstrings.format_docstring(text, 8, 120, '"""', "") == f'"""{text}"""'
+    assert format_python_docstrings.format_docstring("done.", 8, 120, '"""', "") == '"""Done."""'


### PR DESCRIPTION
## Problem

The simple docstring formatter capitalizes the first word of single-line docstrings even when that word is a code identifier, corrupting the reference. Observed in production on ultralytics/ultralytics PR #25040, where the auto-format commit rewrote `"""process_mask/process_mask_native/scale_masks must handle 0 detections without crashing."""` to `"""Process_mask/..."""` in `tests/test_python.py`.

## Fix

Replace the capitalization guard: instead of special-casing only `http://`/`https://` prefixes, skip capitalization whenever the first word contains identifier-ish characters (`_`, `.`, `/`, backtick, `(`). This subsumes the URL check (URLs contain `/` and `.`), so the explicit prefix test is deleted rather than extended, and also covers dotted names like `np.array` and call forms like `foo()`. Regression test added alongside the existing single-line docstring test.

Deleted: the `startswith(("http://", "https://"))` special case (subsumed by the character-class check that replaces it).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Python docstring formatting so code-like first words, URLs, and platform names are preserved correctly while releasing version `0.2.20` ✨

### 📊 Key Changes
- Bumped package version from `0.2.19` to `0.2.20` 🚀
- Refined single-line docstring capitalization logic:
  - Only capitalizes the first word when it is fully lowercase plain text.
  - Avoids changing identifiers containing characters like `_`, `.`, `/`, `` ` ``, or `(`.
  - Preserves URLs and code-style names such as `np.array` and `process_mask/...`.
- Added tests to confirm the formatter preserves:
  - Function or identifier-like first words 🧩
  - Dotted names like `np.array`
  - URLs like `https://ultralytics.com`
  - Case-sensitive terms like `iOS`
- Added a test confirming normal lowercase text such as `done.` is still capitalized to `Done.` ✅

### 🎯 Purpose & Impact
- Reduces accidental changes to technical docstrings where capitalization would make identifiers, URLs, or platform names incorrect 🔧
- Improves reliability of automated formatting in CI and developer workflows 🤖
- Helps keep documentation cleaner and more accurate with fewer manual corrections 📝