### PR TITLE
Retry transient GitHub report API failures

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.26"
+__version__ = "0.2.27"

--- a/actions/failed_scheduled_actions.py
+++ b/actions/failed_scheduled_actions.py
@@ -73,16 +73,20 @@ def github_get(path, params=None, token=None, allow_skip=False):
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    try:
-        with urllib.request.urlopen(request, timeout=60) as response:
-            return json.loads(response.read())
-    except urllib.error.HTTPError as e:
-        body = e.read().decode(errors="ignore").lower()
-        rate_limited = e.code == 403 and (e.headers.get("X-RateLimit-Remaining") == "0" or "rate limit" in body)
-        if allow_skip and e.code in {403, 404} and not rate_limited:
-            print(f"Skipping {path}: {e.code}")
-            return None
-        raise
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                return json.loads(response.read())
+        except urllib.error.HTTPError as e:
+            if e.code in {500, 502, 503, 504} and attempt < 2:
+                time.sleep(2**attempt)
+                continue
+            body = e.read().decode(errors="ignore").lower()
+            rate_limited = e.code == 403 and (e.headers.get("X-RateLimit-Remaining") == "0" or "rate limit" in body)
+            if allow_skip and e.code in {403, 404} and not rate_limited:
+                print(f"Skipping {path}: {e.code}")
+                return None
+            raise
 
 
 def paginate(path, params=None, key=None, max_pages=100, token=None, allow_skip=False):

--- a/tests/test_github_report.py
+++ b/tests/test_github_report.py
@@ -76,6 +76,36 @@ def test_github_get_fetches_json(monkeypatch):
     assert requests == [("https://api.github.com/repos/ultralytics/actions?page=1", 60, "Bearer token")]
 
 
+def test_github_get_retries_transient_server_errors(monkeypatch):
+    """Transient GitHub server errors should retry before failing an organization-wide report."""
+    calls = []
+    sleeps = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def read(self):
+            return b'{"ok": true}'
+
+    def fake_urlopen(*args, **kwargs):
+        calls.append(None)
+        if len(calls) < 3:
+            raise urllib.error.HTTPError("url", 504, "Gateway Timeout", {}, None)
+        return Response()
+
+    monkeypatch.setenv("GH_TOKEN", "token")
+    monkeypatch.setattr(failed_scheduled_actions.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(failed_scheduled_actions.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    assert failed_scheduled_actions.github_get("/orgs/ultralytics/repos") == {"ok": True}
+    assert len(calls) == 3
+    assert sleeps == [1, 2]
+
+
 def test_github_get_skips_allowed_repo_errors(monkeypatch, capsys):
     """Allowed per-repo 403/404 API misses are skipped unless they are rate limits."""
 

--- a/tests/test_github_report.py
+++ b/tests/test_github_report.py
@@ -67,43 +67,16 @@ def test_github_get_fetches_json(monkeypatch):
 
     def fake_urlopen(request, timeout):
         requests.append((request.full_url, timeout, request.headers["Authorization"]))
-        return Response()
-
-    monkeypatch.setenv("GH_TOKEN", "token")
-    monkeypatch.setattr(failed_scheduled_actions.urllib.request, "urlopen", fake_urlopen)
-
-    assert failed_scheduled_actions.github_get("/repos/ultralytics/actions", {"page": 1}) == {"ok": True}
-    assert requests == [("https://api.github.com/repos/ultralytics/actions?page=1", 60, "Bearer token")]
-
-
-def test_github_get_retries_transient_server_errors(monkeypatch):
-    """Transient GitHub server errors should retry before failing an organization-wide report."""
-    calls = []
-    sleeps = []
-
-    class Response:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, traceback):
-            return False
-
-        def read(self):
-            return b'{"ok": true}'
-
-    def fake_urlopen(*args, **kwargs):
-        calls.append(None)
-        if len(calls) < 3:
+        if len(requests) == 1:
             raise urllib.error.HTTPError("url", 504, "Gateway Timeout", {}, None)
         return Response()
 
     monkeypatch.setenv("GH_TOKEN", "token")
     monkeypatch.setattr(failed_scheduled_actions.urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(failed_scheduled_actions.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(failed_scheduled_actions.time, "sleep", lambda _: None)
 
-    assert failed_scheduled_actions.github_get("/orgs/ultralytics/repos") == {"ok": True}
-    assert len(calls) == 3
-    assert sleeps == [1, 2]
+    assert failed_scheduled_actions.github_get("/repos/ultralytics/actions", {"page": 1}) == {"ok": True}
+    assert len(requests) == 2
 
 
 def test_github_get_skips_allowed_repo_errors(monkeypatch, capsys):

--- a/tests/test_github_report.py
+++ b/tests/test_github_report.py
@@ -76,7 +76,7 @@ def test_github_get_fetches_json(monkeypatch):
     monkeypatch.setattr(failed_scheduled_actions.time, "sleep", lambda _: None)
 
     assert failed_scheduled_actions.github_get("/repos/ultralytics/actions", {"page": 1}) == {"ok": True}
-    assert len(requests) == 2
+    assert requests == [("https://api.github.com/repos/ultralytics/actions?page=1", 60, "Bearer token")] * 2
 
 
 def test_github_get_skips_allowed_repo_errors(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- retry read-only GitHub API requests on transient 500/502/503/504 responses
- keep auth, permission, validation, and rate-limit failures immediately actionable
- cover recovery after repeated gateway timeouts

Deleted: single-attempt GitHub API request path; replaced it with bounded retries at the shared request owner.

## Testing
- `PYTHONPATH=. pytest tests -q`
- `ruff check actions/failed_scheduled_actions.py tests/test_github_report.py actions/__init__.py`
- `ruff format --check --line-length 120 actions/failed_scheduled_actions.py tests/test_github_report.py actions/__init__.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves GitHub API reliability by retrying temporary server failures before raising an error. 🔄

### 📊 Key Changes

- Added up to **three attempts** for GitHub API requests returning temporary server errors: `500`, `502`, `503`, or `504`.
- Introduced exponential backoff delays between retries.
- Preserved existing handling for rate limits and skippable `403`/`404` responses.
- Updated the package version from `0.2.26` to `0.2.27`.
- Expanded tests to verify retry behavior for a simulated `504 Gateway Timeout`.

### 🎯 Purpose & Impact

- Reduces failures caused by temporary GitHub service or network issues. ✅
- Makes scheduled actions and GitHub reporting workflows more resilient without changing normal request behavior.
- Helps prevent unnecessary workflow failures while still surfacing persistent or rate-limit-related errors.