### PR TITLE
Unify agent usage telemetry into a single formatter and turns/tools format

### DIFF
--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -7,7 +7,6 @@ import os
 import re
 import time
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
@@ -43,6 +42,7 @@ MODEL_COSTS = {  # (input, output) per 1M tokens
     "claude-opus-4-5-20251101": (5.00, 25.00),
     "claude-opus-4-6": (5.00, 25.00),
     "claude-opus-4-7": (5.00, 25.00),
+    "claude-sonnet-5": (2.00, 10.00),  # introductory pricing, matches ultralytics/assistant MODELS registry
 }
 SYSTEM_PROMPT_ADDITION = """Guidance:
   - Ultralytics Branding: Use YOLO11, YOLO26, etc., not YOLOv11, YOLOv26 (only older versions like YOLOv10 have a v).
@@ -233,8 +233,8 @@ def _add_openai_usage(total_usage: dict | None, response_json: dict) -> dict | N
 def _normalize_usage_tokens(usage: dict) -> tuple[int, int]:
     """Return (input_tokens, cached_tokens) for OpenAI Responses or Anthropic Messages usage shapes.
 
-    Anthropic reports cache reads/writes outside input_tokens, so both fold back into the input total and reads count as
-    cached — the same normalization ultralytics/assistant applies, keeping cross-repo telemetry identical.
+    Anthropic reports cache reads/writes outside input_tokens, so both fold back into the input total and reads count
+    as cached — the same normalization ultralytics/assistant applies, keeping cross-repo telemetry identical.
     """
     cache_read = usage.get("cache_read_input_tokens", 0)
     input_tokens = usage.get("input_tokens", 0) + cache_read + usage.get("cache_creation_input_tokens", 0)
@@ -414,15 +414,14 @@ def get_agent_response(
 
         if not previous_response_id:
             raise RuntimeError("OpenAI response did not include an id for server-managed continuation")
-        if max_cost and total_usage and _openai_usage_cost(total_usage, model) >= max_cost:
+        if max_cost and _openai_usage_cost(total_usage, model) >= max_cost:
             print(f"Agent cost budget ${max_cost:.2f} reached; skipping remaining tool turns")
             next_input = [  # pending calls still need outputs for the chained synthesis request to be valid
                 {"type": "function_call_output", "call_id": call.get("call_id"), "output": "Tool budget exhausted."}
                 for call in function_calls
             ]
             break
-        with ThreadPoolExecutor(max_workers=min(8, len(function_calls))) as pool:  # I/O-bound GitHub/API reads
-            next_input = list(pool.map(lambda call: _handle_function_call(call, tool_handlers), function_calls))
+        next_input = [_handle_function_call(call, tool_handlers) for call in function_calls]
 
     final_instruction = {
         "role": "user",

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -233,8 +233,8 @@ def _add_openai_usage(total_usage: dict | None, response_json: dict) -> dict | N
 def _normalize_usage_tokens(usage: dict) -> tuple[int, int]:
     """Return (input_tokens, cached_tokens) for OpenAI Responses or Anthropic Messages usage shapes.
 
