### PR TITLE
Make Codecov upload best effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,11 @@ jobs:
           ultralytics-actions-info
 
       - name: Upload coverage to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage.xml
           disable_search: true
           plugins: noop
           use_oidc: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- make the Codecov coverage upload non-blocking
- keep pytest and CLI test failures authoritative

## Validation
- python YAML parse for .github/workflows/ci.yml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Makes Codecov coverage upload non-blocking so CI is more resilient when Codecov has issues 🚦

### 📊 Key Changes
- Added `continue-on-error: true` to the Codecov upload step ✅
- Changed Codecov configuration from `fail_ci_if_error: true` to `fail_ci_if_error: false` 🔧
- Keeps existing coverage upload settings, including `coverage.xml`, OIDC authentication, and disabled file search 📄

### 🎯 Purpose & Impact
- Prevents CI failures caused only by Codecov upload errors or service outages 🛡️
- Improves workflow reliability for contributors and maintainers 🚀
- Ensures test results remain the primary signal for PR health, while coverage reporting becomes best-effort 📊