### PR TITLE
Drop misleading plus from thinking-token note

### DIFF
--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -259,7 +259,7 @@ def _format_tool_calls(calls: list[str]) -> str:
 
 
 def _print_openai_usage(response_json: dict, model: str, elapsed: float, metadata: str = "") -> None:
-    """Print token/cost telemetry: 'model: 136036→289 tokens (72% cached, +31 thinking), $0.69, 8.9s'."""
+    """Print token/cost telemetry: 'model: 136036→289 tokens (72% cached, 31 thinking), $0.69, 8.9s'."""
     if usage := response_json.get("usage"):
         input_tokens, cached_tokens = _normalize_usage_tokens(usage)
         output_tokens = usage.get("output_tokens", 0)  # includes thinking, noted in the parenthetical
@@ -269,7 +269,7 @@ def _print_openai_usage(response_json: dict, model: str, elapsed: float, metadat
         if cached_tokens:
             notes.append(f"{round(100 * cached_tokens / input_tokens)}% cached")
         if thinking_tokens:
-            notes.append(f"+{thinking_tokens} thinking")
+            notes.append(f"{thinking_tokens} thinking")
         note_str = f" ({', '.join(notes)})" if notes else ""
         metadata = f", {metadata}" if metadata else ""
         cost_str = f"${cost:.2f}" if cost == 0 or cost >= 0.01 else f"${cost:.5f}"  # match ultralytics/assistant


### PR DESCRIPTION
## Motivation

Follow-up to the compact telemetry format: the `+` in `(72% cached, +31 thinking)` implied the 31 thinking tokens were additive on top of the out figure, but the out figure already includes them. Drop the plus so the parenthetical reads as a breakdown, not an addition. Companion PR applies the same to the other repo.

```
gpt-5.5: 136036→289 tokens (72% cached, 31 thinking), $0.69, 8.9s, 3 turns, 5 tools (2 search_hubspot, 3 search_rag)
```

Deleted: the `+` prefix in the thinking note (one-character format fix; a new exact-string test locks the thinking-inclusive semantics).

## Testing

Exact-string test added/updated asserting `10→8 tokens (3 thinking), $0.50, 1.0s` for usage with 5 output + 3 thinking tokens; suites green, ruff clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Polishes OpenAI usage telemetry formatting by removing an extra `+` from “thinking” token reporting 🧹

### 📊 Key Changes
- Updated the OpenAI usage log docstring to match the new output format.
- Changed thinking token display from `+31 thinking` to `31 thinking`.
- Keeps cached token, cost, elapsed time, and metadata reporting unchanged.

### 🎯 Purpose & Impact
- Improves readability and consistency of token usage logs 📊
- Aligns telemetry output with the expected Ultralytics assistant formatting.
- Reduces minor confusion by presenting thinking tokens as a simple count rather than an additive value.