### PR TITLE
Add centralized PR review workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,52 @@
+name: PR Review
+
+on:
+  repository_dispatch:
+    types: [review_pr]
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./setup-uv
+
+      - name: Review PR
+        env:
+          BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          TARGET_PR_NUMBER: ${{ github.event.client_payload.number }}
+          TARGET_REPOSITORY: ${{ github.event.client_payload.repository }}
+        run: |
+          uv run python - <<'PY'
+          import os
+
+          from actions.review_pr import main
+          from actions.utils import GITHUB_API_URL, Action
+
+          repository = os.environ["TARGET_REPOSITORY"]
+          owner, name = repository.split("/")
+          number = int(os.environ["TARGET_PR_NUMBER"])
+          if owner != "ultralytics" or not name or number < 1:
+              raise ValueError("Invalid target pull request")
+
+          token = os.environ["GITHUB_TOKEN"]
+          event = Action(token=token, event_data={"repository": {"full_name": repository}})
+          pull_request = event.get(
+              f"{GITHUB_API_URL}/repos/{repository}/pulls/{number}", hard=True
+          ).json()
+          main(
+              token=token,
+              event_name="pull_request",
+              event_data={
+                  "action": "review_requested",
+                  "pull_request": pull_request,
+                  "repository": {"full_name": repository},
+                  "requested_reviewer": {"login": event.get_username()},
+              },
+          )
+          PY

--- a/actions/format_python_docstrings.py
+++ b/actions/format_python_docstrings.py
@@ -42,11 +42,13 @@ TABLE_RULE_RX = re.compile(r"^\s*[:\-\|\s]{3,}$")
 TREE_CHARS = ("└", "├", "│", "─")
 
 # Antipatterns for non-Google docstring styles
-RST_FIELD_RX = re.compile(r"^\s*:(param|type|return|rtype|raises)\b", re.M)
-EPYDOC_RX = re.compile(r"^\s*@(?:param|type|return|rtype|raise)\b", re.M)
-NUMPY_UNDERLINE_SECTION_RX = re.compile(r"^\s*(Parameters|Returns|Yields|Raises|Notes|Examples)\n[-]{3,}\s*$", re.M)
+RST_FIELD_RX = re.compile(r"^\s*:(param|type|return|rtype|raises)\b", re.MULTILINE)
+EPYDOC_RX = re.compile(r"^\s*@(?:param|type|return|rtype|raise)\b", re.MULTILINE)
+NUMPY_UNDERLINE_SECTION_RX = re.compile(
+    r"^\s*(Parameters|Returns|Yields|Raises|Notes|Examples)\n[-]{3,}\s*$", re.MULTILINE
+)
 GOOGLE_SECTION_RX = re.compile(
-    r"^\s*(Args|Attributes|Methods|Returns|Yields|Raises|Example|Examples|Notes|References):\s*$", re.M
+    r"^\s*(Args|Attributes|Methods|Returns|Yields|Raises|Example|Examples|Notes|References):\s*$", re.MULTILINE
 )
 NON_GOOGLE = {"numpy", "rest", "epydoc"}
 
