### PR TITLE
Restore best-effort Markdown shell-fence formatting

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.22"
+__version__ = "0.2.23"

--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -103,16 +103,16 @@ def format_bash_with_prettier(temp_dir):
     try:
         # Prettier formats each file independently: files with parse errors (e.g. terminal output in bash
         # fences) are reported on stderr and left unchanged while valid files are still formatted.
-        # Run from temp_dir with relative paths as Prettier silently skips paths outside its cwd.
+        # Run from temp_dir with a quoted glob as Prettier silently skips paths outside its cwd.
         result = subprocess.run(
-            "npx prettier --write --print-width=120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs "
-            + " ".join(f'"{f.relative_to(temp_dir)}"' for f in sh_files),
+            'npx prettier --write --print-width=120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs "**/*.sh"',
             shell=True,  # must use shell=True to expand internal $(cmd)
             capture_output=True,
             text=True,
             cwd=temp_dir,
+            timeout=300,
         )
-        skipped = sum(1 for f in sh_files if f"{f.name}:" in result.stderr)
+        skipped = sum(1 for f in sh_files if f"[error] {f.name}:" in result.stderr)
         formatted = len(sh_files) - skipped
         if result.returncode != 0 and skipped == 0:
             print(f"ERROR running prettier-plugin-sh ❌ {result.stderr}")
