### PR TITLE
Rename CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,7 +3,7 @@
 # Ultralytics Contributor License Agreement (CLA) action https://docs.ultralytics.com/help/CLA
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 
-name: CLA Assistant
+name: CLA
 on:
   issue_comment:
     types:


### PR DESCRIPTION
## Summary

- rename the shared workflow from `CLA Assistant` to `CLA`
- keep the job and action behavior unchanged

Deleted: the redundant `Assistant` suffix from the workflow display name.

Reused: the existing canonical CLA workflow without adding configuration or aliases.

## Validation

- `actionlint .github/workflows/cla.yml`
- `npx prettier --write .github/workflows/cla.yml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Renames the GitHub Actions workflow from **“CLA Assistant”** to **“CLA”** for clearer identification.

### 📊 Key Changes

- Updated the workflow name in `.github/workflows/cla.yml`.
- No changes were made to the workflow’s triggers or CLA functionality.

### 🎯 Purpose & Impact

- 🧭 Makes the workflow name shorter and easier to recognize in GitHub Actions.
- ✅ Preserves the existing contributor license agreement process without affecting contributors or pull request behavior.