### PR TITLE
Pass PR descriptions to automatic reviews

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.29"
+__version__ = "0.2.30"

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.30"
+__version__ = "0.2.31"

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -202,8 +202,6 @@ def main(*args, **kwargs):
             print("Updating PR description with summary...")
             skipped_dropdown = format_skipped_files_dropdown(response.get("skipped_files", []))
             event.update_pr_description(number, f"{SUMMARY_MARKER}\n\n{ACTIONS_CREDIT}\n\n{summary}{skipped_dropdown}")
-        else:
-            summary = body
 
         if relevant_labels := response.get("labels", []):
             apply_and_check_labels(event, number, node_id, issue_type, username, relevant_labels, label_descriptions)

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -221,7 +221,7 @@ def main(*args, **kwargs):
             except RuntimeError as e:
                 print(f"Skipping stale PR review: {e}")
                 return
-            review_data = review_pr.generate_pr_review(event.repository, review_diff, title, summary, event, head_sha)
+            review_data = review_pr.generate_pr_review(event.repository, review_diff, title, body, event, head_sha)
             review_pr.post_review_summary(event, review_data)
             print("PR review completed")
         return

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -219,7 +219,9 @@ def main(*args, **kwargs):
             except RuntimeError as e:
                 print(f"Skipping stale PR review: {e}")
                 return
-            review_data = review_pr.generate_pr_review(event.repository, review_diff, title, body, event, head_sha)
+            review_data = review_pr.generate_pr_review(
+                event.repository, review_diff, title, body or summary or "", event, head_sha
+            )
             review_pr.post_review_summary(event, review_data)
             print("PR review completed")
         return

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -202,7 +202,7 @@ def main(*args, **kwargs):
             print("Updating PR description with summary...")
             skipped_dropdown = format_skipped_files_dropdown(response.get("skipped_files", []))
             event.update_pr_description(number, f"{SUMMARY_MARKER}\n\n{ACTIONS_CREDIT}\n\n{summary}{skipped_dropdown}")
-            if len(body.strip()) < 30:
+            if sum(not char.isspace() for char in body) < 30:
                 body = f"{body.rstrip()}\n\n{summary}".lstrip()
 
         if relevant_labels := response.get("labels", []):

--- a/actions/first_interaction.py
+++ b/actions/first_interaction.py
@@ -202,6 +202,8 @@ def main(*args, **kwargs):
             print("Updating PR description with summary...")
             skipped_dropdown = format_skipped_files_dropdown(response.get("skipped_files", []))
             event.update_pr_description(number, f"{SUMMARY_MARKER}\n\n{ACTIONS_CREDIT}\n\n{summary}{skipped_dropdown}")
+            if len(body.strip()) < 30:
+                body = f"{body.rstrip()}\n\n{summary}".lstrip()
 
         if relevant_labels := response.get("labels", []):
             apply_and_check_labels(event, number, node_id, issue_type, username, relevant_labels, label_descriptions)
@@ -219,9 +221,7 @@ def main(*args, **kwargs):
             except RuntimeError as e:
                 print(f"Skipping stale PR review: {e}")
                 return
-            review_data = review_pr.generate_pr_review(
-                event.repository, review_diff, title, body or summary or "", event, head_sha
-            )
+            review_data = review_pr.generate_pr_review(event.repository, review_diff, title, body, event, head_sha)
             review_pr.post_review_summary(event, review_data)
             print("PR review completed")
         return

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -67,9 +67,19 @@ def test_get_event_content_pr():
 @patch("actions.first_interaction.get_pr_open_response")
 @patch("actions.first_interaction.get_event_content")
 @patch("actions.first_interaction.Action")
-@pytest.mark.parametrize("body", ["PR description\n\nDeleted: superseded registry entries.", ""])
-def test_open_pr_review_uses_author_description(mock_action, mock_content, mock_response, mock_review, mock_post, body):
-    """Test automatic reviews prefer the author's description and fall back to the generated summary."""
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (
+            "PR description\n\nDeleted: superseded registry entries.",
+            "PR description\n\nDeleted: superseded registry entries.",
+        ),
+        ("Short description.", "Short description.\n\nGenerated summary"),
+        ("", "Generated summary"),
+    ],
+)
+def test_open_pr_review_description(mock_action, mock_content, mock_response, mock_review, mock_post, body, expected):
+    """Test automatic reviews use the best available author and generated description context."""
     mock_content.return_value = (456, "node456", "Test PR", body, "testuser", "pull request", "opened")
     mock_response.return_value = {"summary": "Generated summary", "labels": [], "first_comment": ""}
     mock_review.return_value = {"head_sha": "headsha", "summary": "LGTM", "comments": []}
