### PR TITLE
Ignore intentional broad exception handling in Ruff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ pytest tests/test_github_utils.py::test_name -v             # run one test
 pytest tests -v --cov=actions --cov-report=xml:coverage.xml # tests with coverage (CI command)
 
 # Lint/format — mirrors the "Run Python" step in action.yml (source of truth if these drift)
-ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA \
+ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py38 \
   --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 .
 ruff format --line-length 120 .
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ pytest tests/test_github_utils.py::test_name -v             # run one test
 pytest tests -v --cov=actions --cov-report=xml:coverage.xml # tests with coverage (CI command)
 
 # Lint/format — mirrors the "Run Python" step in action.yml (source of truth if these drift)
-ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py39 \
+ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA \
   --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 .
 ruff format --line-length 120 .
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ pytest tests -v --cov=actions --cov-report=xml:coverage.xml # tests with coverag
 
 # Lint/format — mirrors the "Run Python" step in action.yml (source of truth if these drift)
 ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py39 \
-  --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 .
+  --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 .
 ruff format --line-length 120 .
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -172,7 +172,7 @@ runs:
     # D406: Section name should end with a newline
     # D407: Missing dashed underline after section
     # D413: Missing blank line after last section
-    # --target-version is Python 3.9 for --extend-select UP (pyupgrade)
+    # --target-version is Python 3.8 for --extend-select UP (pyupgrade)
     - name: Run Python
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && inputs.python == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |

--- a/action.yml
+++ b/action.yml
@@ -182,7 +182,6 @@ runs:
         --fix \
         --unsafe-fixes \
         --extend-select F,I,D,UP,RUF,FA \
-        --target-version py39 \
         --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 \
         . || true
         ruff format \

--- a/action.yml
+++ b/action.yml
@@ -182,6 +182,7 @@ runs:
         --fix \
         --unsafe-fixes \
         --extend-select F,I,D,UP,RUF,FA \
+        --target-version py38 \
         --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 \
         . || true
         ruff format \

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
         --unsafe-fixes \
         --extend-select F,I,D,UP,RUF,FA \
         --target-version py39 \
-        --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 \
+        --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 \
         . || true
         ruff format \
         --line-length 120 \

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.33"
+__version__ = "0.2.34"

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -12,7 +12,6 @@ RUFF_CHECK = [
     "--fix",
     "--unsafe-fixes",
     "--extend-select=F,I,D,UP,RUF,FA",
-    "--target-version=py39",
     "--ignore=BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110",
     ".",
 ]

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -12,6 +12,7 @@ RUFF_CHECK = [
     "--fix",
     "--unsafe-fixes",
     "--extend-select=F,I,D,UP,RUF,FA",
+    "--target-version=py38",
     "--ignore=BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110",
     ".",
 ]

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -13,7 +13,7 @@ RUFF_CHECK = [
     "--unsafe-fixes",
     "--extend-select=F,I,D,UP,RUF,FA",
     "--target-version=py39",
-    "--ignore=D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012",
+    "--ignore=BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110",
     ".",
 ]
 RUFF_FORMAT = ["ruff", "format", "--line-length=120", "."]

--- a/actions/format_python_docstrings.py
+++ b/actions/format_python_docstrings.py
@@ -42,11 +42,13 @@ TABLE_RULE_RX = re.compile(r"^\s*[:\-\|\s]{3,}$")
 TREE_CHARS = ("└", "├", "│", "─")
 
 # Antipatterns for non-Google docstring styles
-RST_FIELD_RX = re.compile(r"^\s*:(param|type|return|rtype|raises)\b", re.M)
-EPYDOC_RX = re.compile(r"^\s*@(?:param|type|return|rtype|raise)\b", re.M)
-NUMPY_UNDERLINE_SECTION_RX = re.compile(r"^\s*(Parameters|Returns|Yields|Raises|Notes|Examples)\n[-]{3,}\s*$", re.M)
+RST_FIELD_RX = re.compile(r"^\s*:(param|type|return|rtype|raises)\b", re.MULTILINE)
+EPYDOC_RX = re.compile(r"^\s*@(?:param|type|return|rtype|raise)\b", re.MULTILINE)
+NUMPY_UNDERLINE_SECTION_RX = re.compile(
+    r"^\s*(Parameters|Returns|Yields|Raises|Notes|Examples)\n[-]{3,}\s*$", re.MULTILINE
+)
 GOOGLE_SECTION_RX = re.compile(
-    r"^\s*(Args|Attributes|Methods|Returns|Yields|Raises|Example|Examples|Notes|References):\s*$", re.M
+    r"^\s*(Args|Attributes|Methods|Returns|Yields|Raises|Example|Examples|Notes|References):\s*$", re.MULTILINE
 )
 NON_GOOGLE = {"numpy", "rest", "epydoc"}
 
