### PR TITLE
Compact agent telemetry: percent cache, thinking-inclusive output, counted tool types

### DIFF
--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -272,7 +272,8 @@ def _print_openai_usage(response_json: dict, model: str, elapsed: float, metadat
             notes.append(f"+{thinking_tokens} thinking")
         note_str = f" ({', '.join(notes)})" if notes else ""
         metadata = f", {metadata}" if metadata else ""
-        print(f"{model}: {input_tokens}→{output_tokens} tokens{note_str}, ${cost:.5f}, {elapsed:.1f}s{metadata}")
+        cost_str = f"${cost:.2f}" if cost == 0 or cost >= 0.01 else f"${cost:.5f}"  # match ultralytics/assistant
+        print(f"{model}: {input_tokens}→{output_tokens} tokens{note_str}, {cost_str}, {elapsed:.1f}s{metadata}")
 
 
 def _post_openai_response(

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -249,19 +249,30 @@ def _openai_usage_cost(usage: dict, model: str) -> float:
     return ((input_tokens - cached_tokens * 0.9) * costs[0] + usage.get("output_tokens", 0) * costs[1]) / 1e6
 
 
+def _format_tool_calls(calls: list[str]) -> str:
+    """Format tool calls with per-type counts: '5 tools (2 lookup_value, 3 web_search)'."""
+    counts = {}
+    for name in calls:
+        counts[name] = counts.get(name, 0) + 1
+    types = ", ".join(f"{n} {name}" if n > 1 else name for name, n in counts.items())
+    return f"{len(calls)} tools" + (f" ({types})" if calls else "")
+
+
 def _print_openai_usage(response_json: dict, model: str, elapsed: float, metadata: str = "") -> None:
-    """Print token/cost telemetry for one OpenAI Responses or Anthropic Messages response."""
+    """Print token/cost telemetry: 'model: 136036→289 tokens (72% cached, +31 thinking), $0.69000, 8.9s'."""
     if usage := response_json.get("usage"):
         input_tokens, cached_tokens = _normalize_usage_tokens(usage)
-        output_tokens = usage.get("output_tokens", 0)
+        output_tokens = usage.get("output_tokens", 0)  # includes thinking, noted in the parenthetical
         thinking_tokens = (usage.get("output_tokens_details") or {}).get("reasoning_tokens", 0)
         cost = _openai_usage_cost(usage, model)
-        cached_str = f" ({cached_tokens} cached)" if cached_tokens else ""
-        token_str = f"{input_tokens}{cached_str}→{output_tokens - thinking_tokens}"
+        notes = []
+        if cached_tokens:
+            notes.append(f"{round(100 * cached_tokens / input_tokens)}% cached")
         if thinking_tokens:
-            token_str += f" (+{thinking_tokens} thinking)"
+            notes.append(f"+{thinking_tokens} thinking")
+        note_str = f" ({', '.join(notes)})" if notes else ""
         metadata = f", {metadata}" if metadata else ""
-        print(f"{model} {token_str} = {input_tokens + output_tokens} tokens, ${cost:.5f}, {elapsed:.1f}s{metadata}")
+        print(f"{model}: {input_tokens}→{output_tokens} tokens{note_str}, ${cost:.5f}, {elapsed:.1f}s{metadata}")
 
 
 def _post_openai_response(
@@ -385,7 +396,7 @@ def get_agent_response(
     if text_format:
         base_data["text"] = text_format
 
-    tool_calls = 0
+    tool_calls = []
     total_elapsed = 0.0
     total_usage = None
     previous_response_id = None
@@ -401,14 +412,18 @@ def get_agent_response(
         previous_response_id = response_json.get("id")
         output_items = response_json.get("output", [])
         turn_calls = _response_tool_calls(output_items)
-        tool_calls += len(turn_calls)
-        tools_str = f"{len(turn_calls)} tools" + (f" ({', '.join(turn_calls)})" if turn_calls else "")
-        _print_openai_usage(response_json, model, elapsed, f"turn {turn + 1}/{max_turns}, {tools_str}")
+        tool_calls += turn_calls
+        _print_openai_usage(
+            response_json, model, elapsed, f"turn {turn + 1}/{max_turns}, {_format_tool_calls(turn_calls)}"
+        )
         function_calls = [item for item in output_items if item.get("type") == "function_call"]
 
         if not function_calls:
             _print_openai_usage(
-                {"usage": total_usage}, model, total_elapsed, f"agent total, {turn + 1} turns, {tool_calls} tools"
+                {"usage": total_usage},
+                model,
+                total_elapsed,
+                f"agent total, {turn + 1} turns, {_format_tool_calls(tool_calls)}",
             )
             return _finalize_response_content(response_json, text_format)
 
@@ -439,7 +454,7 @@ def get_agent_response(
     total_usage = _add_openai_usage(total_usage, response_json)
     _print_openai_usage(response_json, model, elapsed, f"turn final/{max_turns}, 0 tools")
     _print_openai_usage(
-        {"usage": total_usage}, model, total_elapsed, f"agent total, {turn + 2} turns, {tool_calls} tools"
+        {"usage": total_usage}, model, total_elapsed, f"agent total, {turn + 2} turns, {_format_tool_calls(tool_calls)}"
     )
     return _finalize_response_content(response_json, text_format)
 

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -259,7 +259,7 @@ def _format_tool_calls(calls: list[str]) -> str:
 
 
 def _print_openai_usage(response_json: dict, model: str, elapsed: float, metadata: str = "") -> None:
-    """Print token/cost telemetry: 'model: 136036→289 tokens (72% cached, +31 thinking), $0.69000, 8.9s'."""
+    """Print token/cost telemetry: 'model: 136036→289 tokens (72% cached, +31 thinking), $0.69, 8.9s'."""
     if usage := response_json.get("usage"):
         input_tokens, cached_tokens = _normalize_usage_tokens(usage)
         output_tokens = usage.get("output_tokens", 0)  # includes thinking, noted in the parenthetical

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -238,8 +238,8 @@ def test_get_agent_response_calls_function_tools(mock_post):
     printed = "\n".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
     assert "turn 1/6, 1 tools (lookup_value)" in printed
     assert "turn 2/6, 0 tools" in printed
-    assert "30 (12 cached)→12 = 42 tokens, $0.00046" in printed
-    assert "agent total, 2 turns, 1 tools" in printed
+    assert "30→12 tokens (40% cached), $0.00046" in printed
+    assert "agent total, 2 turns, 1 tools (lookup_value)" in printed
     assert "Agent tool turn" not in printed  # tool names live in the per-turn usage line now
 
 
@@ -351,7 +351,7 @@ def test_get_response_anthropic(mock_post):
     assert result == "Test response from Claude"
     printed = "\n".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
     # Cache reads/writes fold into input and reads count as cached, matching ultralytics/assistant normalization
-    assert "1000 (900 cached)→20 = 1020 tokens, $0.00087" in printed
+    assert "1000→20 tokens (90% cached), $0.00087" in printed
     mock_post.assert_called_once()
     # Verify Anthropic endpoint was called
     call_args = mock_post.call_args


### PR DESCRIPTION
## Motivation

Follow-up to #797 refining the unified telemetry line per operator feedback, kept byte-identical with the companion ultralytics/assistant PR:

```
gpt-5.5: 136036→289 tokens (72% cached, +31 thinking), $0.69000, 8.9s, turn 2/6, 5 tools (2 lookup_value, 3 web_search)
```

One parenthetical (cache as hit-rate percent, thinking marked `+` since it's included in the out figure), no redundant total, `model:` colon, and tool types counted instead of listed per call.

## Changes

- `_print_openai_usage()` renders `in→out tokens (N% cached, +N thinking)`; the out figure now includes reasoning tokens (they're billed output) instead of subtracting them; parenthetical drops when both are zero.
- New `_format_tool_calls()` renders `5 tools (2 lookup_value, 3 web_search)` (count omitted for singles); used by per-turn lines and the agent total, which now names tool types instead of a bare count. `tool_calls` accumulates names, not a counter.

Deleted: the ` = total tokens` segment, the separate `cached_str`/`(+N thinking)` rendering branches, and the inline per-turn tools string construction (replaced by the single `_format_tool_calls` owner).

## Testing

- Updated exact-string assertions: `30→12 tokens (40% cached), $0.00046`, `agent total, 2 turns, 1 tools (lookup_value)`, Anthropic `1000→20 tokens (90% cached), $0.00087`.
- `pytest tests`: 119 passed + 1 pre-existing external-URL flake (`test_is_url`, passes on re-run and on unmodified main); ruff clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves OpenAI/Anthropic usage logging with clearer token, cache, cost, timing, and tool-call summaries 🧾✨

### 📊 Key Changes
- Added `_format_tool_calls()` to summarize tool usage with per-tool counts, e.g. `5 tools (2 lookup_value, 3 web_search)` 🛠️
- Updated usage telemetry output to a cleaner format: `model: input→output tokens (cache/thinking notes), cost, time` 📈
- Changed cached token reporting from raw counts to percentages for easier readability 🔁
- Added clearer reporting for reasoning/thinking tokens when present 🧠
- Improved cost formatting to show fewer decimals for larger costs while preserving precision for very small costs 💵
- Agent tool tracking now stores actual tool names instead of only a count, enabling better total summaries across turns 🤖
- Updated tests to match the new logging format ✅

### 🎯 Purpose & Impact
- Makes AI response telemetry easier to understand at a glance for both developers and non-expert users 👀
- Helps maintainers better monitor tool usage patterns during multi-turn agent workflows 🔍
- Improves consistency with Ultralytics assistant-style logging across projects 🤝
- Provides more actionable debugging information, especially around cached tokens, reasoning tokens, and tool calls 🚀