@@ -82,9 +92,7 @@ def test_open_pr_review_uses_author_description(mock_action, mock_content, mock_
 
     first_interaction.main()
 
-    mock_review.assert_called_once_with(
-        event.repository, "review diff", "Test PR", body or "Generated summary", event, "headsha"
-    )
+    mock_review.assert_called_once_with(event.repository, "review diff", "Test PR", expected, event, "headsha")
     mock_post.assert_called_once_with(event, mock_review.return_value)
 
 

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from actions import review_pr
+from actions import first_interaction, review_pr
 from actions.first_interaction import get_event_content, get_first_interaction_response, get_relevant_labels
 
 
@@ -60,6 +60,30 @@ def test_get_event_content_pr():
     assert username == "testuser"
     assert issue_type == "pull request"
     assert action == "opened"
+
+
+@patch("actions.first_interaction.review_pr.post_review_summary")
+@patch("actions.first_interaction.review_pr.generate_pr_review")
+@patch("actions.first_interaction.get_pr_open_response")
+@patch("actions.first_interaction.get_event_content")
+@patch("actions.first_interaction.Action")
+def test_open_pr_review_uses_author_description(mock_action, mock_content, mock_response, mock_review, mock_post):
+    """Test automatic reviews receive the author's description instead of the generated summary."""
+    body = "PR description\n\nDeleted: superseded registry entries."
+    mock_content.return_value = (456, "node456", "Test PR", body, "testuser", "pull request", "opened")
+    mock_response.return_value = {"summary": "Generated summary", "labels": [], "first_comment": ""}
+    mock_review.return_value = {"head_sha": "headsha", "summary": "LGTM", "comments": []}
+    event = mock_action.return_value
+    event.should_skip_llm.return_value = False
+    event.should_skip_pr_author.return_value = False
+    event.get_repo_data.return_value = []
+    event.get_pr_diff.return_value = "diff"
+    event.get_pr_diff_snapshot.return_value = ("review diff", "headsha")
+
+    first_interaction.main()
+
+    mock_review.assert_called_once_with(event.repository, "review diff", "Test PR", body, event, "headsha")
+    mock_post.assert_called_once_with(event, mock_review.return_value)
 
 
 @patch("actions.first_interaction.get_response")

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -67,9 +67,9 @@ def test_get_event_content_pr():
 @patch("actions.first_interaction.get_pr_open_response")
 @patch("actions.first_interaction.get_event_content")
 @patch("actions.first_interaction.Action")
-def test_open_pr_review_uses_author_description(mock_action, mock_content, mock_response, mock_review, mock_post):
-    """Test automatic reviews receive the author's description instead of the generated summary."""
-    body = "PR description\n\nDeleted: superseded registry entries."
+@pytest.mark.parametrize("body", ["PR description\n\nDeleted: superseded registry entries.", ""])
+def test_open_pr_review_uses_author_description(mock_action, mock_content, mock_response, mock_review, mock_post, body):
+    """Test automatic reviews prefer the author's description and fall back to the generated summary."""
     mock_content.return_value = (456, "node456", "Test PR", body, "testuser", "pull request", "opened")
     mock_response.return_value = {"summary": "Generated summary", "labels": [], "first_comment": ""}
     mock_review.return_value = {"head_sha": "headsha", "summary": "LGTM", "comments": []}
@@ -82,7 +82,9 @@ def test_open_pr_review_uses_author_description(mock_action, mock_content, mock_
 
     first_interaction.main()
 
-    mock_review.assert_called_once_with(event.repository, "review diff", "Test PR", body, event, "headsha")
+    mock_review.assert_called_once_with(
+        event.repository, "review diff", "Test PR", body or "Generated summary", event, "headsha"
+    )
     mock_post.assert_called_once_with(event, mock_review.return_value)
 
 

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -74,7 +74,9 @@ def test_get_event_content_pr():
             "PR description\n\nDeleted: superseded registry entries.",
             "PR description\n\nDeleted: superseded registry entries.",
         ),
-        ("Short description.", "Short description.\n\nGenerated summary"),
+        ("a" * 30, "a" * 30),
+        ("a" * 29, f"{'a' * 29}\n\nGenerated summary"),
+        ("a " * 19 + "a", f"{'a ' * 19}a\n\nGenerated summary"),
         ("", "Generated summary"),
     ],
 )


### PR DESCRIPTION
## Summary

- pass complete author PR descriptions to the automatic review started by first interaction
- append the generated summary when the author description has fewer than 30 non-whitespace characters
- use the generated summary alone when the author description is empty
- add regression coverage for complete, 29/30-character boundary, internally spaced, and empty descriptions

## Validation

- `pytest tests/test_first_interaction.py -v` — 19 passed
- `pytest tests -v` — 151 passed before the parameterized context cases were added
- `ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py39 --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 .`
- `ruff format --line-length 120 .`

Deleted: the unconditional generated-summary substitution and obsolete assignment that hid complete author PR descriptions from automatic reviews.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📝 Improves automatic PR reviews by using the author’s original description when available, while adding generated summaries for very short descriptions.

### 📊 Key Changes

- 🔖 Bumped the package version from `0.2.30` to `0.2.31`.
- 🤖 Updated PR review generation to use the finalized PR description as review context.
- ✨ For descriptions with fewer than 30 non-whitespace characters, appends the generated PR summary.
- 🧪 Added parameterized tests covering normal, short, whitespace-heavy, and empty PR descriptions.

### 🎯 Purpose & Impact

- 🎯 Gives automated reviews more relevant context from the original PR author.
- 📚 Ensures reviews still have useful context when a PR description is missing or too brief.
- ✅ Reduces reliance on generated summaries for well-written descriptions while preserving existing summary generation and labeling behavior.
- 🛡️ Improves reliability through expanded test coverage without changing the review workflow for typical PRs.