### PR TITLE
Fix action log group closure

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,32 +21,13 @@ jobs:
   actions:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Local Action
-        if: github.event_name == 'pull_request' && github.repository == 'ultralytics/actions' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v7
+      # Dogfood this repo's own action: PR events run the PR's action.yml, issue events run main's
+      - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Run Local Ultralytics Actions
-        if: github.event_name == 'pull_request' && github.repository == 'ultralytics/actions' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: ./
-        with:
-          token: ${{ secrets._GITHUB_TOKEN || github.token }} # Auto-generated fallback
-          labels: true # Auto-label issues/PRs using AI
-          python: true # Format Python with Ruff
-          python_docstrings: true # Format Python docstrings
-          prettier: true # Format YAML, JSON, Markdown, CSS
-          spelling: true # Check spelling with codespell
-          links: false # Check broken links with Lychee
-          summary: true # Generate AI-powered PR summaries
-          review: true # PR reviews
-          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run Ultralytics Actions
-        if: github.event_name != 'pull_request' || github.repository != 'ultralytics/actions' || github.event.pull_request.head.repo.full_name != github.repository
-        uses: ultralytics/actions@main
+        uses: ./
         with:
           token: ${{ secrets._GITHUB_TOKEN || github.token }} # Auto-generated fallback
           labels: true # Auto-label issues/PRs using AI

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,31 @@ jobs:
   actions:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Local Action
+        if: github.event_name == 'pull_request' && github.repository == 'ultralytics/actions' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run Local Ultralytics Actions
+        if: github.event_name == 'pull_request' && github.repository == 'ultralytics/actions' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./
+        with:
+          token: ${{ secrets._GITHUB_TOKEN || github.token }} # Auto-generated fallback
+          labels: true # Auto-label issues/PRs using AI
+          python: true # Format Python with Ruff
+          python_docstrings: true # Format Python docstrings
+          prettier: true # Format YAML, JSON, Markdown, CSS
+          spelling: true # Check spelling with codespell
+          links: false # Check broken links with Lychee
+          summary: true # Generate AI-powered PR summaries
+          review: true # PR reviews
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution
+
       - name: Run Ultralytics Actions
+        if: github.event_name != 'pull_request' || github.repository != 'ultralytics/actions' || github.event.pull_request.head.repo.full_name != github.repository
         uses: ultralytics/actions@main
         with:
           token: ${{ secrets._GITHUB_TOKEN || github.token }} # Auto-generated fallback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Key flow: GitHub workflow event → `action.yml` step (gated by `github.event_na
 
 Most shared utilities are re-exported through `actions/utils/__init__.py` — keep `__all__` updated when adding exports.
 
-Self-hosting detail: workflows in this repo pin `ultralytics/actions@main`, but `action.yml` installs the Python package from the current git branch — so PRs here dogfood Python package changes via `.github/workflows/format.yml`, while changes to `action.yml` itself only take effect after merging to main.
+Self-hosting detail: `.github/workflows/format.yml` checks out the event's ref (PR head for pull requests, main for issue events) and runs `uses: ./` — so PRs here dogfood both the Python package and `action.yml` itself before merge.
 
 ## Conventions
 

--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,10 @@ runs:
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (github.event.action == 'opened' || github.event.action == 'synchronize')
       env:
         HEADER: ${{ inputs.header }}
-      run: ultralytics-actions-headers
+      run: |
+        echo "::group::File Header"
+        trap 'echo "::endgroup::"' EXIT
+        ultralytics-actions-headers
       shell: bash
       continue-on-error: false
 
@@ -253,6 +256,8 @@ runs:
     - name: Run Dart Formatter
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && inputs.dart == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
+        echo "::group::Run Dart Formatter"
+        trap 'echo "::endgroup::"' EXIT
         dart format .
       shell: bash
       continue-on-error: true # Important so that commit step can pick up changes
@@ -283,7 +288,10 @@ runs:
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         MODEL: ${{ inputs.model }}
-      run: ultralytics-actions-summarize-pr
+      run: |
+        echo "::group::PR Summary"
+        trap 'echo "::endgroup::"' EXIT
+        ultralytics-actions-summarize-pr
       shell: bash
       continue-on-error: true
 