@@ -283,9 +285,8 @@ def format_structured_block(lines: list[str], width: int, base: int) -> list[str
         desc = " ".join(parts)
         head = " " * cont + (f"{name}: " if (desc or had_colon) else name)
         out.extend(wrap_hanging(head, desc, width, cont + 4))
-        if tail:
-            if body := emit_paragraphs(tail, width, cont + 4, lst, orphan_min=2):
-                out.extend(body)
+        if tail and (body := emit_paragraphs(tail, width, cont + 4, lst, orphan_min=2)):
+            out.extend(body)
     return out
 
 

--- a/actions/github_report.py
+++ b/actions/github_report.py
@@ -113,8 +113,10 @@ def format_pr_report(prs, repos, visibility, org="ultralytics"):
     lines.extend(
         [
             f"**Total:** {len(prs)} open PRs across {repo_count}/{len(repos)} {visibility} repos",
-            f"**By Phase:** 🆕 {phase_counts['new']} New | 🟢 {phase_counts['green']} ≤7d | "
-            f"🟡 {phase_counts['yellow']} ≤30d | 🔴 {phase_counts['red']} >30d",
+            (
+                f"**By Phase:** 🆕 {phase_counts['new']} New | 🟢 {phase_counts['green']} ≤7d | "
+                f"🟡 {phase_counts['yellow']} ≤30d | 🔴 {phase_counts['red']} >30d"
+            ),
             "",
         ]
     )

--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -202,7 +202,7 @@ def remove_html_comments(body: str) -> str:
 def should_skip_file(path: str) -> bool:
     """Return True if file path matches a generated/minified skip pattern (lock files, images, etc.)."""
     normalized = Path(path).as_posix()
-    normalized = normalized[2:] if normalized.startswith("./") else normalized
+    normalized = normalized.removeprefix("./")
     filename = normalized.rsplit("/", 1)[-1]
     return any(pattern.search(candidate) for pattern in SKIP_PATTERNS for candidate in (normalized, filename))
 

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -89,7 +89,7 @@ def filter_labels(available_labels: dict, current_labels: list | None = None, is
     current_labels = current_labels or []
     filtered = available_labels.copy()
 
-    for label in {
+    for label in (
         "help wanted",
         "TODO",
         "research",
@@ -99,7 +99,7 @@ def filter_labels(available_labels: dict, current_labels: list | None = None, is
         "Stale",
         "wontfix",
         "duplicate",
-    }:
+    ):
         filtered.pop(label, None)
 
     if "bug" in current_labels:

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -40,10 +40,9 @@ def test_get_pr_branch_fork():
         "base": {"repo": {"id": 1}},
     }
 
-    with patch("time.time", return_value=1234567.890):
-        with patch("subprocess.run") as mock_run:
-            with patch("os.environ.get", return_value="test-token"):
-                branch, temp_branch = get_pr_branch(mock_event)
+    with patch("time.time", return_value=1234567.890), patch("subprocess.run") as mock_run:
+        with patch("os.environ.get", return_value="test-token"):
+            branch, temp_branch = get_pr_branch(mock_event)
 
     assert branch == "temp-ci-456-1234567890"
     assert temp_branch == "temp-ci-456-1234567890"

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -364,22 +364,7 @@ def test_get_repo_guidelines_fetches_pr_head(mock_fetch):
 
 def test_review_agent_tools_can_list_and_read_changed_file_diffs():
     """Test PR diff tools let the agent inspect every changed file on demand."""
-    diff = "\n".join(
-        [
-            "diff --git a/early.py b/early.py",
-            "--- a/early.py",
-            "+++ b/early.py",
-            "@@ -1 +1 @@",
-            "-old = True",
-            "+old = False",
-            "diff --git a/nested/late.py b/nested/late.py",
-            "--- a/nested/late.py",
-            "+++ b/nested/late.py",
-            "@@ -10 +10 @@",
-            "-value = 1",
-            "+value = 2",
-        ]
-    )
+    diff = "diff --git a/early.py b/early.py\n--- a/early.py\n+++ b/early.py\n@@ -1 +1 @@\n-old = True\n+old = False\ndiff --git a/nested/late.py b/nested/late.py\n--- a/nested/late.py\n+++ b/nested/late.py\n@@ -10 +10 @@\n-value = 1\n+value = 2"
     diff_files, augmented_diff = review_pr.parse_diff_files(diff)
     _, handlers = review_pr.build_review_agent_tools(diff_files, augmented_diff)
 

--- a/tests/test_github_report.py
+++ b/tests/test_github_report.py
@@ -11,7 +11,7 @@ def test_paginate_only_skips_http_errors_when_allowed(monkeypatch):
 
     def fake_get(path, params=None, token=None, allow_skip=False):
         if allow_skip:
-            return None
+            return
         raise PermissionError(path)
 
     monkeypatch.setattr(failed_scheduled_actions, "github_get", fake_get)

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -257,15 +257,14 @@ def test_get_agent_response_calls_function_tools(mock_post):
         }
     ]
 
-    with patch("actions.utils.openai_utils.OPENAI_API_KEY", "test-key"):
-        with patch("builtins.print") as mock_print:
-            result = get_agent_response(
-                [{"role": "user", "content": "review"}],
-                tools=tools,
-                tool_handlers={"lookup_value": lambda value: {"found": value}},
-                text_format={"format": {"type": "json_schema", "name": "review", "strict": True, "schema": schema}},
-                retries=0,
-            )
+    with patch("actions.utils.openai_utils.OPENAI_API_KEY", "test-key"), patch("builtins.print") as mock_print:
+        result = get_agent_response(
+            [{"role": "user", "content": "review"}],
+            tools=tools,
+            tool_handlers={"lookup_value": lambda value: {"found": value}},
+            text_format={"format": {"type": "json_schema", "name": "review", "strict": True, "schema": schema}},
+            retries=0,
+        )
 
     assert result == {"comments": [], "summary": "done"}
     assert mock_post.call_count == 2


### PR DESCRIPTION
## Summary

- add one organization-owned dispatch workflow for requested PR reviews
- reuse the existing exact-head reviewer and approval decision path
- restrict targets to Ultralytics repositories

This standalone workflow is the smallest owner-level solution because cross-repository dispatch is a distinct runtime; putting it in each repository or its formatting workflow would duplicate configuration and drift.

Deleted: per-repository review workflow changes are no longer required.

## Validation

- `npx prettier --check .github/workflows/review.yml`
- `actionlint .github/workflows/review.yml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a centralized GitHub Actions workflow to review pull requests triggered by a `repository_dispatch` event.

### 📊 Key Changes
- Adds `.github/workflows/review.yml` with a `review_pr` dispatch trigger.
- Checks out the repository and initializes the shared `setup-uv` environment.
- Retrieves the target pull request using the configured GitHub token and validates the repository and PR number.
- Invokes `actions.review_pr.main` with the target PR data and required Brave and OpenAI API credentials.

### 🎯 Purpose & Impact
- Centralizes automated PR review execution for repositories in the Ultralytics organization.
- Enables reviews to be requested on demand through a repository dispatch event.
- Uses read-only contents permissions and explicit secret-based authentication to limit workflow access.
- Improves consistency and maintainability of automated review operations, while requiring correct event payloads and repository secrets.