-    Anthropic reports cache reads/writes outside input_tokens, so both fold back into the input total and reads count
-    as cached — the same normalization ultralytics/assistant applies, keeping cross-repo telemetry identical.
+    Anthropic reports cache reads/writes outside input_tokens, so both fold back into the input total and reads count as
+    cached — the same normalization ultralytics/assistant applies, keeping cross-repo telemetry identical.
     """
     cache_read = usage.get("cache_read_input_tokens", 0)
     input_tokens = usage.get("input_tokens", 0) + cache_read + usage.get("cache_creation_input_tokens", 0)

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -200,7 +200,7 @@ def _openai_response_text(response_json: dict) -> str:
 def _response_tool_calls(output_items: list[dict]) -> list[str]:
     """Name Responses API tool-call output items, including hosted tools (e.g. web_search_call -> web_search)."""
     return [
-        item.get("name") or (item.get("type") or "").removesuffix("_call")
+        item.get("name") or (item.get("type") or "")[: -len("_call")]  # removesuffix needs py3.9+, repo floor is 3.8
         for item in output_items
         if (item.get("type") or "").endswith("_call")
     ]
@@ -265,9 +265,10 @@ def _post_openai_response(
             success = r.status_code == 200
             print(f"{'✓' if success else '✗'} POST {url} → {r.status_code} ({elapsed:.1f}s)")
 
-            if attempt < retries and r.status_code >= 500:
-                print(f"Retrying {r.status_code} in {2**attempt}s (attempt {attempt + 1}/{retries + 1})...")
-                time.sleep(2**attempt)
+            if attempt < retries and (r.status_code >= 500 or r.status_code == 429):
+                wait = 10 * 2**attempt if r.status_code == 429 else 2**attempt  # rate limits need longer backoff
+                print(f"Retrying {r.status_code} in {wait}s (attempt {attempt + 1}/{retries + 1})...")
+                time.sleep(wait)
                 continue
 
             if r.status_code >= 400:
@@ -504,10 +505,11 @@ def get_response(
             success = r.status_code == 200
             print(f"{'✓' if success else '✗'} POST {url} → {r.status_code} ({elapsed:.1f}s)")
 
-            # Retry server errors
-            if attempt < retries and r.status_code >= 500:
-                print(f"Retrying {r.status_code} in {2**attempt}s (attempt {attempt + 1}/{retries + 1})...")
-                time.sleep(2**attempt)
+            # Retry server errors and rate limits (a 429 rejection executed nothing, so retrying is side-effect free)
+            if attempt < retries and (r.status_code >= 500 or r.status_code == 429):
+                wait = 10 * 2**attempt if r.status_code == 429 else 2**attempt  # rate limits need longer backoff
+                print(f"Retrying {r.status_code} in {wait}s (attempt {attempt + 1}/{retries + 1})...")
+                time.sleep(wait)
                 continue
 
             if r.status_code >= 400:

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -197,9 +197,13 @@ def _openai_response_text(response_json: dict) -> str:
     return content.strip()
 
 
-def _count_response_tool_calls(output_items: list[dict]) -> int:
-    """Count Responses API tool-call output items, including hosted tools."""
-    return sum(1 for item in output_items if (item.get("type") or "").endswith("_call"))
+def _response_tool_calls(output_items: list[dict]) -> list[str]:
+    """Name Responses API tool-call output items, including hosted tools (e.g. web_search_call -> web_search)."""
+    return [
+        item.get("name") or (item.get("type") or "").removesuffix("_call")
+        for item in output_items
+        if (item.get("type") or "").endswith("_call")
+    ]
 
 
 def _add_openai_usage(total_usage: dict | None, response_json: dict) -> dict | None:
@@ -246,7 +250,7 @@ def _print_openai_usage(response_json: dict, model: str, elapsed: float, metadat
         if thinking_tokens:
             token_str += f" (+{thinking_tokens} thinking)"
         metadata = f", {metadata}" if metadata else ""
-        print(f"{model} ({token_str} = {input_tokens + output_tokens} tokens, ${cost:.5f}, {elapsed:.1f}s{metadata})")
+        print(f"{model} {token_str} = {input_tokens + output_tokens} tokens, ${cost:.5f}, {elapsed:.1f}s{metadata}")
 
 
 def _post_openai_response(
@@ -381,18 +385,18 @@ def get_agent_response(
         total_usage = _add_openai_usage(total_usage, response_json)
         previous_response_id = response_json.get("id")
         output_items = response_json.get("output", [])
-        turn_tool_calls = _count_response_tool_calls(output_items)
-        tool_calls += turn_tool_calls
-        _print_openai_usage(response_json, model, elapsed, f"turn {turn + 1}/{max_turns}, tools {turn_tool_calls}")
+        turn_calls = _response_tool_calls(output_items)
+        tool_calls += len(turn_calls)
+        tools_str = f"{len(turn_calls)} tools" + (f" ({', '.join(turn_calls)})" if turn_calls else "")
+        _print_openai_usage(response_json, model, elapsed, f"turn {turn + 1}/{max_turns}, {tools_str}")
         function_calls = [item for item in output_items if item.get("type") == "function_call"]
 
         if not function_calls:
             _print_openai_usage(
-                {"usage": total_usage}, model, total_elapsed, f"agent total, turns {turn + 1}, tools {tool_calls}"
+                {"usage": total_usage}, model, total_elapsed, f"agent total, {turn + 1} turns, {tool_calls} tools"
             )
             return _finalize_response_content(response_json, text_format)
 
-        print(f"Agent tool turn {turn + 1}: {', '.join(c.get('name', 'unknown') for c in function_calls)}")
         if not previous_response_id:
             raise RuntimeError("OpenAI response did not include an id for server-managed continuation")
         if max_cost and _openai_usage_cost(total_usage, model) >= max_cost:
@@ -418,9 +422,9 @@ def get_agent_response(
     response_json, elapsed = _post_openai_response(data, headers, max(retries, 2), request_timeout)
     total_elapsed += elapsed
     total_usage = _add_openai_usage(total_usage, response_json)
-    _print_openai_usage(response_json, model, elapsed, f"turn final/{max_turns}, tools 0")
+    _print_openai_usage(response_json, model, elapsed, f"turn final/{max_turns}, 0 tools")
     _print_openai_usage(
-        {"usage": total_usage}, model, total_elapsed, f"agent total, turns {turn + 2}, tools {tool_calls}"
+        {"usage": total_usage}, model, total_elapsed, f"agent total, {turn + 2} turns, {tool_calls} tools"
     )
     return _finalize_response_content(response_json, text_format)
 
@@ -525,15 +529,7 @@ def get_response(
                         content += block.get("text") or ""
                 content = content.strip()
 
-                # Extract usage
-                if usage := response_json.get("usage"):
-                    input_tokens = usage.get("input_tokens", 0)
-                    output_tokens = usage.get("output_tokens", 0)
-                    costs = MODEL_COSTS.get(model, (0.0, 0.0))
-                    cost = (input_tokens * costs[0] + output_tokens * costs[1]) / 1e6
-                    print(
-                        f"{model} ({input_tokens}→{output_tokens} = {input_tokens + output_tokens} tokens, ${cost:.5f}, {elapsed:.1f}s)"
-                    )
+                _print_openai_usage(response_json, model, elapsed)
             else:
                 content = _openai_response_text(response_json)
                 _print_openai_usage(response_json, model, elapsed)

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -7,6 +7,7 @@ import os
 import re
 import time
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
@@ -229,20 +230,30 @@ def _add_openai_usage(total_usage: dict | None, response_json: dict) -> dict | N
     return total_usage
 
 
+def _normalize_usage_tokens(usage: dict) -> tuple[int, int]:
+    """Return (input_tokens, cached_tokens) for OpenAI Responses or Anthropic Messages usage shapes.
+
+    Anthropic reports cache reads/writes outside input_tokens, so both fold back into the input total and reads count
+    as cached — the same normalization ultralytics/assistant applies, keeping cross-repo telemetry identical.
+    """
+    cache_read = usage.get("cache_read_input_tokens", 0)
+    input_tokens = usage.get("input_tokens", 0) + cache_read + usage.get("cache_creation_input_tokens", 0)
+    cached_tokens = (usage.get("input_tokens_details") or {}).get("cached_tokens", 0) or cache_read
+    return input_tokens, cached_tokens
+
+
 def _openai_usage_cost(usage: dict, model: str) -> float:
-    """Compute billed USD cost for a Responses API usage block (cached input billed at 10% of the input rate)."""
+    """Compute billed USD cost for one usage block (cached input billed at 10% of the input rate)."""
     costs = MODEL_COSTS.get(model, (0.0, 0.0))
-    input_tokens = usage.get("input_tokens", 0)
-    cached_tokens = (usage.get("input_tokens_details") or {}).get("cached_tokens", 0)
+    input_tokens, cached_tokens = _normalize_usage_tokens(usage)
     return ((input_tokens - cached_tokens * 0.9) * costs[0] + usage.get("output_tokens", 0) * costs[1]) / 1e6
 
 
 def _print_openai_usage(response_json: dict, model: str, elapsed: float, metadata: str = "") -> None:
-    """Print Responses API token/cost telemetry."""
+    """Print token/cost telemetry for one OpenAI Responses or Anthropic Messages response."""
     if usage := response_json.get("usage"):
-        input_tokens = usage.get("input_tokens", 0)
+        input_tokens, cached_tokens = _normalize_usage_tokens(usage)
         output_tokens = usage.get("output_tokens", 0)
-        cached_tokens = (usage.get("input_tokens_details") or {}).get("cached_tokens", 0)
         thinking_tokens = (usage.get("output_tokens_details") or {}).get("reasoning_tokens", 0)
         cost = _openai_usage_cost(usage, model)
         cached_str = f" ({cached_tokens} cached)" if cached_tokens else ""
@@ -336,9 +347,12 @@ def get_agent_response(
     """Run an iterative OpenAI Responses API agent with application-managed function tools.
 
     max_cost is a USD ceiling across all turns (0 disables); once reached, remaining tool turns are skipped and the
