### PR TITLE
Skip CLA success comment when nobody had to sign

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.25"
+__version__ = "0.2.26"

--- a/actions/cla.py
+++ b/actions/cla.py
@@ -194,25 +194,25 @@ Thank you for your contribution. Before it can be accepted, every contributor mu
 """
 
 
-def _update_comment(action: Action, number: int, comments: list[dict], body: str) -> None:
-    """Create or update one bot-owned CLA status comment."""
-    existing = [
+def _status_comments(comments: list[dict]) -> list[dict]:
+    """Return the bot-owned CLA status comments."""
+    return [
         comment
         for comment in comments
         if comment.get("user", {}).get("login") == BOT_LOGIN
         and (COMMENT_MARKER in (comment.get("body") or "") or LEGACY_MARKER in (comment.get("body") or ""))
     ]
+
+
+def _update_comment(action: Action, number: int, comments: list[dict], body: str) -> None:
+    """Create or update one bot-owned CLA status comment."""
+    existing = _status_comments(comments)
     if not existing:
         response = action.post(
             f"{GITHUB_API_URL}/repos/{action.repository}/issues/{number}/comments",
             json={"body": body},
         )
-        existing = [
-            comment
-            for comment in _comments(action, number)
-            if comment.get("user", {}).get("login") == BOT_LOGIN
-            and (COMMENT_MARKER in (comment.get("body") or "") or LEGACY_MARKER in (comment.get("body") or ""))
-        ]
+        existing = _status_comments(_comments(action, number))
         if not existing:
             response.raise_for_status()
             raise RuntimeError("GitHub did not return the created CLA status comment")
@@ -271,7 +271,8 @@ def run(action: Action, ledger_action: Action) -> None:
     signed = [user for user in contributors if user["id"] in signed_ids]
     unsigned = [user for user in contributors if user["id"] is not None and user["id"] not in signed_ids]
     unknown = [user for user in contributors if user["id"] is None]
-    _update_comment(action, number, comments, _comment_body(signed, unsigned, unknown))
+    if unsigned or unknown or _status_comments(comments):
+        _update_comment(action, number, comments, _comment_body(signed, unsigned, unknown))
     if unsigned or unknown:
         raise RuntimeError("All PR contributors must sign the CLA")
     _rerun_pr_check(action, number)

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -189,6 +189,22 @@ def test_run_records_exact_sentence_and_updates_legacy_comment():
     assert "All Contributors have signed" in source.patch.call_args.kwargs["json"]["body"]
 
 
+def test_run_stays_silent_when_all_contributors_already_signed():
+    """Skip the status comment entirely when nobody needed to sign."""
+    source, store = action(), action()
+    source.get.side_effect = [
+        response(data={"user": {"id": 1, "login": "signed"}}),
+        response(data=[]),
+    ]
+    source.post.return_value = commits_response([{"user": {"databaseId": 1, "login": "signed"}}])
+    store.get.return_value = ledger_response([{"id": 1}])
+
+    cla.run(source, store)
+
+    assert source.post.call_count == 1  # GraphQL commits query only, no comment created
+    source.patch.assert_not_called()
+
+
 @pytest.mark.parametrize("body", [f"{cla.SIGN_COMMENT}!", cla.SIGN_COMMENT.lower(), f" {cla.SIGN_COMMENT}"])
 def test_run_rejects_similar_sentence_and_keeps_hard_failure(body):
     """Reject a modified signing sentence and leave the CLA gate failed."""


### PR DESCRIPTION
## Summary

The CLA check currently posts an "All Contributors have signed the CLA. ✅" comment on every PR — including PRs where every contributor was already in the signature ledger and nobody was ever asked to sign (e.g. #813). That comment adds no information beyond the green check run.

This PR makes the check stay silent when all contributors are pre-signed and no CLA status comment exists on the PR. The sign flow is unchanged: new contributors still get the "please sign" comment, and it still updates to ✅ once everyone signs.

## Changes

- `run()` only posts/updates the status comment when there are unsigned/unknown contributors or an existing CLA status comment to update
- Extracted the duplicated bot-comment filter in `_update_comment()` into a `_status_comments()` helper
- Added `test_run_stays_silent_when_all_contributors_already_signed`
- Bumped `__version__` to 0.2.26

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🤫 CLA checks now stay silent when all PR contributors have already signed, while preserving reliable status-comment handling.

### 📊 Key Changes

- Added `_status_comments()` to centralize detection of bot-owned CLA status comments, including legacy comments.
- Updated CLA processing to:
  - Skip creating or updating a status comment when everyone has signed and no existing status comment needs cleanup.
  - Continue updating existing comments when needed.
  - Preserve failure behavior for unsigned or unknown contributors.
- Added a regression test confirming no unnecessary comment is created for fully compliant PRs.
- Bumped the package version from `0.2.25` to `0.2.26`.

### 🎯 Purpose & Impact

- 🧹 Reduces unnecessary bot comments on PRs where all contributors have already signed the CLA.
- 🔄 Maintains compatibility with existing and legacy CLA status comments.
- ✅ Keeps enforcement unchanged: PRs with unsigned or unknown contributors still fail the CLA check.
- 🧪 Improves test coverage and makes future CLA comment handling more maintainable.