### PR TITLE
Bump lycheeverse/lychee-action from v2.8.0 to v2.9.0 in /.github/workflows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -391,7 +391,7 @@ runs:
     # Broken links -----------------------------------------------------------------------------------------------------
     - name: Broken Link Checker
       if: inputs.links == 'true' && github.event.action != 'closed'
-      uses: lycheeverse/lychee-action@v2.8.0
+      uses: lycheeverse/lychee-action@v2.9.0
       with:
         # Check all markdown and html files in repo. Ignores the following status codes to reduce false positives:
         #   - 401(generic, "unauthorized")


### PR DESCRIPTION
Bump lycheeverse/lychee-action from v2.8.0 to v2.9.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⬆️ Updates the Lychee broken-link checker from v2.8.0 to v2.9.0.

### 📊 Key Changes

- Upgraded `lycheeverse/lychee-action` to `v2.9.0` in `action.yml`.
- No changes were made to the existing link-checking conditions or configuration.

### 🎯 Purpose & Impact

- 🔗 Provides the repository with the latest Lychee action improvements and fixes.
- ✅ Maintains the same broken-link checking behavior for Markdown and HTML files.
- ⚙️ Requires no user workflow changes beyond automatically using the updated action version.