### PR TITLE
Transient poll retries and clear Anthropic truncation errors

### DIFF
--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -16,7 +16,7 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
 MODEL = os.getenv("MODEL")  # Auto-detected from API keys if not set
 REVIEW_MODEL = os.getenv("REVIEW_MODEL")  # Optional override for PR reviews
-MAX_PROMPT_CHARS = round(128000 * 3.3 * 0.5)  # Max characters for prompt (50% of 128k context)
+MAX_PROMPT_CHARS = round(128000 * 3.3 * 0.5)  # deliberate COST ceiling, not a context limit; agent tools read the rest
 
 # Default models (single source of truth)
 OPENAI_MODEL_DEFAULT = "gpt-5.5"
@@ -176,9 +176,12 @@ def _poll_openai_response(response_json: dict, headers: dict, timeout: int = 900
         time.sleep(2)
         try:
             r = requests.get(f"https://api.openai.com/v1/responses/{response_id}", headers=headers, timeout=(30, 60))
+            if r.status_code >= 500 or r.status_code == 429:  # transient; the deadline above bounds the loop
+                print(f"OpenAI poll got {r.status_code}; continuing...")
+                continue
             r.raise_for_status()
             response_json = r.json()
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, json.JSONDecodeError) as e:
             print(f"OpenAI poll failed with {e.__class__.__name__}; continuing...")
 
     if response_id and response_json.get("status") != "completed":
@@ -504,7 +507,7 @@ def get_response(
         if is_anthropic:
             data = {
                 "model": model,
-                "max_tokens": 8192,
+                "max_tokens": 32000,  # large replies (reviews) exceed 8192; truncated schema output is unusable
                 "messages": user_messages,
             }
             if temperature != 1.0:  # 1.0 is the API default; newer Claude models 400 on explicit non-default values
@@ -563,6 +566,9 @@ def get_response(
                 content = content.strip()
 
                 _print_openai_usage(response_json, model, elapsed)
+                if response_json.get("stop_reason") == "max_tokens" and text_format:
+                    # A truncated schema-constrained reply is partial JSON; fail clearly instead of at json.loads
+                    raise RuntimeError(f"{model} response truncated at max_tokens; structured output is incomplete")
             else:
                 content = _openai_response_text(response_json)
                 _print_openai_usage(response_json, model, elapsed)


### PR DESCRIPTION
## Motivation

Round 2 of the two-repo LLM/agent audit backlog (companion to the ultralytics/assistant streaming-telemetry PR): background polling died on transient errors that the POST path already survives, and a truncated Anthropic schema reply crashed later in `json.loads` with a misleading parse error.

## Changes

- `_poll_openai_response` now treats 5xx/429 and JSON-decode failures on the polling GET as transient (the existing deadline still bounds the loop; 4xx still aborts) — matching the POST retry policy.
- Anthropic `max_tokens` raised 8192 → 32000, and a schema-constrained reply that stops at `max_tokens` raises a clear `RuntimeError` ("structured output is incomplete") instead of failing later in `json.loads` with a confusing parse error.
- `MAX_PROMPT_CHARS` comment corrected: it's a deliberate cost ceiling, not a stale context-size assumption — the tool-based review agent reads beyond it via `list_changed_files`/`read_diff` (design-review verdict: capability is not budget policy; left unchanged).

Deleted: nothing — each fix modifies an existing line in place (poll retry gate, max_tokens value, comment) plus the two-line truncation raise; there is no code whose deletion or relocation would produce these behaviors, and the net diff is under 10 lines.

## Testing

- `pytest tests/test_openai_utils.py`: 13 passed; ruff clean with the repo lint flags.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves AI action reliability by handling transient OpenAI polling errors better and allowing larger Anthropic review responses 🚀

### 📊 Key Changes
- Clarified that `MAX_PROMPT_CHARS` is a deliberate cost ceiling, not a hard model context limit 💸
- Added retry-friendly handling for OpenAI polling responses with `429` or `5xx` status codes 🔁
- Added JSON decode errors to recoverable OpenAI polling failures 🛡️
- Increased Anthropic `max_tokens` from `8192` to `32000` to support longer PR review outputs 📝
- Added a clear runtime error when structured Anthropic responses are truncated, instead of failing later during JSON parsing ⚠️

### 🎯 Purpose & Impact
- Makes automated PR review and AI response workflows more robust against temporary API issues ✅
- Reduces failures caused by long review outputs being cut off, especially for structured responses 📦
- Provides clearer error messages when responses are incomplete, making debugging easier for maintainers 🔍
- Helps Ultralytics GitHub Actions deliver more consistent and reliable AI-assisted automation 🤖