### PR TITLE
Optimize PR review context reuse

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.30"
+__version__ = "0.2.32"

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -8,6 +8,7 @@ import re
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from uuid import uuid4
 
 import requests
 
@@ -419,6 +420,8 @@ def get_agent_response(
         "tools": tools,
         "tool_choice": "auto",
         "parallel_tool_calls": True,  # batched tool calls share one turn, so the history is re-billed fewer times
+        "prompt_cache_key": f"agent-run:{uuid4().hex}",
+        "context_management": [{"type": "compaction", "compact_threshold": 200_000}],
     }
     if "gpt-5" in model:
         base_data["reasoning"] = {"effort": reasoning_effort or "low"}

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -273,11 +273,15 @@ def test_get_agent_response_calls_function_tools(mock_post):
     assert first_payload["store"] is True
     assert first_payload["service_tier"] == "default"
     assert first_payload["reasoning"] == {"effort": "low"}
+    assert first_payload["context_management"] == [{"type": "compaction", "compact_threshold": 200_000}]
+    assert first_payload["prompt_cache_key"].startswith("agent-run:")
     assert "include" not in first_payload
     assert "previous_response_id" not in first_payload
     assert first_payload["input"] == [{"role": "user", "content": "review"}]
-    assert mock_post.call_args_list[1].kwargs["json"]["previous_response_id"] == "resp_first"
-    second_input = mock_post.call_args_list[1].kwargs["json"]["input"]
+    second_payload = mock_post.call_args_list[1].kwargs["json"]
+    assert second_payload["previous_response_id"] == "resp_first"
+    assert second_payload["prompt_cache_key"] == first_payload["prompt_cache_key"]
+    second_input = second_payload["input"]
     assert second_input == [
         {
             "type": "function_call_output",


### PR DESCRIPTION
## Summary

- route every iterative review turn through one stable prompt cache key
- enable server-side context compaction after 200,000 rendered tokens
- verify both fields persist across `previous_response_id` turns

Version is bumped to 0.2.32 because PR #826 already reserves 0.2.31.

## Validation

- `ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py39 --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 .`
- `ruff format --line-length 120 .`
- `pytest tests -q --cov=actions --cov-report=xml:coverage.xml` (150 passed)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds prompt caching and automatic context compaction to agent responses, with updated tests and a version bump to 0.2.32. ⚡

### 📊 Key Changes
- Added a unique `prompt_cache_key` for each agent run and reused it across follow-up requests.
- Enabled automatic context compaction when conversations reach 200,000 tokens.
- Updated tests to verify cache-key consistency and compaction settings.
- Bumped the package version from `0.2.31` to `0.2.32`.

### 🎯 Purpose & Impact
- 💰 Reduces repeated prompt processing and potential API costs across multi-turn agent interactions.
- 🧠 Helps prevent overly large conversation contexts from affecting reliability or request limits.
- 🔁 Preserves consistent caching throughout an agent run while keeping separate runs isolated.
- ✅ Improves test coverage for the new OpenAI response configuration.