### PR TITLE
Simplify CLA workflow identity

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,12 +20,12 @@ permissions:
 
 jobs:
   CLA:
-    if: github.repository == 'ultralytics/actions' && (github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA')))
+    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA'))
     concurrency:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest
     steps:
-      - name: CLA Assistant
+      - name: CLA
         uses: ultralytics/actions/cla@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/cla/README.md
+++ b/cla/README.md
@@ -4,7 +4,7 @@ Checks every pull request commit author against the shared signature ledger in
 `ultralytics/cla` and maintains one status comment on the pull request.
 
 ```yaml
-name: CLA Assistant
+name: CLA
 on:
   issue_comment:
     types: [created]
@@ -22,7 +22,7 @@ jobs:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest
     steps:
-      - name: CLA Assistant
+      - name: CLA
         uses: ultralytics/actions/cla@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- delete the redundant repository-name condition from the repository-scoped CLA workflow
- replace the remaining `CLA Assistant` step and documentation labels with `CLA`
- keep event routing and action behavior unchanged

Deleted: the redundant `github.repository == ...` condition and all remaining `CLA Assistant` labels in the canonical workflow example.

Reused: GitHub Actions repository scoping and the existing actionable-event condition; no new guard, alias, or helper was added.

## Validation

- `uv run pytest -q tests/test_cla.py` (19 passed)
- `actionlint .github/workflows/cla.yml`
- `npx prettier --write .github/workflows/cla.yml cla/README.md`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔐 Simplifies CLA workflow configuration and standardizes the action name to **CLA**.

### 📊 Key Changes

- Removed the repository-specific condition from the CLA workflow, allowing it to run based on the relevant GitHub events alone.
- Renamed the workflow step from **“CLA Assistant”** to **“CLA”**.
- Updated the CLA documentation examples to use the new **“CLA”** name consistently.

### 🎯 Purpose & Impact

- ✅ Makes the shared CLA action easier to reuse across repositories.
- 📄 Keeps workflow documentation aligned with the actual configuration.
- ⚙️ Preserves CLA checks for pull requests and contributor signature requests while reducing unnecessary restrictions.