### PR TITLE
Skip Markdown symlinks in Prettier formatting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -224,9 +224,9 @@ runs:
           npx prettier --write --list-different --print-width 120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs "**/*.sh"
         fi
         # Handle Markdown separately
-        find . -name "*.md" ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
+        find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
         if [ -d "./docs" ]; then
-          find ./docs -name "*.md" ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
+          find ./docs -name "*.md" -type f ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
         fi
         echo "::endgroup::"
       shell: bash

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.20"
+__version__ = "0.2.21"

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -26,9 +26,9 @@ if find . -name "*.sh" -type f | grep -q .; then
     npx prettier --write --list-different --print-width 120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs "**/*.sh"
 fi
 # Handle Markdown separately
-find . -name "*.md" ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
+find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
 if [ -d "./docs" ]; then
-    find ./docs -name "*.md" ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
+    find ./docs -name "*.md" -type f ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
 fi
 """
 CODESPELL = [

--- a/tests/test_format_code.py
+++ b/tests/test_format_code.py
@@ -19,6 +19,12 @@ def test_format_commands_match_action_yml():
         assert arg == "*" or arg in text, f"codespell arg not in action.yml: {arg}"
 
 
+def test_markdown_prettier_skips_symlinks():
+    """Test Markdown formatting only targets regular files because Prettier rejects explicit symlink paths."""
+    assert 'find . -name "*.md" -type f' in format_code.PRETTIER
+    assert 'find ./docs -name "*.md" -type f' in format_code.PRETTIER
+
+
 @patch("actions.format_code.subprocess.run")
 def test_format_main_runs_all_formatters(mock_run, monkeypatch):
     """Test format CLI runs every formatter by default and respects INPUTS_* opt-outs."""


### PR DESCRIPTION
## Summary
- restrict Markdown Prettier passes to regular files so symlinked AGENTS/CLAUDE guide files are not passed explicitly to Prettier
- keep the packaged format-code command mirror aligned with action.yml
- bump package version to 0.2.21

## Validation
- PYTHONPATH=. pytest -q tests/test_format_code.py tests/test_cli_commands.py tests/test_init.py
- ruff check actions/__init__.py actions/format_code.py tests/test_format_code.py
- ruff format actions/__init__.py actions/format_code.py tests/test_format_code.py
- npx prettier --check action.yml
- verified find selects AGENTS.md and skips symlinked CLAUDE.md

Deleted: symlinked Markdown paths from the Prettier input set by targeting regular files only.

Fixes the Prettier failure seen in ultralytics/ultralytics#25039.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Markdown formatting reliability by ensuring Prettier only processes regular `.md` files, avoiding failures on symlinks 🔧

### 📊 Key Changes
- Added `-type f` to Markdown `find` commands in both `action.yml` and `actions/format_code.py` 📝
- Ensures Markdown formatting skips symlinks, which Prettier can reject when passed explicitly 🚫🔗
- Added a regression test to verify Markdown Prettier commands target only regular files ✅
- Bumped package version from `0.2.20` to `0.2.21` 📦

### 🎯 Purpose & Impact
- Makes the formatting action more robust in repositories that contain Markdown symlinks 💪
- Reduces CI formatting failures caused by unsupported symlink handling in Prettier 🚀
- Keeps the GitHub Action implementation and Python helper script aligned for consistent behavior 🔄
- Improves confidence with added test coverage for this edge case 🧪