@@ -283,9 +285,8 @@ def format_structured_block(lines: list[str], width: int, base: int) -> list[str
         desc = " ".join(parts)
         head = " " * cont + (f"{name}: " if (desc or had_colon) else name)
         out.extend(wrap_hanging(head, desc, width, cont + 4))
-        if tail:
-            if body := emit_paragraphs(tail, width, cont + 4, lst, orphan_min=2):
-                out.extend(body)
+        if tail and (body := emit_paragraphs(tail, width, cont + 4, lst, orphan_min=2)):
+            out.extend(body)
     return out
 
 

--- a/actions/github_report.py
+++ b/actions/github_report.py
@@ -113,8 +113,10 @@ def format_pr_report(prs, repos, visibility, org="ultralytics"):
     lines.extend(
         [
             f"**Total:** {len(prs)} open PRs across {repo_count}/{len(repos)} {visibility} repos",
-            f"**By Phase:** 🆕 {phase_counts['new']} New | 🟢 {phase_counts['green']} ≤7d | "
-            f"🟡 {phase_counts['yellow']} ≤30d | 🔴 {phase_counts['red']} >30d",
+            (
+                f"**By Phase:** 🆕 {phase_counts['new']} New | 🟢 {phase_counts['green']} ≤7d | "
+                f"🟡 {phase_counts['yellow']} ≤30d | 🔴 {phase_counts['red']} >30d"
+            ),
             "",
         ]
     )

--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -72,7 +72,6 @@ def format_code_with_ruff(temp_dir):
                 "--fix",
                 "--unsafe-fixes",
                 "--extend-select=F,I,D,UP,RUF",
-                "--target-version=py39",
                 "--ignore=BLE001,D100,D101,D103,D104,D203,D205,D212,D213,D401,D406,D407,D413,F821,F841,RUF001,RUF002,RUF012,S110",
                 str(temp_dir),
             ],

--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -72,6 +72,7 @@ def format_code_with_ruff(temp_dir):
                 "--fix",
                 "--unsafe-fixes",
                 "--extend-select=F,I,D,UP,RUF",
+                "--target-version=py38",
                 "--ignore=BLE001,D100,D101,D103,D104,D203,D205,D212,D213,D401,D406,D407,D413,F821,F841,RUF001,RUF002,RUF012,S110",
                 str(temp_dir),
             ],

--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -73,7 +73,7 @@ def format_code_with_ruff(temp_dir):
                 "--unsafe-fixes",
                 "--extend-select=F,I,D,UP,RUF",
                 "--target-version=py39",
-                "--ignore=D100,D101,D103,D104,D203,D205,D212,D213,D401,D406,D407,D413,F821,F841,RUF001,RUF002,RUF012",
+                "--ignore=BLE001,D100,D101,D103,D104,D203,D205,D212,D213,D401,D406,D407,D413,F821,F841,RUF001,RUF002,RUF012,S110",
                 str(temp_dir),
             ],
             check=True,

--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -202,7 +202,7 @@ def remove_html_comments(body: str) -> str:
 def should_skip_file(path: str) -> bool:
     """Return True if file path matches a generated/minified skip pattern (lock files, images, etc.)."""
     normalized = Path(path).as_posix()
-    normalized = normalized.removeprefix("./")
+    normalized = normalized[2:] if normalized.startswith("./") else normalized
     filename = normalized.rsplit("/", 1)[-1]
     return any(pattern.search(candidate) for pattern in SKIP_PATTERNS for candidate in (normalized, filename))
 

--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -202,7 +202,7 @@ def remove_html_comments(body: str) -> str:
 def should_skip_file(path: str) -> bool:
     """Return True if file path matches a generated/minified skip pattern (lock files, images, etc.)."""
     normalized = Path(path).as_posix()