-    agent synthesizes a final answer. Models missing from MODEL_COSTS report zero cost, so only max_turns bounds them.
+    agent synthesizes a final answer. Models missing from MODEL_COSTS disable max_cost loudly; max_turns still bounds.
     """
     model = model or _get_default_model()
+    if max_cost and model not in MODEL_COSTS:
+        print(f"WARNING ⚠️ {model} missing from MODEL_COSTS; max_cost budget disabled (max_turns still applies)")
+        max_cost = 0.0
     if _is_anthropic_model(model):
         print("Anthropic review model selected; falling back to single-shot response without local agent tools")
         return get_response(
@@ -407,7 +421,8 @@ def get_agent_response(
                 for call in function_calls
             ]
             break
-        next_input = [_handle_function_call(call, tool_handlers) for call in function_calls]
+        with ThreadPoolExecutor(max_workers=min(8, len(function_calls))) as pool:  # I/O-bound GitHub/API reads
+            next_input = list(pool.map(lambda call: _handle_function_call(call, tool_handlers), function_calls))
 
     final_instruction = {
         "role": "user",
@@ -557,10 +572,6 @@ def get_response(
                 time.sleep(2**attempt)
                 continue
             raise
-        except requests.exceptions.HTTPError:
-            raise
-
-    return content
 
 
 def get_pr_open_response(repository: str, diff_text: str, title: str, username: str, available_labels: dict) -> dict:

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -233,8 +233,8 @@ def _add_openai_usage(total_usage: dict | None, response_json: dict) -> dict | N
 def _normalize_usage_tokens(usage: dict) -> tuple[int, int]:
     """Return (input_tokens, cached_tokens) for OpenAI Responses or Anthropic Messages usage shapes.
 
