### PR TITLE
Fix CLA PR-head rerun: use bare workflow filename in workflow-runs API

### DIFF
--- a/actions/cla.py
+++ b/actions/cla.py
@@ -230,7 +230,7 @@ def _rerun_pr_check(action: Action, number: int) -> None:
         return
     pr = _read(action, "get", f"{GITHUB_API_URL}/repos/{action.repository}/pulls/{number}").json()
     workflow_ref = os.environ["GITHUB_WORKFLOW_REF"]
-    workflow = workflow_ref.split(f"{action.repository}/", 1)[1].rsplit("@", 1)[0]
+    workflow = workflow_ref.rsplit("@", 1)[0].rsplit("/", 1)[-1]  # API accepts only the numeric id or bare filename
     run = None
     url = f"{GITHUB_API_URL}/repos/{action.repository}/actions/workflows/{workflow}/runs"
     for page in range(1, 101):


### PR DESCRIPTION
`_rerun_pr_check` builds the workflow-runs URL from `GITHUB_WORKFLOW_REF`, yielding `/actions/workflows/.github/workflows/cla.yml/runs`. The API accepts only a numeric workflow id or the bare filename, so the unencoded path 404s and every signature-triggered run fails after successfully updating the ledger and status comment — observed live on ultralytics/ultralytics#25065 (run 29085744530):

```
✗ GET https://api.github.com/repos/ultralytics/ultralytics/actions/workflows/.github/workflows/cla.yml/runs → 404
requests.exceptions.HTTPError: 404 Client Error: Not Found
```

Fix strips the ref to the bare filename: `workflow_ref.rsplit("@", 1)[0].rsplit("/", 1)[-1]` → `cla.yml`. This also drops the repository-prefix split, which would additionally break for reusable workflows called from another repo.

Deleted: the `split(f"{action.repository}/", 1)` repository-prefix parsing (replaced by the shorter basename split).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔧 Fixes CLA workflow reruns by using a GitHub API-compatible workflow identifier.

### 📊 Key Changes

- Updated workflow name extraction in `actions/cla.py`.
- Uses the workflow’s bare filename instead of the full repository path.
- Retains the workflow reference without its branch or tag suffix.

### 🎯 Purpose & Impact

- ✅ Ensures the GitHub Actions API can correctly locate and rerun CLA workflow checks.
- 🚀 Improves reliability when processing pull requests that require CLA validation.
- 🛠️ Prevents rerun failures caused by passing an unsupported workflow path format.