### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache build
       - run: python -m build
       - uses: actions/upload-artifact@v7
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: |
           uv venv sbom-env
           uv pip install -e .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: ultralytics/actions/setup-uv@main
+      - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: ultralytics/actions/setup-uv@main
+      - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
       - run: uv pip install --system --no-cache build
       - run: python -m build
       - uses: actions/upload-artifact@v7
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: ultralytics/actions/setup-uv@main
+      - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
       - run: |
           uv venv sbom-env
           uv pip install -e .

--- a/action.yml
+++ b/action.yml
@@ -107,11 +107,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - uses: astral-sh/setup-uv@v7
-      with:
-        ignore-empty-workdir: true
-        enable-cache: false
-        version: "0.9.4"
+    - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
     - name: Install Dependencies
       # Note tomli required for codespell with pyproject.toml
       env:

--- a/cla/action.yml
+++ b/cla/action.yml
@@ -16,11 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-      with:
-        github-token: ""
-        ignore-empty-workdir: true
-        version: "0.9.4"
+    - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
 
     - name: Check CLA
       env:

--- a/dependabot/action.yml
+++ b/dependabot/action.yml
@@ -29,11 +29,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: astral-sh/setup-uv@v7
-      with:
-        ignore-empty-workdir: true
-        enable-cache: false
-        version: "0.9.4"
+    - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
 
     - name: Install ultralytics-actions
       env:

--- a/github-report/action.yml
+++ b/github-report/action.yml
@@ -45,11 +45,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: astral-sh/setup-uv@v7
-      with:
-        ignore-empty-workdir: true
-        enable-cache: false
-        version: "0.9.4"
+    - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
 
     - name: Install ultralytics-actions
       env:


### PR DESCRIPTION
## Summary

- replace every executable Astral uv setup step in this repository with the shared retried owner
- pin reusable composite actions and privileged release workflows to the reviewed Windows-capable implementation from #819

Reused: `ultralytics/actions/setup-uv` is now the single uv installer owner and intentionally installs the latest uv release.

Deleted: four Astral composite-action dependencies, three Astral workflow dependencies, and 16 lines of obsolete cache/version/workdir configuration.

## Validation

- zero `uses: astral-sh/setup-uv` occurrences
- YAML parse for all changed composite actions
- `git diff --check`
- Actions owner #819 passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Centralized all `uv` setup across Ultralytics GitHub Actions by switching to the pinned internal `setup-uv` action. 🔧

### 📊 Key Changes

- Replaced `astral-sh/setup-uv` with `ultralytics/actions/setup-uv` at a fixed commit.
- Updated `publish.yml` to use the internal action for publishing, package building, and SBOM generation.
- Updated the main composite action, CLA, Dependabot, and GitHub reporting actions.
- Removed duplicated `uv` configuration, including explicit version, cache, and empty-workdir settings.

### 🎯 Purpose & Impact

- Provides a consistent `uv` setup across all repository workflows. ✅
- Centralizes configuration and simplifies future maintenance.
- Pins the action to a specific commit for more predictable and reproducible CI runs.
- Reduces reliance on external action configuration, potentially improving control and supply-chain stability. 🔒