### PR TITLE
Remove codespell rare dictionary to avoid rewriting valid words

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -266,11 +266,11 @@ runs:
         echo "::group::Run Codespell"
         trap 'echo "::endgroup::"' EXIT
         codespell \
-          --builtin clear,rare,informal,en-GB_to_en-US \
+          --builtin clear,informal,en-GB_to_en-US \
           --write-changes \
           --uri-ignore-words-list "*" \
           --ignore-regex '\b[a-z]+[A-Z][a-zA-Z]*\b' \
-          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,cann,CANN" \
+          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN" \
           --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml"
       shell: bash
       continue-on-error: true

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.29"
+__version__ = "0.2.30"

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -34,14 +34,14 @@ fi
 CODESPELL = [
     "codespell",
     "--builtin",
-    "clear,rare,informal,en-GB_to_en-US",
+    "clear,informal,en-GB_to_en-US",
     "--write-changes",
     "--uri-ignore-words-list",
     "*",
     "--ignore-regex",
     r"\b[a-z]+[A-Z][a-zA-Z]*\b",
     "--ignore-words-list",
-    "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,WIT,Smoot,EHR,ROUGE,ALS,Carmel,FPR,Hach,Calle,ore,COO,MOT,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,commend,bloc,nam,afterall,skelton,goin,cann,CANN",
+    "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN",
     "--skip",
     "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml",
 ]


### PR DESCRIPTION
## Summary

Removes codespell's `rare` built-in dictionary from the spelling check in both owners: `actions/format_code.py` and the synchronized `action.yml` command.

Codespell runs here with `--write-changes`, so it **auto-rewrites** source and docs in place. The `rare` dictionary maps valid-but-uncommon English words to more common ones, producing silent, incorrect rewrites across every repo that uses this action. Known examples from the LVIS dataset class label `manger/trough`:

- `manger` → `manager`
- `trough` → `through`

Removing `rare` fixes this class of false positives at the source instead of adding per-word exceptions. The `clear`, `informal`, and `en-GB_to_en-US` dictionaries are preserved unchanged.

## Ignore-list cleanup

With `rare` gone, seven `--ignore-words-list` entries that existed **only** to suppress `rare`-dictionary false positives are now dead weight and have been deleted: `WIT`, `ROUGE`, `ore`, `COO`, `MOT`, `commend`, `bloc`. (Each was verified to appear only in codespell's `dictionary_rare.txt`, not in `clear`/`informal`/`en-GB_to_en-US`.)

## Validation

- `pytest tests/test_format_code.py` passes — the `action.yml` ↔ `format_code.py` sync assertion confirms both owners stay identical.
- Ran the new codespell config over the full repo (dry-run, no `--write-changes`): exit 0, no new findings.
- Bumped `__version__` to `0.2.30` (package behavior change gates PyPI publish).

## Context

Originates from the false-positive report in ultralytics/actions#823 and the sibling docs fix ultralytics/docs#340.

Slack discussion: https://ultralytics-work.slack.com/archives/C01EDRWJ95W/p1784360628239059

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves codespell configuration and releases `ultralytics/actions` version `0.2.30`. ✨

### 📊 Key Changes

- Removed the `rare` codespell dictionary to reduce potentially unwanted spelling corrections.
- Removed several terms from the codespell ignore list, allowing them to be detected as possible misspellings:
  - `WIT`, `ROUGE`, `ore`, `COO`, `MOT`, `commend`, and `bloc`.
- Applied the same codespell updates to both the GitHub Action configuration and Python formatting utility.
- Bumped the package version from `0.2.29` to `0.2.30`. 📦

### 🎯 Purpose & Impact

- Makes spelling checks more consistent and focused on common spelling rules.
- Enables codespell to flag additional terms that may represent genuine typos.
- Keeps automated formatting and CI validation aligned across the repository.
- Users adopting version `0.2.30` will receive the updated linting behavior without other functional changes. ✅