### PR TITLE
Add optional caching to setup-uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           python-version: "3.14"
           activate-environment: true
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - run: |
           uv --version
           python -c "import os, sys; assert sys.version_info[:2] == (3, 14); assert os.environ['VIRTUAL_ENV'].endswith(r'\.venv')"
@@ -44,6 +46,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
         run: |

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.28"
+__version__ = "0.2.29"

--- a/setup-uv/README.md
+++ b/setup-uv/README.md
@@ -9,11 +9,15 @@ Installs the latest [uv](https://docs.astral.sh/uv/) release with retry support 
   with:
     python-version: "3.14"
     activate-environment: true
+    enable-cache: true
+    cache-dependency-glob: "pyproject.toml"
 ```
 
 ## Inputs
 
-| Input                  | Description                               | Required | Default |
-| ---------------------- | ----------------------------------------- | -------- | ------- |
-| `python-version`       | Python version for uv commands            | No       | -       |
-| `activate-environment` | Create and activate a `.venv` environment | No       | `false` |
+| Input                   | Description                               | Required | Default      |
+| ----------------------- | ----------------------------------------- | -------- | ------------ |
+| `python-version`        | Python version for uv commands            | No       | -            |
+| `activate-environment`  | Create and activate a `.venv` environment | No       | `false`      |
+| `enable-cache`          | Cache uv downloads between workflow runs  | No       | `false`      |
+| `cache-dependency-glob` | Dependency files used to invalidate cache | No       | `**/uv.lock` |

--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -11,6 +11,14 @@ inputs:
     description: "Create and activate a .venv environment"
     required: false
     default: "false"
+  enable-cache:
+    description: "Cache uv downloads between workflow runs"
+    required: false
+    default: "false"
+  cache-dependency-glob:
+    description: "Dependency files used to invalidate the uv cache"
+    required: false
+    default: "**/uv.lock"
 
 runs:
   using: "composite"
@@ -49,3 +57,16 @@ runs:
             echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
           fi
         fi
+
+    - name: Find uv cache
+      if: inputs.enable-cache == 'true'
+      id: uv-cache
+      shell: bash
+      run: echo "path=$(uv cache dir)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache uv
+      if: inputs.enable-cache == 'true'
+      uses: actions/cache@v6
+      with:
+        path: ${{ steps.uv-cache.outputs.path }}
+        key: uv-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ hashFiles(inputs.cache-dependency-glob) }}

--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -70,3 +70,4 @@ runs:
       with:
         path: ${{ steps.uv-cache.outputs.path }}
         key: uv-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-${{ hashFiles(inputs.cache-dependency-glob) }}
+        restore-keys: uv-${{ runner.os }}-${{ runner.arch }}-${{ inputs.python-version }}-


### PR DESCRIPTION
## Summary
- add opt-in uv download caching to the shared setup action
- invalidate caches from a caller-selected dependency glob
- exercise caching in the existing Windows, Ubuntu, and macOS setup-uv jobs
- bump the package patch version to 0.2.29

Reused: actions/cache@v6 owns cross-platform restore and post-job persistence; the existing setup action owns cache-path discovery and its existing CI jobs validate the new inputs.

Deleted: no runtime code; caching was absent from the shared owner, so preserving existing enabled caches requires extending that owner before replacing Astral callers.

## Validation
- actionlint .github/workflows/ci.yml
- parsed setup-uv/action.yml and verified both inputs plus the cache step
- git diff --check
- live setup-uv jobs on Windows, Ubuntu, and macOS

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds configurable `uv` dependency caching to speed up GitHub Actions workflows and releases version `0.2.29`. ⚡

### 📊 Key Changes
- Added `enable-cache` and `cache-dependency-glob` inputs to the `setup-uv` action.
- Implemented caching with `actions/cache@v6`, keyed by OS, architecture, Python version, and dependency files.
- Enabled `uv` caching in the repository’s CI workflows using `pyproject.toml` for cache invalidation.
- Updated `setup-uv` documentation with the new inputs and usage example.
- Bumped the package version from `0.2.28` to `0.2.29`.

### 🎯 Purpose & Impact
- Reduces workflow runtime by reusing downloaded `uv` packages across runs. 🚀
- Automatically refreshes caches when dependency files change, helping keep builds reliable.
- Gives users control over whether caching is enabled and which files trigger cache invalidation.
- Improves CI efficiency without changing the default behavior for existing users.