### PR TITLE
Track shared setup-uv on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache build
       - run: python -m build
       - uses: actions/upload-artifact@v7
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
+      - uses: ultralytics/actions/setup-uv@main
       - run: |
           uv venv sbom-env
           uv pip install -e .

--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
+    - uses: ultralytics/actions/setup-uv@main
     - name: Install Dependencies
       # Note tomli required for codespell with pyproject.toml
       env:

--- a/cla/action.yml
+++ b/cla/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
+    - uses: ultralytics/actions/setup-uv@main
 
     - name: Check CLA
       env:

--- a/dependabot/action.yml
+++ b/dependabot/action.yml
@@ -29,7 +29,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
+    - uses: ultralytics/actions/setup-uv@main
 
     - name: Install ultralytics-actions
       env:

--- a/github-report/action.yml
+++ b/github-report/action.yml
@@ -45,7 +45,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ultralytics/actions/setup-uv@fb59797d8aaaf12aa0d2d3aa7fe66dd64db99833
+    - uses: ultralytics/actions/setup-uv@main
 
     - name: Install ultralytics-actions
       env:

--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: ultralytics/actions/retry@a9e123c43a227f70901da045ca6ef1c08c6bb39d
+      uses: ultralytics/actions/retry@main
       with:
         run: |
           set -o pipefail


### PR DESCRIPTION
## Summary

- use `ultralytics/actions/setup-uv@main` for every shared uv setup call
- keep the setup action on `ultralytics/actions/retry@main`

Reused: the maintained `main` owners provide latest uv installation and retry behavior everywhere.

Deleted: all immutable `ultralytics/actions/setup-uv` and `ultralytics/actions/retry` SHA references.

## Validation

- all seven setup calls are exactly `ultralytics/actions/setup-uv@main`
- `actionlint .github/workflows/ci.yml`
- YAML parse and `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔄 Updated shared GitHub Actions references from fixed commits to the `main` branch for easier maintenance and faster updates.

### 📊 Key Changes

- Replaced the pinned `setup-uv` action commit with `ultralytics/actions/setup-uv@main` across:
  - Publishing workflows
  - The primary composite action
  - CLA, Dependabot, and GitHub report actions
- Updated `setup-uv` to use `ultralytics/actions/retry@main` instead of a fixed commit.
- Applied the changes consistently across all affected workflows and reusable actions.

### 🎯 Purpose & Impact

- 🚀 Ensures workflows receive the latest updates and fixes from the shared actions automatically.
- 🛠️ Reduces the maintenance required to update action references manually.
- ⚠️ Introduces a small stability and security trade-off because the `main` branch can change unexpectedly, unlike immutable commit pins.
- ✅ Keeps Python setup, package publishing, dependency installation, and reporting workflows aligned with the latest shared action behavior.