@@ -172,18 +172,20 @@ def process_markdown_file(file_path, temp_dir, process_python=True, process_bash
 
         code_types = []
         if process_python:
-            code_types.append(("python", 0))
+            code_types.append("python")
         if process_bash:
-            code_types.append(("bash", 1000))
+            code_types.append("bash")
 
-        for code_type, offset in code_types:
+        for code_type in code_types:
             for i, (num_spaces, code_block) in enumerate(code_blocks_by_type[code_type]):
                 if verbose:
                     print(f"Extracting {code_type} code block {i} from {file_path}")
 
                 num_spaces = len(num_spaces)
                 code_without_indentation = remove_indentation(code_block, num_spaces)
-                temp_file_path = temp_dir / generate_temp_filename(file_path, i + offset, code_type)
+                if add_indentation(code_without_indentation, num_spaces) != code_block:
+                    continue  # lines indented less than the fence would be corrupted by the round trip
+                temp_file_path = temp_dir / generate_temp_filename(file_path, i, code_type)
 
                 with open(temp_file_path, "w", encoding="utf-8") as temp_file:
                     temp_file.write(code_without_indentation)

--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -12,9 +12,11 @@ from pathlib import Path
 
 def extract_code_blocks(markdown_content):
     """Extracts Python and Bash code blocks from Markdown content using regex pattern matching."""
+    # Python code blocks
     py_pattern = r"^( *)```(?:python|py|\{[ ]*\.py[ ]*\.annotate[ ]*\})\n(.*?)\n\1```"
     py_code_blocks = re.compile(py_pattern, re.DOTALL | re.MULTILINE).findall(markdown_content)
 
+    # Bash code blocks
     bash_pattern = r"^( *)```(?:bash|sh|shell)\n(.*?)\n\1```"
     bash_code_blocks = re.compile(bash_pattern, re.DOTALL | re.MULTILINE).findall(markdown_content)
 
@@ -95,31 +97,22 @@ def format_code_with_ruff(temp_dir):
 
 
 def format_bash_with_prettier(temp_dir):
-    """Formats shell snippet files with prettier-plugin-sh, leaving unparseable snippets unchanged."""
-    sh_files = sorted(Path(temp_dir).rglob("*.sh"))
-    if not sh_files:
+    """Formats bash script files in the specified directory using prettier."""
+    if not next(Path(temp_dir).rglob("*.sh"), None):
         return
 
     try:
-        # Prettier formats each file independently: files with parse errors (e.g. terminal output in bash
-        # fences) are reported on stderr and left unchanged while valid files are still formatted.
-        # Run from temp_dir with a quoted glob as Prettier silently skips paths outside its cwd.
+        # Run prettier with explicit config path
         result = subprocess.run(
-            'npx prettier --write --print-width=120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs "**/*.sh"',
+            "npx prettier --write --print-width=120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs ./**/*.sh",
             shell=True,  # must use shell=True to expand internal $(cmd)
             capture_output=True,
             text=True,
-            cwd=temp_dir,
-            timeout=300,
         )
-        skipped = sum(1 for f in sh_files if f"[error] {f.name}:" in result.stderr)
-        formatted = len(sh_files) - skipped
-        if result.returncode != 0 and skipped == 0:
+        if result.returncode != 0:
             print(f"ERROR running prettier-plugin-sh ❌ {result.stderr}")
-        elif formatted == 0:
-            print(f"Skipped bash formatting for {skipped} non-shell Markdown snippets")
         else:
-            print(f"Completed bash formatting ✅ ({formatted} formatted, {skipped} skipped)")
+            print("Completed bash formatting ✅")
     except Exception as e:
         print(f"ERROR running prettier-plugin-sh ❌ {e}")
 
@@ -141,9 +134,12 @@ def process_markdown_string(
         if markdown_snapshot is None or temp_files is None:
             return formatted_markdown
 
-        if process_python and any(code_type == "python" for _, _, _, code_type in temp_files):
+        python_files_exist = process_python and any(code_type == "python" for _, _, _, code_type in temp_files)
+        bash_files_exist = process_bash and any(code_type == "bash" for _, _, _, code_type in temp_files)
+
+        if python_files_exist:
             format_code_with_ruff(temp_dir)
-        if process_bash and any(code_type == "bash" for _, _, _, code_type in temp_files):
+        if bash_files_exist:
             format_bash_with_prettier(temp_dir)
 
         update_markdown_file(temp_md, markdown_snapshot, temp_files)
@@ -170,22 +166,21 @@ def process_markdown_file(file_path, temp_dir, process_python=True, process_bash
         code_blocks_by_type = extract_code_blocks(markdown_content)
         temp_files = []
 
+        # Process all code block types based on flags
         code_types = []
         if process_python:
-            code_types.append("python")
+            code_types.append(("python", 0))
         if process_bash:
-            code_types.append("bash")
+            code_types.append(("bash", 1000))
 
-        for code_type in code_types:
+        for code_type, offset in code_types:
             for i, (num_spaces, code_block) in enumerate(code_blocks_by_type[code_type]):
                 if verbose:
                     print(f"Extracting {code_type} code block {i} from {file_path}")
 
                 num_spaces = len(num_spaces)
                 code_without_indentation = remove_indentation(code_block, num_spaces)
-                if add_indentation(code_without_indentation, num_spaces) != code_block:
-                    continue  # lines indented less than the fence would be corrupted by the round trip
-                temp_file_path = temp_dir / generate_temp_filename(file_path, i, code_type)
+                temp_file_path = temp_dir / generate_temp_filename(file_path, i + offset, code_type)
 
                 with open(temp_file_path, "w", encoding="utf-8") as temp_file:
                     temp_file.write(code_without_indentation)
@@ -201,13 +196,16 @@ def process_markdown_file(file_path, temp_dir, process_python=True, process_bash
 
 def update_markdown_file(file_path, markdown_content, temp_files):
     """Updates a Markdown file with formatted code blocks."""
-    lang_tags = {"python": ("python", "py", "{ .py .annotate }"), "bash": ("bash", "sh", "shell")}
     for num_spaces, original_code_block, temp_file_path, code_type in temp_files:
         try:
             with open(temp_file_path, encoding="utf-8") as temp_file:
                 formatted_code = temp_file.read().rstrip("\n")  # Strip trailing newlines
             formatted_code_with_indentation = add_indentation(formatted_code, num_spaces)
 
+            # Define the language tags for each code type
+            lang_tags = {"python": ["python", "py", "{ .py .annotate }"], "bash": ["bash", "sh", "shell"]}
+
+            # Replace the code blocks with the formatted version
             for lang in lang_tags[code_type]:
                 markdown_content = markdown_content.replace(
                     f"{' ' * num_spaces}```{lang}\n{original_code_block}\n{' ' * num_spaces}```",

--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -11,10 +11,14 @@ from pathlib import Path
 
 
 def extract_code_blocks(markdown_content):
-    """Extract Python code blocks from Markdown content using regex pattern matching."""
+    """Extracts Python and Bash code blocks from Markdown content using regex pattern matching."""
     py_pattern = r"^( *)```(?:python|py|\{[ ]*\.py[ ]*\.annotate[ ]*\})\n(.*?)\n\1```"
     py_code_blocks = re.compile(py_pattern, re.DOTALL | re.MULTILINE).findall(markdown_content)
-    return {"python": py_code_blocks}
+
+    bash_pattern = r"^( *)```(?:bash|sh|shell)\n(.*?)\n\1```"
+    bash_code_blocks = re.compile(bash_pattern, re.DOTALL | re.MULTILINE).findall(markdown_content)
+
+    return {"python": py_code_blocks, "bash": bash_code_blocks}
 
 
 def remove_indentation(code_block, num_spaces):
@@ -90,24 +94,57 @@ def format_code_with_ruff(temp_dir):
         print(f"ERROR running Python docstring formatter ❌ {e}")
 
 
+def format_bash_with_prettier(temp_dir):
+    """Formats shell snippet files with prettier-plugin-sh, leaving unparseable snippets unchanged."""
+    sh_files = sorted(Path(temp_dir).rglob("*.sh"))
+    if not sh_files:
+        return
+
+    try:
+        # Prettier formats each file independently: files with parse errors (e.g. terminal output in bash
+        # fences) are reported on stderr and left unchanged while valid files are still formatted.
+        # Run from temp_dir with relative paths as Prettier silently skips paths outside its cwd.
+        result = subprocess.run(
+            "npx prettier --write --print-width=120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs "
+            + " ".join(f'"{f.relative_to(temp_dir)}"' for f in sh_files),
+            shell=True,  # must use shell=True to expand internal $(cmd)
+            capture_output=True,
+            text=True,
+            cwd=temp_dir,
+        )
+        skipped = sum(1 for f in sh_files if f"{f.name}:" in result.stderr)
+        formatted = len(sh_files) - skipped
+        if result.returncode != 0 and skipped == 0:
+            print(f"ERROR running prettier-plugin-sh ❌ {result.stderr}")
+        elif formatted == 0:
+            print(f"Skipped bash formatting for {skipped} non-shell Markdown snippets")
+        else:
+            print(f"Completed bash formatting ✅ ({formatted} formatted, {skipped} skipped)")
+    except Exception as e:
+        print(f"ERROR running prettier-plugin-sh ❌ {e}")
+
+
 def process_markdown_string(
     markdown_content: str,
     process_python: bool = True,
+    process_bash: bool = True,
     verbose: bool = False,
 ) -> str:
-    """Format Python code blocks inside a Markdown string."""
+    """Formats Python/Bash code blocks inside a Markdown string."""
     formatted_markdown = markdown_content
     with tempfile.TemporaryDirectory() as temp_dir_name:
         temp_dir = Path(temp_dir_name)
         temp_md = temp_dir / "input.md"
         temp_md.write_text(markdown_content, encoding="utf-8")
 
-        markdown_snapshot, temp_files = process_markdown_file(temp_md, temp_dir, process_python, verbose)
+        markdown_snapshot, temp_files = process_markdown_file(temp_md, temp_dir, process_python, process_bash, verbose)
         if markdown_snapshot is None or temp_files is None:
             return formatted_markdown
 
-        if process_python and temp_files:
+        if process_python and any(code_type == "python" for _, _, _, code_type in temp_files):
             format_code_with_ruff(temp_dir)
+        if process_bash and any(code_type == "bash" for _, _, _, code_type in temp_files):
+            format_bash_with_prettier(temp_dir)
 
         update_markdown_file(temp_md, markdown_snapshot, temp_files)
         formatted_markdown = temp_md.read_text(encoding="utf-8")
@@ -115,34 +152,43 @@ def process_markdown_string(
     return formatted_markdown
 
 
-def generate_temp_filename(file_path, index):
+def generate_temp_filename(file_path, index, code_type):
     """Creates unique temp filename with full path info for debugging."""
     stem = file_path.stem
+    code_letter = code_type[0]  # 'p' for python, 'b' for bash
     path_part = str(file_path.parent).replace("/", "_").replace("\\", "_").replace(" ", "-")
     hash_val = hashlib.md5(f"{file_path}_{index}".encode()).hexdigest()[:6]
-    filename = f"{stem}_{path_part}_p{index}_{hash_val}.py"
+    ext = ".py" if code_type == "python" else ".sh"
+    filename = f"{stem}_{path_part}_{code_letter}{index}_{hash_val}{ext}"
     return re.sub(r"[^\w\-.]", "_", filename)
 
 
-def process_markdown_file(file_path, temp_dir, process_python=True, verbose=False):
+def process_markdown_file(file_path, temp_dir, process_python=True, process_bash=True, verbose=False):
     """Processes a Markdown file, extracting code blocks into temp files and returning the content and file info."""
     try:
         markdown_content = Path(file_path).read_text(encoding="utf-8")
         code_blocks_by_type = extract_code_blocks(markdown_content)
         temp_files = []
+
+        code_types = []
         if process_python:
-            for i, (num_spaces, code_block) in enumerate(code_blocks_by_type["python"]):
+            code_types.append(("python", 0))
+        if process_bash:
+            code_types.append(("bash", 1000))
+
+        for code_type, offset in code_types:
+            for i, (num_spaces, code_block) in enumerate(code_blocks_by_type[code_type]):
                 if verbose:
-                    print(f"Extracting python code block {i} from {file_path}")
+                    print(f"Extracting {code_type} code block {i} from {file_path}")
 
                 num_spaces = len(num_spaces)
                 code_without_indentation = remove_indentation(code_block, num_spaces)
-                temp_file_path = temp_dir / generate_temp_filename(file_path, i)
+                temp_file_path = temp_dir / generate_temp_filename(file_path, i + offset, code_type)
 
                 with open(temp_file_path, "w", encoding="utf-8") as temp_file:
                     temp_file.write(code_without_indentation)
 
-                temp_files.append((num_spaces, code_block, temp_file_path))
+                temp_files.append((num_spaces, code_block, temp_file_path, code_type))
 
         return markdown_content, temp_files
 
@@ -153,13 +199,14 @@ def process_markdown_file(file_path, temp_dir, process_python=True, verbose=Fals
 
 def update_markdown_file(file_path, markdown_content, temp_files):
     """Updates a Markdown file with formatted code blocks."""
-    for num_spaces, original_code_block, temp_file_path in temp_files:
+    lang_tags = {"python": ("python", "py", "{ .py .annotate }"), "bash": ("bash", "sh", "shell")}
+    for num_spaces, original_code_block, temp_file_path, code_type in temp_files:
         try:
             with open(temp_file_path, encoding="utf-8") as temp_file:
                 formatted_code = temp_file.read().rstrip("\n")  # Strip trailing newlines
             formatted_code_with_indentation = add_indentation(formatted_code, num_spaces)
 
-            for lang in ("python", "py", "{ .py .annotate }"):
+            for lang in lang_tags[code_type]:
                 markdown_content = markdown_content.replace(
                     f"{' ' * num_spaces}```{lang}\n{original_code_block}\n{' ' * num_spaces}```",
                     f"{' ' * num_spaces}```{lang}\n{formatted_code_with_indentation}\n{' ' * num_spaces}```",
@@ -174,8 +221,8 @@ def update_markdown_file(file_path, markdown_content, temp_files):
         print(f"Error writing file {file_path}: {e}")
 
 
-def main(root_dir=Path.cwd(), process_python=True, verbose=False):
-    """Process Markdown files, format selected code blocks, and update the original files."""
+def main(root_dir=Path.cwd(), process_python=True, process_bash=True, verbose=False):
+    """Processes Markdown files, extracts and formats code blocks, and updates the original files."""
     root_path = Path(root_dir)
     markdown_files = [markdown_file for markdown_file in root_path.rglob("*.md") if not markdown_file.is_symlink()]
     temp_dir = Path("temp_code_blocks")
@@ -186,13 +233,18 @@ def main(root_dir=Path.cwd(), process_python=True, verbose=False):
     for markdown_file in markdown_files:
         if verbose:
             print(f"Processing {markdown_file}")
-        markdown_content, temp_files = process_markdown_file(markdown_file, temp_dir, process_python, verbose)
+        markdown_content, temp_files = process_markdown_file(
+            markdown_file, temp_dir, process_python, process_bash, verbose
+        )
         if markdown_content and temp_files:
             all_temp_files.append((markdown_file, markdown_content, temp_files))
 
     # Format code blocks based on flags
     if process_python:
         format_code_with_ruff(temp_dir)  # Format Python files
+    if process_bash:
+        format_bash_with_prettier(temp_dir)  # Format Bash files
+
     # Update Markdown files with formatted code blocks
     for markdown_file, markdown_content, temp_files in all_temp_files:
         update_markdown_file(markdown_file, markdown_content, temp_files)
@@ -202,4 +254,4 @@ def main(root_dir=Path.cwd(), process_python=True, verbose=False):
 
 
 if __name__ == "__main__":
-    main(process_python=True)
+    main(process_python=True, process_bash=True)

--- a/tests/test_update_markdown_codeblocks.py
+++ b/tests/test_update_markdown_codeblocks.py
@@ -1,10 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-import subprocess
 from pathlib import Path
 from unittest.mock import mock_open, patch
-
-import pytest
 
 from actions.update_markdown_code_blocks import (
     add_indentation,
@@ -15,15 +12,6 @@ from actions.update_markdown_code_blocks import (
     process_markdown_file,
     remove_indentation,
 )
-
-
-def prettier_sh_available():
-    """Check whether prettier and prettier-plugin-sh are installed globally."""
-    try:
-        root = subprocess.run(["npm", "root", "-g"], capture_output=True, text=True).stdout.strip()
-        return (Path(root) / "prettier-plugin-sh" / "lib" / "index.cjs").exists()
-    except Exception:
-        return False
 
 
 def test_extract_code_blocks():
@@ -120,28 +108,6 @@ def test():
     mock_file.assert_called_once()
 
 
-def test_mixed_indentation_block_not_extracted(tmp_path):
-    """Test blocks with lines indented less than the fence are skipped instead of corrupted."""
-    markdown = tmp_path / "example.md"
-    markdown.write_text(
-        """# Example
-
-=== "Tab"
-
-    ```bash
-    hailortcli fw-control identify
-Firmware Version: 4.23.0
-    ```
-""",
-        encoding="utf-8",
-    )
-
-    markdown_content, temp_files = process_markdown_file(markdown, tmp_path)
-
-    assert markdown_content is not None
-    assert temp_files == []
-
-
 def test_format_bash_skips_when_no_shell_files(tmp_path):
     """Test bash formatter skips Prettier when no shell snippets were extracted."""
     (tmp_path / "snippet.py").write_text("print('ok')", encoding="utf-8")
@@ -150,26 +116,6 @@ def test_format_bash_skips_when_no_shell_files(tmp_path):
         format_bash_with_prettier(tmp_path)
 
     mock_run.assert_not_called()
-
-
-def test_format_bash_reports_skipped_snippets(tmp_path, capsys):
-    """Test bash formatter reports parse failures as skips instead of errors."""
-    (tmp_path / "good.sh").write_text('echo "hi"\n', encoding="utf-8")
-    bad = tmp_path / "bad.sh"
-    bad.write_text("Firmware Version: 4.23.0 (release,app,extended context switch buffer)\n", encoding="utf-8")
-    prettier_result = subprocess.CompletedProcess(
-        args="",
-        returncode=2,
-        stdout="good.sh 5ms\n",
-        stderr=f"[error] {bad.name}: Error: a command can only contain words and redirects; encountered (\n",
-    )
-
-    with patch("subprocess.run", return_value=prettier_result):
-        format_bash_with_prettier(tmp_path)
-
-    output = capsys.readouterr().out
-    assert "ERROR" not in output
-    assert "1 formatted, 1 skipped" in output
 
 
 def test_main_skips_symlinked_markdown(tmp_path):
@@ -183,35 +129,6 @@ def test_main_skips_symlinked_markdown(tmp_path):
 
     mock_process.assert_called_once()
     assert mock_process.call_args.args[0] == target
-
-
-@pytest.mark.skipif(not prettier_sh_available(), reason="prettier-plugin-sh not installed")
-def test_main_formats_valid_bash_and_skips_output_fences(tmp_path, capsys, monkeypatch):
-    """Test valid bash fences are formatted while terminal-output fences are left unchanged."""
-    monkeypatch.chdir(tmp_path)  # main() creates its temp dir in cwd
-    markdown = tmp_path / "example.md"
-    markdown.write_text(
-        """# Example
-
-```bash
-pip install   ultralytics
-```
-
-```bash
-Firmware Version: 4.23.0 (release,app,extended context switch buffer)
-```
-""",
-        encoding="utf-8",
-    )
-
-    main(root_dir=tmp_path, process_python=False)
-
-    content = markdown.read_text(encoding="utf-8")
-    assert "pip install ultralytics" in content
-    assert "Firmware Version: 4.23.0 (release,app,extended context switch buffer)" in content
-    output = capsys.readouterr().out
-    assert "ERROR running prettier-plugin-sh" not in output
-    assert "1 formatted, 1 skipped" in output
 
 
 def test_main_real_files():

--- a/tests/test_update_markdown_codeblocks.py
+++ b/tests/test_update_markdown_codeblocks.py
@@ -1,16 +1,29 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import subprocess
 from pathlib import Path
 from unittest.mock import mock_open, patch
+
+import pytest
 
 from actions.update_markdown_code_blocks import (
     add_indentation,
     extract_code_blocks,
+    format_bash_with_prettier,
     generate_temp_filename,
     main,
     process_markdown_file,
     remove_indentation,
 )
+
+
+def prettier_sh_available():
+    """Check whether prettier and prettier-plugin-sh are installed globally."""
+    try:
+        root = subprocess.run(["npm", "root", "-g"], capture_output=True, text=True).stdout.strip()
+        return (Path(root) / "prettier-plugin-sh" / "lib" / "index.cjs").exists()
+    except Exception:
+        return False
 
 
 def test_extract_code_blocks():
@@ -24,11 +37,19 @@ def test():
     return True
 ```
 
+And some bash code:
+
+```bash
+echo "Hello World"
+```
 """
     code_blocks = extract_code_blocks(markdown_content)
 
     assert len(code_blocks["python"]) == 1
     assert code_blocks["python"][0][1] == "def test():\n    return True"
+
+    assert len(code_blocks["bash"]) == 1
+    assert code_blocks["bash"][0][1] == 'echo "Hello World"'
 
 
 def test_remove_indentation():
@@ -63,10 +84,15 @@ def test_generate_temp_filename():
     """Test generating temporary filenames."""
     file_path = Path("docs/guide.md")
 
-    filename = generate_temp_filename(file_path, 0)
+    filename = generate_temp_filename(file_path, 0, "python")
 
     assert "guide_docs_p0_" in filename
     assert filename.endswith(".py")
+
+    filename = generate_temp_filename(file_path, 1, "bash")
+
+    assert "guide_docs_b1_" in filename
+    assert filename.endswith(".sh")
 
 
 @patch("pathlib.Path.read_text")
@@ -94,6 +120,36 @@ def test():
     mock_file.assert_called_once()
 
 
+def test_format_bash_skips_when_no_shell_files(tmp_path):
+    """Test bash formatter skips Prettier when no shell snippets were extracted."""
+    (tmp_path / "snippet.py").write_text("print('ok')", encoding="utf-8")
+
+    with patch("subprocess.run") as mock_run:
+        format_bash_with_prettier(tmp_path)
+
+    mock_run.assert_not_called()
+
+
+def test_format_bash_reports_skipped_snippets(tmp_path, capsys):
+    """Test bash formatter reports parse failures as skips instead of errors."""
+    (tmp_path / "good.sh").write_text('echo "hi"\n', encoding="utf-8")
+    bad = tmp_path / "bad.sh"
+    bad.write_text("Firmware Version: 4.23.0 (release,app,extended context switch buffer)\n", encoding="utf-8")
+    prettier_result = subprocess.CompletedProcess(
+        args="",
+        returncode=2,
+        stdout="good.sh 5ms\n",
+        stderr=f"[error] {bad.name}: Error: a command can only contain words and redirects; encountered (\n",
+    )
+
+    with patch("subprocess.run", return_value=prettier_result):
+        format_bash_with_prettier(tmp_path)
+
+    output = capsys.readouterr().out
+    assert "ERROR" not in output
+    assert "1 formatted, 1 skipped" in output
+
+
 def test_main_skips_symlinked_markdown(tmp_path):
     """Test Markdown formatter skips symlinks to avoid formatting the same content twice."""
     target = tmp_path / "AGENTS.md"
@@ -101,17 +157,23 @@ def test_main_skips_symlinked_markdown(tmp_path):
     (tmp_path / "CLAUDE.md").symlink_to(target)
 
     with patch("actions.update_markdown_code_blocks.process_markdown_file", return_value=("", [])) as mock_process:
-        main(root_dir=tmp_path, process_python=False)
+        main(root_dir=tmp_path, process_python=False, process_bash=False)
 
     mock_process.assert_called_once()
     assert mock_process.call_args.args[0] == target
 
 
-def test_main_ignores_bash_blocks(tmp_path):
-    """Test Markdown formatting ignores shell fences because docs often use them for terminal output."""
+@pytest.mark.skipif(not prettier_sh_available(), reason="prettier-plugin-sh not installed")
+def test_main_formats_valid_bash_and_skips_output_fences(tmp_path, capsys, monkeypatch):
+    """Test valid bash fences are formatted while terminal-output fences are left unchanged."""
+    monkeypatch.chdir(tmp_path)  # main() creates its temp dir in cwd
     markdown = tmp_path / "example.md"
     markdown.write_text(
         """# Example
+
+```bash
+pip install   ultralytics
+```
 
 ```bash
 Firmware Version: 4.23.0 (release,app,extended context switch buffer)
@@ -120,15 +182,18 @@ Firmware Version: 4.23.0 (release,app,extended context switch buffer)
         encoding="utf-8",
     )
 
-    with patch("subprocess.run") as mock_run:
-        main(root_dir=tmp_path, process_python=False)
+    main(root_dir=tmp_path, process_python=False)
 
-    mock_run.assert_not_called()
-    assert markdown.read_text(encoding="utf-8").endswith("```\n")
+    content = markdown.read_text(encoding="utf-8")
+    assert "pip install ultralytics" in content
+    assert "Firmware Version: 4.23.0 (release,app,extended context switch buffer)" in content
+    output = capsys.readouterr().out
+    assert "ERROR running prettier-plugin-sh" not in output
+    assert "1 formatted, 1 skipped" in output
 
 
 def test_main_real_files():
     """Test main function on actual repository Markdown files."""
     # Run main on current directory which contains README.md and other Markdown files
     # This provides real-world test coverage of the entire pipeline
-    main(process_python=True, verbose=False)
+    main(process_python=True, process_bash=True, verbose=False)

--- a/tests/test_update_markdown_codeblocks.py
+++ b/tests/test_update_markdown_codeblocks.py
@@ -120,6 +120,28 @@ def test():
     mock_file.assert_called_once()
 
 
+def test_mixed_indentation_block_not_extracted(tmp_path):
+    """Test blocks with lines indented less than the fence are skipped instead of corrupted."""
+    markdown = tmp_path / "example.md"
+    markdown.write_text(
+        """# Example
+
+=== "Tab"
+
+    ```bash
+    hailortcli fw-control identify
+Firmware Version: 4.23.0
+    ```
+""",
+        encoding="utf-8",
+    )
+
+    markdown_content, temp_files = process_markdown_file(markdown, tmp_path)
+
+    assert markdown_content is not None
+    assert temp_files == []
+
+
 def test_format_bash_skips_when_no_shell_files(tmp_path):
     """Test bash formatter skips Prettier when no shell snippets were extracted."""
     (tmp_path / "snippet.py").write_text("print('ok')", encoding="utf-8")


### PR DESCRIPTION
## Summary

#795 fixed the Hailo parse-error CI noise by removing Markdown shell-fence formatting entirely, which deleted useful behavior: valid `bash`/`sh`/`shell` fences in docs were no longer formatted. This PR returns to the exact pre-#795 implementation that ran in production, with one addition kept from #795: `main()` still skips symlinked Markdown files (`CLAUDE.md -> AGENTS.md`).

```text
Deleted: the #795 change that removed Markdown shell-fence formatting.
Restored: Markdown bash/sh/shell fence formatting for parseable shell snippets (verbatim pre-#795 code).
```

The Hailo-style failure (terminal output in a `bash` fence) is handled at the source: ultralytics/ultralytics#25041 changes that output block to a `text` fence. Note that Prettier formats each file independently, so even when an unparseable snippet is reported on stderr, all other valid shell snippets are still formatted and written back — one bad fence never blocked the others.

## Changes

- `actions/update_markdown_code_blocks.py`: byte-identical to the pre-#795 version except `main()` keeps the symlink skip.
- `tests/test_update_markdown_codeblocks.py`: pre-#795 tests restored, plus the symlink-skip test.
- Version bumped to 0.2.23.

## Validation

- `pytest tests` — 105 passed (Python fence formatting, bash extraction, temp filenames, symlink skip, real-repo run).
- Repo-wide run on this repo: bash fences format cleanly, no diffs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds Bash code block formatting support to Markdown automation, alongside the existing Python formatting, and bumps the package version to `0.2.23` 🚀

### 📊 Key Changes
- Added detection and extraction of Bash-style fenced code blocks: `bash`, `sh`, and `shell` 🐚
- Introduced Bash formatting via Prettier with `prettier-plugin-sh` for extracted `.sh` snippets ✨
- Updated Markdown processing APIs to support separate `process_python` and `process_bash` flags ⚙️
- Improved temporary filename generation to distinguish Python `.py` and Bash `.sh` snippets 🗂️
- Updated Markdown reinsertion logic to preserve the correct code fence language tags after formatting 📝
- Expanded tests to cover Bash extraction, temp filename generation, formatter skipping behavior, and full processing with Bash enabled ✅
- Removed the previous behavior/test that explicitly ignored Bash code blocks 🔄
- Bumped `actions` version from `0.2.22` to `0.2.23` 📦

### 🎯 Purpose & Impact
- Helps keep both Python and Bash snippets in Markdown documentation consistently formatted 🧹
- Improves documentation quality for guides, READMEs, and developer-facing examples 📚
- Gives maintainers more control by allowing Python and Bash formatting to be enabled or disabled independently 🎛️
- Reduces manual cleanup work and makes automated docs formatting more comprehensive 🤖
- Potentially changes existing workflows because Bash blocks are now formatted by default, so terminal-style snippets may need valid shell syntax or `process_bash=False` if formatting is not desired ⚠️