### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.34"
+__version__ = "0.2.35"

--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -73,7 +73,7 @@ def format_code_with_ruff(temp_dir):
                 "--unsafe-fixes",
                 "--extend-select=F,I,D,UP,RUF",
                 "--target-version=py38",
-                "--ignore=BLE001,D100,D101,D103,D104,D203,D205,D212,D213,D401,D406,D407,D413,F821,F841,RUF001,RUF002,RUF012,S110",
+                "--ignore=B018,BLE001,D100,D101,D103,D104,D203,D205,D212,D213,D401,D406,D407,D413,F821,F841,RUF001,RUF002,RUF012,S110",
                 str(temp_dir),
             ],
             check=True,
@@ -108,6 +108,7 @@ def format_bash_with_prettier(temp_dir):
             shell=True,  # must use shell=True to expand internal $(cmd)
             capture_output=True,
             text=True,
+            check=False,
         )
         if result.returncode != 0:
             print(f"ERROR running prettier-plugin-sh ❌ {result.stderr}")
@@ -183,7 +184,7 @@ def process_markdown_file(file_path, temp_dir, process_python=True, process_bash
                 temp_file_path = temp_dir / generate_temp_filename(file_path, i + offset, code_type)
 
                 with open(temp_file_path, "w", encoding="utf-8") as temp_file:
-                    temp_file.write(code_without_indentation)
+                    temp_file.write(f"{code_without_indentation}\n")
 
                 temp_files.append((num_spaces, code_block, temp_file_path, code_type))
 
@@ -221,9 +222,9 @@ def update_markdown_file(file_path, markdown_content, temp_files):
         print(f"Error writing file {file_path}: {e}")
 
 
-def main(root_dir=Path.cwd(), process_python=True, process_bash=True, verbose=False):
+def main(root_dir=None, process_python=True, process_bash=True, verbose=False):
     """Processes Markdown files, extracts and formats code blocks, and updates the original files."""
-    root_path = Path(root_dir)
+    root_path = Path.cwd() if root_dir is None else Path(root_dir)
     markdown_files = [markdown_file for markdown_file in root_path.rglob("*.md") if not markdown_file.is_symlink()]
     temp_dir = Path("temp_code_blocks")
     temp_dir.mkdir(exist_ok=True)

--- a/tests/test_update_markdown_codeblocks.py
+++ b/tests/test_update_markdown_codeblocks.py
@@ -106,6 +106,7 @@ def test():
     assert len(temp_files) == 1
     assert temp_files[0][1] == "def test():\n    return True"
     mock_file.assert_called_once()
+    mock_file().write.assert_called_once_with("def test():\n    return True\n")
 
 
 def test_format_bash_skips_when_no_shell_files(tmp_path):


### PR DESCRIPTION
## Summary

- preserve useful Ruff diagnostics for extracted Markdown code blocks while ignoring intentional bare expressions (`B018`)
- write extracted snippets with a terminal newline so unchanged snippets are no longer reported as reformatted
- keep the Markdown helper's subprocess and default-path handling Ruff-compliant
- bump `ultralytics-actions` to 0.2.35

## Validation

- `uv run --extra dev pytest tests -q` (155 passed)
- focused Ruff 0.16.0 check and format verification
- Ultralytics docs: 1,021 snippets unchanged, Ruff check passed with zero remaining diagnostics

Deleted: the implicit import-time `Path.cwd()` default and false-positive formatting signal caused by newline-less temporary snippets.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves Markdown code-block formatting reliability and updates the actions package to version `0.2.35`. 🛠️

### 📊 Key Changes

- Added the Ruff `B018` rule to the ignored checks for formatted Python code blocks.
- Made Prettier shell formatting handle command failures without raising exceptions, while still reporting errors.
- Added a trailing newline when writing extracted code blocks to temporary files.
- Updated the Markdown processing entry point to accept `root_dir=None` and default to the current working directory.
- Expanded tests to verify that temporary code files include the expected trailing newline.
- Bumped the package version from `0.2.34` to `0.2.35`. 📦

### 🎯 Purpose & Impact

- Makes automated Markdown code formatting more robust and predictable.
- Prevents formatting failures from interrupting processing when shell-specific tooling encounters an error.
- Ensures generated temporary files follow standard text-file formatting conventions.
- Improves default behavior and test coverage for processing repositories from the current directory.
- Users should see more reliable documentation formatting with fewer unnecessary Ruff warnings. ✅