### PR TITLE
Bump slackapi/slack-github-action from v3.0.5 to v4.0.0 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -148,7 +148,7 @@ jobs:
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.publish.result == 'success' && needs.sbom.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v3.0.5
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_LLM }}
@@ -156,7 +156,7 @@ jobs:
             text: "*${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
         if: needs.publish.result != 'success' || needs.sbom.result != 'success'
-        uses: slackapi/slack-github-action@v3.0.5
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_LLM }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.5 to v4.0.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Upgraded the Slack GitHub Action used by the publishing workflow from v3.0.5 to v4.0.0. 🔄

### 📊 Key Changes

- Updated the **Notify Success** step to use `slackapi/slack-github-action@v4.0.0`.
- Updated the **Notify Failure** step to use `slackapi/slack-github-action@v4.0.0`.
- Kept the existing webhook configuration and notification messages unchanged.

### 🎯 Purpose & Impact

- ✅ Ensures release notifications use the latest major version of the Slack GitHub Action.
- 🔧 May provide improved compatibility, maintenance, and support from the action.
- 📢 Success and failure alerts for publishing workflows should continue reaching Slack without changing their content.