@@ -299,7 +307,10 @@ runs:
         MODEL: ${{ inputs.model }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REVIEW: ${{ inputs.review }}
-      run: ultralytics-actions-first-interaction
+      run: |
+        echo "::group::Autolabel Issues and PRs"
+        trap 'echo "::endgroup::"' EXIT
+        ultralytics-actions-first-interaction
       shell: bash
       continue-on-error: true
 
@@ -315,7 +326,10 @@ runs:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         MODEL: ${{ inputs.model }}
         REVIEW_MODEL: ${{ inputs.review_model }}
-      run: ultralytics-actions-review-pr
+      run: |
+        echo "::group::PR Review"
+        trap 'echo "::endgroup::"' EXIT
+        ultralytics-actions-review-pr
       shell: bash
       continue-on-error: true
 

--- a/action.yml
+++ b/action.yml
@@ -120,6 +120,7 @@ runs:
         GITHUB_REF: ${{ github.ref }}
       run: |
         echo "::group::Install Dependencies"
+        trap 'echo "::endgroup::"' EXIT
         # Install from current git branch if testing in ultralytics/actions repo, otherwise from GitHub main branch
         if [ "$GITHUB_REPOSITORY" = "ultralytics/actions" ]; then
           echo "Installing from git branch: $GITHUB_REF"
@@ -139,7 +140,6 @@ runs:
           sudo env "PATH=$PATH" uv pip install --system --break-system-packages $packages
         fi
         ultralytics-actions-info
-        echo "::endgroup::"
       shell: bash
 
     # Checkout Repository ----------------------------------------------------------------------------------------------
@@ -178,6 +178,7 @@ runs:
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && inputs.python == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
         echo "::group::Run Python"
+        trap 'echo "::endgroup::"' EXIT
         ruff check \
         --fix \
         --unsafe-fixes \
@@ -191,7 +192,6 @@ runs:
         if [ "${{ inputs.python_docstrings }}" = "true" ]; then
           ultralytics-actions-format-python-docstrings . || true
         fi
-        echo "::endgroup::"
       shell: bash
       continue-on-error: true
 
@@ -200,6 +200,7 @@ runs:
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && inputs.biome == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
         echo "::group::Run Biome"
+        trap 'echo "::endgroup::"' EXIT
         if [ -f "biome.json" ] || [ -f "biome.jsonc" ]; then
           npm install -g @biomejs/biome@latest
           npx biome --version
@@ -207,7 +208,6 @@ runs:
         else
           echo "⚠️  No biome.json found - skipping Biome formatting. Add biome.json to enable."
         fi
-        echo "::endgroup::"
       shell: bash
       continue-on-error: true
 
@@ -216,6 +216,7 @@ runs:
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (inputs.prettier == 'true' || inputs.markdown == 'true') && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
         echo "::group::Run Prettier"
+        trap 'echo "::endgroup::"' EXIT
         npm install -g prettier@3.6.2 prettier-plugin-sh
         ultralytics-actions-update-markdown-code-blocks
         npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
@@ -228,7 +229,6 @@ runs:
         if [ -d "./docs" ]; then
           find ./docs -name "*.md" -type f ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
         fi
-        echo "::endgroup::"
       shell: bash
       continue-on-error: true
 
@@ -237,9 +237,9 @@ runs:
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && inputs.swift == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
         echo "::group::Run Swift Formatter"
+        trap 'echo "::endgroup::"' EXIT
         brew install swift-format
         swift-format --in-place --recursive .
-        echo "::endgroup::"
       shell: bash
       continue-on-error: true
 
@@ -263,6 +263,7 @@ runs:
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && inputs.spelling == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
         echo "::group::Run Codespell"
+        trap 'echo "::endgroup::"' EXIT
         codespell \
           --builtin clear,rare,informal,en-GB_to_en-US \
           --write-changes \
@@ -270,7 +271,6 @@ runs:
           --ignore-regex '\b[a-z]+[A-Z][a-zA-Z]*\b' \
           --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,cann,CANN" \
           --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml"
-        echo "::endgroup::"
       shell: bash
       continue-on-error: true
 
@@ -324,6 +324,7 @@ runs:
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && inputs.bun_update == 'true' && github.event.action == 'opened'
       run: |
         echo "::group::Bun Update"
+        trap 'echo "::endgroup::"' EXIT
         if [ -f "bun.lock" ] || [ -f "bun.lockb" ]; then
           npm install -g bun
           echo "Updating root..."
@@ -339,7 +340,6 @@ runs:
         else
           echo "No bun.lock found - skipping Bun update"
         fi
-        echo "::endgroup::"
       shell: bash
       continue-on-error: true
 
@@ -359,6 +359,7 @@ runs:
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         echo "::group::Commit and Push Changes"
+        trap 'echo "::endgroup::"' EXIT
         COMMIT_MSG="Auto-format by https://ultralytics.com/actions"
         git config --global user.name "$GITHUB_USERNAME"
         git config --global user.email "$GITHUB_EMAIL"
@@ -370,7 +371,6 @@ runs:
         else
           echo "No changes to commit"
         fi
-        echo "::endgroup::"
       shell: bash
       continue-on-error: true
 

--- a/tests/test_format_code.py
+++ b/tests/test_format_code.py
@@ -19,6 +19,16 @@ def test_format_commands_match_action_yml():
         assert arg == "*" or arg in text, f"codespell arg not in action.yml: {arg}"
 
 
+def test_action_yml_groups_close_on_exit():
+    """Test log groups close even when a grouped shell command fails."""
+    lines = ACTION_YML.read_text(encoding="utf-8").splitlines()
+    group_lines = [i for i, line in enumerate(lines) if 'echo "::group::' in line]
+
+    assert group_lines
+    assert all(lines[i + 1].strip() == "trap 'echo \"::endgroup::\"' EXIT" for i in group_lines)
+    assert not any(line.strip() == 'echo "::endgroup::"' for line in lines)
+
+
 def test_markdown_prettier_skips_symlinks():
     """Test Markdown formatting only targets regular files because Prettier rejects explicit symlink paths."""
     assert 'find . -name "*.md" -type f' in format_code.PRETTIER

--- a/tests/test_format_code.py
+++ b/tests/test_format_code.py
@@ -20,12 +20,15 @@ def test_format_commands_match_action_yml():
 
 
 def test_action_yml_groups_close_on_exit():
-    """Test log groups close even when a grouped shell command fails."""
+    """Test every run step opens a log group that closes even when a command fails."""
     lines = ACTION_YML.read_text(encoding="utf-8").splitlines()
-    group_lines = [i for i, line in enumerate(lines) if 'echo "::group::' in line]
+    run_lines = [i for i, line in enumerate(lines) if line.strip().startswith("run:")]
 
-    assert group_lines
-    assert all(lines[i + 1].strip() == "trap 'echo \"::endgroup::\"' EXIT" for i in group_lines)
+    assert run_lines
+    for i in run_lines:
+        assert lines[i].strip() == "run: |", f"line {i + 1}: run step must be a block opening a log group"
+        assert lines[i + 1].strip().startswith('echo "::group::'), f"line {i + 2}: run step must open a log group"
+        assert lines[i + 2].strip() == "trap 'echo \"::endgroup::\"' EXIT", f"line {i + 3}: missing EXIT trap"
     assert not any(line.strip() == 'echo "::endgroup::"' for line in lines)
 
 


### PR DESCRIPTION
## Summary
- close each composite-action log group with an EXIT trap so groups close even when a command fails mid-step
- open a log group in every remaining `run:` step (File Header, Dart, PR Summary, Autolabel, PR Review) so no step output renders inline
- dogfood the local action in `format.yml`: one checkout + `uses: ./` for all events (PR events run the PR's action.yml, issue events resolve to main), replacing the previous `@main` pin
- strengthen the regression test: every `run:` step must open a group and install the trap; no manual `::endgroup::` allowed

Deleted: all 8 manual `echo "::endgroup::"` statements in `action.yml`; the duplicated `Run Local Ultralytics Actions` step and its three mirrored `if:` guards in `format.yml` (consolidated to a single unconditional path).

Note: output from external `uses:` steps (setup-uv, checkout, setup-dart, lychee) cannot be grouped from a composite action — GitHub's runner emits its own group markers around those steps, so their runtime output stays inline. This is a platform limitation, not a regression.

## Tests
- `PYTHONPATH=. pytest tests -q --ignore=tests/test_urls.py` (108 passed)
- `ruff check .` and `ruff format --check .` clean
- `action.yml` and `format.yml` validated with `yaml.safe_load`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the Ultralytics Actions workflow by dogfooding local PR changes and making GitHub Actions log groups close reliably, even when steps fail 🚀

### 📊 Key Changes
- Updated `.github/workflows/format.yml` to check out the PR/event ref and run the action locally with `uses: ./` instead of `ultralytics/actions@main` 🧪
- Added `trap 'echo "::endgroup::"' EXIT` across `action.yml` run steps so GitHub log groups always close cleanly ✅
- Converted remaining single-line `run:` commands into block-style grouped commands for consistency 📦
- Added missing log grouping for Dart formatting and other action steps, improving CI log readability 🔍
- Updated `AGENTS.md` to document the new self-hosting behavior accurately 📝
- Added a test to ensure every `run:` step opens a log group and closes it via an exit trap 🛡️

### 🎯 Purpose & Impact
- Enables PRs in `ultralytics/actions` to test both Python package changes and `action.yml` changes before merge, reducing risk of broken action updates ⚙️
- Makes workflow logs cleaner and easier to navigate for developers and contributors 👀
- Prevents unclosed GitHub Actions log groups when commands fail, improving debugging reliability 🧰
- Strengthens CI quality by enforcing consistent log group structure through automated tests 🤖