-    normalized = normalized[2:] if normalized.startswith("./") else normalized
+    normalized = normalized.removeprefix("./")
     filename = normalized.rsplit("/", 1)[-1]
     return any(pattern.search(candidate) for pattern in SKIP_PATTERNS for candidate in (normalized, filename))
 

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -89,7 +89,7 @@ def filter_labels(available_labels: dict, current_labels: list | None = None, is
     current_labels = current_labels or []
     filtered = available_labels.copy()
 
-    for label in {
+    for label in (
         "help wanted",
         "TODO",
         "research",
@@ -99,7 +99,7 @@ def filter_labels(available_labels: dict, current_labels: list | None = None, is
         "Stale",
         "wontfix",
         "duplicate",
-    }:
+    ):
         filtered.pop(label, None)
 
     if "bug" in current_labels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ omit = [
 
 [tool.ruff]
 line-length = 120
+target-version = "py38"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -40,10 +40,9 @@ def test_get_pr_branch_fork():
         "base": {"repo": {"id": 1}},
     }
 
-    with patch("time.time", return_value=1234567.890):
-        with patch("subprocess.run") as mock_run:
-            with patch("os.environ.get", return_value="test-token"):
-                branch, temp_branch = get_pr_branch(mock_event)
+    with patch("time.time", return_value=1234567.890), patch("subprocess.run") as mock_run:
+        with patch("os.environ.get", return_value="test-token"):
+            branch, temp_branch = get_pr_branch(mock_event)
 
     assert branch == "temp-ci-456-1234567890"
     assert temp_branch == "temp-ci-456-1234567890"

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -364,22 +364,7 @@ def test_get_repo_guidelines_fetches_pr_head(mock_fetch):
 
 def test_review_agent_tools_can_list_and_read_changed_file_diffs():
     """Test PR diff tools let the agent inspect every changed file on demand."""
-    diff = "\n".join(
-        [
-            "diff --git a/early.py b/early.py",
-            "--- a/early.py",
-            "+++ b/early.py",
-            "@@ -1 +1 @@",
-            "-old = True",
-            "+old = False",
-            "diff --git a/nested/late.py b/nested/late.py",
-            "--- a/nested/late.py",
-            "+++ b/nested/late.py",
-            "@@ -10 +10 @@",
-            "-value = 1",
-            "+value = 2",
-        ]
-    )
+    diff = "diff --git a/early.py b/early.py\n--- a/early.py\n+++ b/early.py\n@@ -1 +1 @@\n-old = True\n+old = False\ndiff --git a/nested/late.py b/nested/late.py\n--- a/nested/late.py\n+++ b/nested/late.py\n@@ -10 +10 @@\n-value = 1\n+value = 2"
     diff_files, augmented_diff = review_pr.parse_diff_files(diff)
     _, handlers = review_pr.build_review_agent_tools(diff_files, augmented_diff)
 

--- a/tests/test_github_report.py
+++ b/tests/test_github_report.py
@@ -11,7 +11,7 @@ def test_paginate_only_skips_http_errors_when_allowed(monkeypatch):
 
     def fake_get(path, params=None, token=None, allow_skip=False):
         if allow_skip:
-            return None
+            return
         raise PermissionError(path)
 
     monkeypatch.setattr(failed_scheduled_actions, "github_get", fake_get)

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -257,15 +257,14 @@ def test_get_agent_response_calls_function_tools(mock_post):
         }
     ]
 
-    with patch("actions.utils.openai_utils.OPENAI_API_KEY", "test-key"):
-        with patch("builtins.print") as mock_print:
-            result = get_agent_response(
-                [{"role": "user", "content": "review"}],
-                tools=tools,
-                tool_handlers={"lookup_value": lambda value: {"found": value}},
-                text_format={"format": {"type": "json_schema", "name": "review", "strict": True, "schema": schema}},
-                retries=0,
-            )
+    with patch("actions.utils.openai_utils.OPENAI_API_KEY", "test-key"), patch("builtins.print") as mock_print:
+        result = get_agent_response(
+            [{"role": "user", "content": "review"}],
+            tools=tools,
+            tool_handlers={"lookup_value": lambda value: {"found": value}},
+            text_format={"format": {"type": "json_schema", "name": "review", "strict": True, "schema": schema}},
+            retries=0,
+        )
 
     assert result == {"comments": [], "summary": "done"}
     assert mock_post.call_count == 2


### PR DESCRIPTION
## Summary

Exclude `BLE001` and `S110` from every Ruff formatting entry point because Ultralytics intentionally uses broad, silent exception handling at optional integration and cleanup boundaries.

Keep the packaged formatter, composite action, Markdown code-block formatter, and documented command aligned.

## Validation

- `PYTHONPATH=. pytest -q tests/test_format_code.py tests/test_update_markdown_codeblocks.py` (12 passed)
- Ruff 0.16.0 on changed Python files
- Prettier 3.6.2 check on `AGENTS.md` and `action.yml`

Deleted: nothing; this replaces existing ignore lists in place without adding code paths.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the Ultralytics GitHub Actions tooling for Python 3.8 compatibility, improved Ruff configuration, and incremented the package version to 0.2.34. 🛠️

### 📊 Key Changes

- Changed Ruff’s target version from Python 3.9 to Python 3.8 across CI, project configuration, and code-formatting utilities.
- Added Ruff ignores for `BLE001` and `S110` to reduce unwanted linting failures.
- Improved docstring formatter readability by using explicit multiline regex flags and simplifying conditional logic.
- Applied minor formatting and test cleanup, including consolidated patch contexts and more concise test fixtures.
- Updated label filtering to use a tuple instead of a set for deterministic iteration.
- Bumped the `actions` package version from `0.2.33` to `0.2.34`. 📦

### 🎯 Purpose & Impact

- Enables the repository’s formatting and linting tools to remain compatible with Python 3.8 environments. 🐍
- Keeps Ruff behavior consistent across local development, CI, and Markdown code-block formatting.
- Reduces formatting noise and improves maintainability without changing core action behavior.
- Makes tests and internal code cleaner while preserving existing functionality.
- Provides a new package release containing these compatibility and maintenance updates. 🚀