-    Anthropic reports cache reads/writes outside input_tokens, so both fold back into the input total and reads count as
-    cached — the same normalization ultralytics/assistant applies, keeping cross-repo telemetry identical.
+    Anthropic reports cache reads/writes outside input_tokens, so both fold back into the input total and reads count
+    as cached — the same normalization ultralytics/assistant applies, keeping cross-repo telemetry identical.
     """
     cache_read = usage.get("cache_read_input_tokens", 0)
     input_tokens = usage.get("input_tokens", 0) + cache_read + usage.get("cache_creation_input_tokens", 0)
@@ -414,7 +414,7 @@ def get_agent_response(
 
         if not previous_response_id:
             raise RuntimeError("OpenAI response did not include an id for server-managed continuation")
-        if max_cost and _openai_usage_cost(total_usage, model) >= max_cost:
+        if max_cost and total_usage and _openai_usage_cost(total_usage, model) >= max_cost:
             print(f"Agent cost budget ${max_cost:.2f} reached; skipping remaining tool turns")
             next_input = [  # pending calls still need outputs for the chained synthesis request to be valid
                 {"type": "function_call_output", "call_id": call.get("call_id"), "output": "Tool budget exhausted."}
@@ -490,9 +490,10 @@ def get_response(
             data = {
                 "model": model,
                 "max_tokens": 8192,
-                "temperature": temperature,
                 "messages": user_messages,
             }
+            if temperature != 1.0:  # 1.0 is the API default; newer Claude models 400 on explicit non-default values
+                data["temperature"] = temperature
             if system_content:
                 data["system"] = system_content
             # Tools (web_search) are not forwarded to Anthropic (caused empty responses with JSON schema)

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import requests
 
 from actions.utils.openai_utils import (
+    MODEL_COSTS,
     OPENAI_MODEL_DEFAULT,
     PR_REVIEW_MODEL_DEFAULT,
     _is_anthropic_model,
@@ -17,9 +18,11 @@ from actions.utils.openai_utils import (
 
 
 def test_default_models():
-    """Test canonical default models."""
+    """Test canonical default models are priced so max_cost budgets stay enforceable."""
     assert OPENAI_MODEL_DEFAULT == "gpt-5.5"
     assert PR_REVIEW_MODEL_DEFAULT == "gpt-5.5"
+    assert OPENAI_MODEL_DEFAULT in MODEL_COSTS  # unpriced models disable max_cost budgets
+    assert PR_REVIEW_MODEL_DEFAULT in MODEL_COSTS
 
 
 def test_is_anthropic_model():
@@ -329,7 +332,12 @@ def test_get_response_anthropic(mock_post):
     mock_response.elapsed.total_seconds.return_value = 1.5
     mock_response.json.return_value = {
         "content": [{"type": "text", "text": "Test response from Claude"}],
-        "usage": {"input_tokens": 50, "output_tokens": 20},
+        "usage": {
+            "input_tokens": 50,
+            "cache_read_input_tokens": 900,
+            "cache_creation_input_tokens": 50,
+            "output_tokens": 20,
+        },
     }
     mock_post.return_value = mock_response
 
@@ -337,9 +345,13 @@ def test_get_response_anthropic(mock_post):
 
     with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=False):
         with patch("actions.utils.openai_utils.ANTHROPIC_API_KEY", "test-key"):
-            result = get_response(messages, check_links=False, model="claude-sonnet-4-6", background=True)
+            with patch("builtins.print") as mock_print:
+                result = get_response(messages, check_links=False, model="claude-sonnet-4-6", background=True)
 
     assert result == "Test response from Claude"
+    printed = "\n".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
+    # Cache reads/writes fold into input and reads count as cached, matching ultralytics/assistant normalization
+    assert "1000 (900 cached)→20 = 1020 tokens, $0.00087" in printed
     mock_post.assert_called_once()
     # Verify Anthropic endpoint was called
     call_args = mock_post.call_args

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -101,6 +101,27 @@ def test_get_response(mock_post):
     mock_post.assert_called_once()
 
 
+@patch("time.sleep")
+@patch("requests.post")
+def test_get_response_retries_rate_limits(mock_post, mock_sleep):
+    """Test a 429 response is retried with a longer backoff than server errors."""
+    limited = MagicMock()
+    limited.status_code = 429
+    limited.elapsed.total_seconds.return_value = 0.1
+    ok = MagicMock()
+    ok.status_code = 200
+    ok.elapsed.total_seconds.return_value = 1.0
+    ok.json.return_value = {"output": [{"type": "message", "content": [{"type": "output_text", "text": "recovered"}]}]}
+    mock_post.side_effect = [limited, ok]
+
+    with patch("actions.utils.openai_utils.OPENAI_API_KEY", "test-key"):
+        result = get_response([{"role": "user", "content": "Hello"}], check_links=False, retries=1)
+
+    assert result == "recovered"
+    assert mock_post.call_count == 2
+    mock_sleep.assert_called_once_with(10)  # 10 * 2**0, not the 2**0 server-error backoff
+
+
 @patch("requests.post")
 @patch("actions.utils.openai_utils.check_links_in_string")
 def test_get_response_with_link_check(mock_check_links, mock_post):

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -7,8 +7,8 @@ import requests
 from actions.utils.openai_utils import (
     OPENAI_MODEL_DEFAULT,
     PR_REVIEW_MODEL_DEFAULT,
-    _count_response_tool_calls,
     _is_anthropic_model,
+    _response_tool_calls,
     get_agent_response,
     get_response,
     get_review_model,
@@ -31,15 +31,15 @@ def test_is_anthropic_model():
     assert _is_anthropic_model("gpt-5-mini-2025-08-07") is False
 
 
-def test_count_response_tool_calls():
-    """Test Responses API tool-call item counting."""
+def test_response_tool_calls():
+    """Test Responses API tool-call item naming, including hosted tools without a name field."""
     output_items = [
-        {"type": "function_call"},
+        {"type": "function_call", "name": "lookup_value"},
         {"type": "web_search_call"},
         {"type": "message"},
         {"type": "function_call_output"},
     ]
-    assert _count_response_tool_calls(output_items) == 2
+    assert _response_tool_calls(output_items) == ["lookup_value", "web_search"]
 
 
 def test_remove_outer_codeblocks():
@@ -212,10 +212,11 @@ def test_get_agent_response_calls_function_tools(mock_post):
         }
     ]
     printed = "\n".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
-    assert "turn 1/6, tools 1" in printed
-    assert "turn 2/6, tools 0" in printed
+    assert "turn 1/6, 1 tools (lookup_value)" in printed
+    assert "turn 2/6, 0 tools" in printed
     assert "30 (12 cached)→12 = 42 tokens, $0.00046" in printed
-    assert "agent total, turns 2, tools 1" in printed
+    assert "agent total, 2 turns, 1 tools" in printed
+    assert "Agent tool turn" not in printed  # tool names live in the per-turn usage line now
 
 
 @patch("requests.post")


### PR DESCRIPTION
## Motivation

Agent/LLM telemetry lines had three divergent formats in this file (OpenAI `_print_openai_usage`, an inline Anthropic usage print, and a separate `Agent tool turn N:` names line), and the metadata read `turns 2, tools 1` instead of natural `2 turns, 1 tools`. This PR unifies them into a single formatter and format, matching the same single-line agent summary being adopted in `ultralytics/assistant` (PR ultralytics/assistant#2776) so both repos' agent logs read identically:

```
gpt-5.5 30 (12 cached)→12 = 42 tokens, $0.00046, 1.0s, turn 1/6, 1 tools (lookup_value)
gpt-5.5 50→7 = 57 tokens, $0.00055, 1.0s, agent total, 2 turns, 1 tools
```

## Changes

- `_print_openai_usage` drops the outer parentheses; metadata now reads `N turns` / `N tools (name_a, name_b)`.
- `_count_response_tool_calls` → `_response_tool_calls`, returning tool-call names (hosted tools derive their name from the item type, e.g. `web_search_call` → `web_search`); counts are `len()` of it.
- Tool names moved into the per-turn usage line, so the separate `Agent tool turn N: ...` print is deleted — and it now covers hosted tools (web_search, etc.) that the old print silently omitted.
- The Anthropic branch reuses `_print_openai_usage` instead of its own inline usage/cost print (identical math: no cached-token details means zero cached discount).

Deleted: the `print(f"Agent tool turn {turn + 1}: ...")` line, the inline Anthropic usage-extraction/cost/print block (8 lines) in `get_response`, and `_count_response_tool_calls` (replaced by `_response_tool_calls`). Net production diff is negative excluding tests.

## Testing

- `pytest tests`: 119 passed (updated assertions cover the new per-turn `1 tools (lookup_value)` line, the `agent total, 2 turns, 1 tools` line, hosted-tool naming, and that no `Agent tool turn` line prints).
- `ruff check`/`ruff format` clean with the repo's action.yml lint flags.

## Follow-up commits

- Fixed a Python 3.8 regression flagged by the automated review: `str.removesuffix` (3.9+) replaced with suffix slicing.
- Cross-ported the rate-limit retry lesson from `ultralytics/assistant`: both HTTP retry gates now also retry 429 responses with a 10x longer backoff (a 429 rejection executed nothing, so the retry is side-effect free). Covered by `test_get_response_retries_rate_limits`.
- Round-1 joint review fix: `_normalize_usage_tokens()` folds Anthropic `cache_read/cache_creation_input_tokens` into the input total (reads count as cached), so Anthropic telemetry/cost match OpenAI's and ultralytics/assistant's normalization exactly. Covered by an updated Anthropic usage test.
- Audit fixes: an unpriced model with `max_cost` set now warns loudly and disables the budget instead of silently never enforcing it (guarded by a new MODEL_COSTS default-model test), and `claude-sonnet-5` is now priced (introductory rate, matching the ultralytics/assistant MODELS registry); deleted the unreachable trailing `return content` and the no-op `except HTTPError: raise` in `get_response`. (A ThreadPoolExecutor parallel-tool-execution experiment was reverted in round-3 review: `get_agent_response` is a public API with no handler thread-safety contract.)
- Round-3 review fixes: `temperature` is omitted from Anthropic payloads when it equals the 1.0 API default — live-verified that current-gen Claude models return 400 for explicit non-default values while 1.0/omission always works.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves AI response utilities with better Claude support, clearer usage/cost tracking, smarter retries, and stronger tests 🚀

### 📊 Key Changes
- Added pricing for `claude-sonnet-5`, aligned with the Ultralytics assistant model registry 💰
- Normalized token usage reporting across OpenAI Responses and Anthropic Messages APIs, including cache read/write tokens 📊
- Improved cost calculation so cached input tokens are handled consistently across providers
- Added retries for `429` rate-limit responses with longer backoff delays ⏳
- Updated agent tool-call telemetry to show tool names, not just counts, for clearer debugging 🛠️
- Added a warning when `max_cost` is used with an unpriced model, since budget enforcement would be disabled ⚠️
- Avoids sending default `temperature=1.0` to Anthropic, preventing errors with newer Claude models ✅
- Expanded tests for model pricing coverage, rate-limit retries, Anthropic cache accounting, and tool-call naming 🧪

### 🎯 Purpose & Impact
- Makes AI automation in `ultralytics/actions` more reliable under rate limits and transient API issues 🔁
- Provides more accurate and consistent usage/cost logs across OpenAI and Anthropic models 📈
- Improves maintainability by aligning telemetry behavior with `ultralytics/assistant`
- Helps developers debug agent workflows faster with clearer per-turn tool information 🔍
- Reduces unexpected failures when using newer Claude models, including `claude-sonnet-5` 🤖