### PR TITLE
Speed up action setup with tarball install and parallel tool installs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,23 +107,50 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    # Start npm and brew installs in the background so their downloads overlap the steps below instead of blocking
+    # them. Each formatter step waits for its own marker file before running, and reinstalls if the download failed.
+    - name: Start Tool Installs
+      if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (github.event.action == 'opened' || github.event.action == 'synchronize')
+      env:
+        INPUTS_BIOME: ${{ inputs.biome }}
+        INPUTS_MARKDOWN: ${{ inputs.markdown }}
+        INPUTS_PRETTIER: ${{ inputs.prettier }}
+        INPUTS_SWIFT: ${{ inputs.swift }}
+      run: |
+        # npm installs share a global prefix, so keep them in one background chain ordered by first use
+        (
+          set +e
+          if [ "$INPUTS_BIOME" = "true" ]; then
+            npm install -g @biomejs/biome@latest > "$RUNNER_TEMP/biome-install.log" 2>&1
+            echo $? > "$RUNNER_TEMP/biome-install.done"
+          fi
+          if [ "$INPUTS_PRETTIER" = "true" ] || [ "$INPUTS_MARKDOWN" = "true" ]; then
+            npm install -g prettier@3.6.2 prettier-plugin-sh > "$RUNNER_TEMP/prettier-install.log" 2>&1
+            echo $? > "$RUNNER_TEMP/prettier-install.done"
+          fi
+        ) &
+        if [ "$INPUTS_SWIFT" = "true" ]; then
+          (set +e; brew install swift-format > "$RUNNER_TEMP/swift-install.log" 2>&1; echo $? > "$RUNNER_TEMP/swift-install.done") &
+        fi
+      shell: bash
+
     - uses: ultralytics/actions/setup-uv@main
     - name: Install Dependencies
       # Note tomli required for codespell with pyproject.toml
       env:
         INPUTS_SPELLING: ${{ inputs.spelling }}
         GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_REF: ${{ github.ref }}
+        GITHUB_SHA: ${{ github.sha }}
       run: |
         echo "::group::Install Dependencies"
         trap 'echo "::endgroup::"' EXIT
-        # Install from current git branch if testing in ultralytics/actions repo, otherwise from GitHub main branch
+        # Source tarballs install ~2x faster than git+ URLs, which clone the repository first. Test the current commit
+        # in the ultralytics/actions repo, otherwise install main.
         if [ "$GITHUB_REPOSITORY" = "ultralytics/actions" ]; then
-          echo "Installing from git branch: $GITHUB_REF"
-          packages="git+https://github.com/ultralytics/actions@${GITHUB_REF#refs/heads/}"
+          echo "Installing from commit: $GITHUB_SHA"
+          packages="https://github.com/ultralytics/actions/archive/${GITHUB_SHA}.tar.gz"
         else
-          # packages="ultralytics-actions"
-          packages="git+https://github.com/ultralytics/actions@main"
+          packages="https://github.com/ultralytics/actions/archive/refs/heads/main.tar.gz"
         fi
 
         if [ "$INPUTS_SPELLING" = "true" ]; then
@@ -201,7 +228,9 @@ runs:
         echo "::group::Run Biome"
         trap 'echo "::endgroup::"' EXIT
         if [ -f "biome.json" ] || [ -f "biome.jsonc" ]; then
-          npm install -g @biomejs/biome@latest
+          for _ in $(seq 120); do [ -f "$RUNNER_TEMP/biome-install.done" ] && break; sleep 0.5; done
+          cat "$RUNNER_TEMP/biome-install.log" 2>/dev/null || true
+          [ "$(cat "$RUNNER_TEMP/biome-install.done" 2>/dev/null)" = "0" ] || npm install -g @biomejs/biome@latest
           npx biome --version
           npx biome check --write --line-width=120 --max-diagnostics=1000 --diagnostic-level=error --unsafe .
         else
@@ -216,7 +245,9 @@ runs:
       run: |
         echo "::group::Run Prettier"
         trap 'echo "::endgroup::"' EXIT
-        npm install -g prettier@3.6.2 prettier-plugin-sh
+        for _ in $(seq 120); do [ -f "$RUNNER_TEMP/prettier-install.done" ] && break; sleep 0.5; done
+        cat "$RUNNER_TEMP/prettier-install.log" 2>/dev/null || true
+        [ "$(cat "$RUNNER_TEMP/prettier-install.done" 2>/dev/null)" = "0" ] || npm install -g prettier@3.6.2 prettier-plugin-sh
         ultralytics-actions-update-markdown-code-blocks
         npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
         # Bash file format
@@ -237,7 +268,9 @@ runs:
       run: |
         echo "::group::Run Swift Formatter"
         trap 'echo "::endgroup::"' EXIT
-        brew install swift-format
+        for _ in $(seq 120); do [ -f "$RUNNER_TEMP/swift-install.done" ] && break; sleep 0.5; done
+        cat "$RUNNER_TEMP/swift-install.log" 2>/dev/null || true
+        [ "$(cat "$RUNNER_TEMP/swift-install.done" 2>/dev/null)" = "0" ] || brew install swift-format
         swift-format --in-place --recursive .
       shell: bash
       continue-on-error: true

--- a/action.yml
+++ b/action.yml
@@ -117,8 +117,10 @@ runs:
         INPUTS_PRETTIER: ${{ inputs.prettier }}
         INPUTS_SWIFT: ${{ inputs.swift }}
       run: |
+        echo "::group::Start Tool Installs"
+        trap 'echo "::endgroup::"' EXIT
         if [ "$INPUTS_PRETTIER" = "true" ] || [ "$INPUTS_MARKDOWN" = "true" ]; then
-          (set +e; npm install -g prettier@3.6.2 prettier-plugin-sh > "$RUNNER_TEMP/prettier-install.log" 2>&1; echo $? > "$RUNNER_TEMP/prettier-install.done") &
+          (set +e; npm install -g prettier@3.6.2 > "$RUNNER_TEMP/prettier-install.log" 2>&1; echo $? > "$RUNNER_TEMP/prettier-install.done") &
         fi
         if [ "$INPUTS_SWIFT" = "true" ]; then
           (set +e; brew install swift-format > "$RUNNER_TEMP/swift-install.log" 2>&1; echo $? > "$RUNNER_TEMP/swift-install.done") &
@@ -236,13 +238,12 @@ runs:
         trap 'echo "::endgroup::"' EXIT
         for _ in $(seq 120); do [ -f "$RUNNER_TEMP/prettier-install.done" ] && break; sleep 0.5; done
         cat "$RUNNER_TEMP/prettier-install.log" 2>/dev/null || true
-        [ "$(cat "$RUNNER_TEMP/prettier-install.done" 2>/dev/null)" = "0" ] || npm install -g prettier@3.6.2 prettier-plugin-sh
+        [ "$(cat "$RUNNER_TEMP/prettier-install.done" 2>/dev/null)" = "0" ] || npm install -g prettier@3.6.2
+        curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
         ultralytics-actions-update-markdown-code-blocks
         npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
-        # Bash file format
-        if find . -name "*.sh" -type f | grep -q .; then
-          npx prettier --write --list-different --print-width 120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs "**/*.sh"
-        fi
+        # Bash file format, matching the files Prettier's "**/*.sh" glob covered
+        find . -name "*.sh" -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -exec shfmt -i 2 -sr -bn -ci -l -w {} +
         # Handle Markdown separately
         find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
         if [ -d "./docs" ]; then

--- a/action.yml
+++ b/action.yml
@@ -239,7 +239,7 @@ runs:
         for _ in $(seq 120); do [ -f "$RUNNER_TEMP/prettier-install.done" ] && break; sleep 0.5; done
         cat "$RUNNER_TEMP/prettier-install.log" 2>/dev/null || true
         [ "$(cat "$RUNNER_TEMP/prettier-install.done" 2>/dev/null)" = "0" ] || npm install -g prettier@3.6.2
-        curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+        curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt" && chmod +x "$(npm prefix -g)/bin/shfmt"
         ultralytics-actions-update-markdown-code-blocks
         npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
         # Bash file format, matching the files Prettier's "**/*.sh" glob covered

--- a/action.yml
+++ b/action.yml
@@ -107,26 +107,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    # Start the Prettier and swift-format installs in the background so their downloads overlap the steps below instead
-    # of blocking them. Each formatter step waits for its marker file before running, and reinstalls if the download
-    # failed. Biome is excluded because its install is conditional on a repository config file checked out later.
-    - name: Start Tool Installs
-      if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (github.event.action == 'opened' || github.event.action == 'synchronize')
-      env:
-        INPUTS_MARKDOWN: ${{ inputs.markdown }}
-        INPUTS_PRETTIER: ${{ inputs.prettier }}
-        INPUTS_SWIFT: ${{ inputs.swift }}
-      run: |
-        echo "::group::Start Tool Installs"
-        trap 'echo "::endgroup::"' EXIT
-        if [ "$INPUTS_PRETTIER" = "true" ] || [ "$INPUTS_MARKDOWN" = "true" ]; then
-          (set +e; npm install -g prettier@3.6.2 > "$RUNNER_TEMP/prettier-install.log" 2>&1; echo $? > "$RUNNER_TEMP/prettier-install.done") &
-        fi
-        if [ "$INPUTS_SWIFT" = "true" ]; then
-          (set +e; brew install swift-format > "$RUNNER_TEMP/swift-install.log" 2>&1; echo $? > "$RUNNER_TEMP/swift-install.done") &
-        fi
-      shell: bash
-
     - uses: ultralytics/actions/setup-uv@main
     - name: Install Dependencies
       # Note tomli required for codespell with pyproject.toml
@@ -236,19 +216,18 @@ runs:
       run: |
         echo "::group::Run Prettier"
         trap 'echo "::endgroup::"' EXIT
-        for _ in $(seq 120); do [ -f "$RUNNER_TEMP/prettier-install.done" ] && break; sleep 0.5; done
-        cat "$RUNNER_TEMP/prettier-install.log" 2>/dev/null || true
-        [ "$(cat "$RUNNER_TEMP/prettier-install.done" 2>/dev/null)" = "0" ] || npm install -g prettier@3.6.2
-        curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt" && chmod +x "$(npm prefix -g)/bin/shfmt"
+        npm install -g prettier@3.6.2
+        curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt"
+        chmod +x "$(npm prefix -g)/bin/shfmt"
         ultralytics-actions-update-markdown-code-blocks
         npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
-        # Bash file format, matching the files Prettier's "**/*.sh" glob covered
-        find . -name "*.sh" -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -exec shfmt -i 2 -sr -bn -ci -l -w {} +
         # Handle Markdown separately
         find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
         if [ -d "./docs" ]; then
           find ./docs -name "*.md" -type f ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
         fi
+        # Bash last: shfmt exits non-zero on any unparseable script, which would otherwise skip the formatting above
+        find . -name "*.sh" -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -exec shfmt -i 2 -sr -bn -ci -l -w {} +
       shell: bash
       continue-on-error: true
 
@@ -258,9 +237,7 @@ runs:
       run: |
         echo "::group::Run Swift Formatter"
         trap 'echo "::endgroup::"' EXIT
-        for _ in $(seq 120); do [ -f "$RUNNER_TEMP/swift-install.done" ] && break; sleep 0.5; done
-        cat "$RUNNER_TEMP/swift-install.log" 2>/dev/null || true
-        [ "$(cat "$RUNNER_TEMP/swift-install.done" 2>/dev/null)" = "0" ] || brew install swift-format
+        brew install swift-format
         swift-format --in-place --recursive .
       shell: bash
       continue-on-error: true

--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ runs:
         if [ -d "./docs" ]; then
           find ./docs -name "*.md" -type f ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
         fi
-        # Bash last: shfmt exits non-zero on any unparseable script, which would otherwise skip the formatting above
+        # Bash last: shfmt exits non-zero when a script fails to parse, which would otherwise skip the formatting above
         find . -name "*.sh" -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -exec shfmt -i 2 -sr -bn -ci -l -w {} +
       shell: bash
       continue-on-error: true

--- a/action.yml
+++ b/action.yml
@@ -107,28 +107,19 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    # Start npm and brew installs in the background so their downloads overlap the steps below instead of blocking
-    # them. Each formatter step waits for its own marker file before running, and reinstalls if the download failed.
+    # Start the Prettier and swift-format installs in the background so their downloads overlap the steps below instead
+    # of blocking them. Each formatter step waits for its marker file before running, and reinstalls if the download
+    # failed. Biome is excluded because its install is conditional on a repository config file checked out later.
     - name: Start Tool Installs
       if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (github.event.action == 'opened' || github.event.action == 'synchronize')
       env:
-        INPUTS_BIOME: ${{ inputs.biome }}
         INPUTS_MARKDOWN: ${{ inputs.markdown }}
         INPUTS_PRETTIER: ${{ inputs.prettier }}
         INPUTS_SWIFT: ${{ inputs.swift }}
       run: |
-        # npm installs share a global prefix, so keep them in one background chain ordered by first use
-        (
-          set +e
-          if [ "$INPUTS_BIOME" = "true" ]; then
-            npm install -g @biomejs/biome@latest > "$RUNNER_TEMP/biome-install.log" 2>&1
-            echo $? > "$RUNNER_TEMP/biome-install.done"
-          fi
-          if [ "$INPUTS_PRETTIER" = "true" ] || [ "$INPUTS_MARKDOWN" = "true" ]; then
-            npm install -g prettier@3.6.2 prettier-plugin-sh > "$RUNNER_TEMP/prettier-install.log" 2>&1
-            echo $? > "$RUNNER_TEMP/prettier-install.done"
-          fi
-        ) &
+        if [ "$INPUTS_PRETTIER" = "true" ] || [ "$INPUTS_MARKDOWN" = "true" ]; then
+          (set +e; npm install -g prettier@3.6.2 prettier-plugin-sh > "$RUNNER_TEMP/prettier-install.log" 2>&1; echo $? > "$RUNNER_TEMP/prettier-install.done") &
+        fi
         if [ "$INPUTS_SWIFT" = "true" ]; then
           (set +e; brew install swift-format > "$RUNNER_TEMP/swift-install.log" 2>&1; echo $? > "$RUNNER_TEMP/swift-install.done") &
         fi
@@ -228,9 +219,7 @@ runs:
         echo "::group::Run Biome"
         trap 'echo "::endgroup::"' EXIT
         if [ -f "biome.json" ] || [ -f "biome.jsonc" ]; then
-          for _ in $(seq 120); do [ -f "$RUNNER_TEMP/biome-install.done" ] && break; sleep 0.5; done
-          cat "$RUNNER_TEMP/biome-install.log" 2>/dev/null || true
-          [ "$(cat "$RUNNER_TEMP/biome-install.done" 2>/dev/null)" = "0" ] || npm install -g @biomejs/biome@latest
+          npm install -g @biomejs/biome@latest
           npx biome --version
           npx biome check --write --line-width=120 --max-diagnostics=1000 --diagnostic-level=error --unsafe .
         else

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.39"
+__version__ = "0.2.40"

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -29,7 +29,7 @@ find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list
 if [ -d "./docs" ]; then
     find ./docs -name "*.md" -type f ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
 fi
-# Bash last: shfmt exits non-zero on any unparseable script, which would otherwise skip the formatting above
+# Bash last: shfmt exits non-zero on any unparsable script, which would otherwise skip the formatting above
 find . -name "*.sh" -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -exec shfmt -i 2 -sr -bn -ci -l -w {} +
 """
 CODESPELL = [

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -19,12 +19,12 @@ RUFF_CHECK = [
 RUFF_FORMAT = ["ruff", "format", "--line-length=120", "."]
 DOCSTRINGS = ["ultralytics-actions-format-python-docstrings", "."]
 PRETTIER = """
-npm install -g prettier@3.6.2 prettier-plugin-sh
+npm install -g prettier@3.6.2
+curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
 ultralytics-actions-update-markdown-code-blocks
 npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
-if find . -name "*.sh" -type f | grep -q .; then
-    npx prettier --write --list-different --print-width 120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs "**/*.sh"
-fi
+# Bash file format, matching the files Prettier's "**/*.sh" glob covered
+find . -name "*.sh" -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -exec shfmt -i 2 -sr -bn -ci -l -w {} +
 # Handle Markdown separately
 find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
 if [ -d "./docs" ]; then

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -20,7 +20,7 @@ RUFF_FORMAT = ["ruff", "format", "--line-length=120", "."]
 DOCSTRINGS = ["ultralytics-actions-format-python-docstrings", "."]
 PRETTIER = """
 npm install -g prettier@3.6.2
-curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt" && chmod +x "$(npm prefix -g)/bin/shfmt"
 ultralytics-actions-update-markdown-code-blocks
 npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
 # Bash file format, matching the files Prettier's "**/*.sh" glob covered

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -20,16 +20,17 @@ RUFF_FORMAT = ["ruff", "format", "--line-length=120", "."]
 DOCSTRINGS = ["ultralytics-actions-format-python-docstrings", "."]
 PRETTIER = """
 npm install -g prettier@3.6.2
-curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt" && chmod +x "$(npm prefix -g)/bin/shfmt"
+curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt"
+chmod +x "$(npm prefix -g)/bin/shfmt"
 ultralytics-actions-update-markdown-code-blocks
 npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
-# Bash file format, matching the files Prettier's "**/*.sh" glob covered
-find . -name "*.sh" -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -exec shfmt -i 2 -sr -bn -ci -l -w {} +
 # Handle Markdown separately
 find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
 if [ -d "./docs" ]; then
     find ./docs -name "*.md" -type f ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
 fi
+# Bash last: shfmt exits non-zero on any unparseable script, which would otherwise skip the formatting above
+find . -name "*.sh" -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -exec shfmt -i 2 -sr -bn -ci -l -w {} +
 """
 CODESPELL = [
     "codespell",

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -29,7 +29,7 @@ find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list
 if [ -d "./docs" ]; then
     find ./docs -name "*.md" -type f ! -path "*/reference/*" -exec npx prettier --tab-width 4 --print-width 120 --write --list-different {} +
 fi
-# Bash last: shfmt exits non-zero on any unparsable script, which would otherwise skip the formatting above
+# Bash last: shfmt exits non-zero when a script fails to parse, which would otherwise skip the formatting above
 find . -name "*.sh" -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -exec shfmt -i 2 -sr -bn -ci -l -w {} +
 """
 CODESPELL = [

--- a/actions/update_markdown_code_blocks.py
+++ b/actions/update_markdown_code_blocks.py
@@ -96,26 +96,25 @@ def format_code_with_ruff(temp_dir):
         print(f"ERROR running Python docstring formatter ❌ {e}")
 
 
-def format_bash_with_prettier(temp_dir):
-    """Formats bash script files in the specified directory using prettier."""
+def format_bash_with_shfmt(temp_dir):
+    """Formats bash script files in the specified directory using shfmt."""
     if not next(Path(temp_dir).rglob("*.sh"), None):
         return
 
     try:
-        # Run prettier with explicit config path
+        # Flags reproduce prettier-plugin-sh output: 2-space indent, spaced redirects, binary ops and cases indented
         result = subprocess.run(
-            "npx prettier --write --print-width=120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs ./**/*.sh",
-            shell=True,  # must use shell=True to expand internal $(cmd)
+            ["shfmt", "-i", "2", "-sr", "-bn", "-ci", "-w", str(temp_dir)],
             capture_output=True,
             text=True,
             check=False,
         )
         if result.returncode != 0:
-            print(f"ERROR running prettier-plugin-sh ❌ {result.stderr}")
+            print(f"ERROR running shfmt ❌ {result.stderr}")
         else:
             print("Completed bash formatting ✅")
     except Exception as e:
-        print(f"ERROR running prettier-plugin-sh ❌ {e}")
+        print(f"ERROR running shfmt ❌ {e}")
 
 
 def process_markdown_string(
@@ -141,7 +140,7 @@ def process_markdown_string(
         if python_files_exist:
             format_code_with_ruff(temp_dir)
         if bash_files_exist:
-            format_bash_with_prettier(temp_dir)
+            format_bash_with_shfmt(temp_dir)
 
         update_markdown_file(temp_md, markdown_snapshot, temp_files)
         formatted_markdown = temp_md.read_text(encoding="utf-8")
@@ -244,7 +243,7 @@ def main(root_dir=None, process_python=True, process_bash=True, verbose=False):
     if process_python:
         format_code_with_ruff(temp_dir)  # Format Python files
     if process_bash:
-        format_bash_with_prettier(temp_dir)  # Format Bash files
+        format_bash_with_shfmt(temp_dir)  # Format Bash files
 
     # Update Markdown files with formatted code blocks
     for markdown_file, markdown_content, temp_files in all_temp_files:

--- a/dependabot/action.yml
+++ b/dependabot/action.yml
@@ -39,9 +39,9 @@ runs:
         echo "::group::Install ultralytics-actions"
         if [ "$GITHUB_REPOSITORY" = "ultralytics/actions" ]; then
           echo "Installing from commit: $GITHUB_SHA"
-          packages="git+https://github.com/ultralytics/actions@${GITHUB_SHA}"
+          packages="https://github.com/ultralytics/actions/archive/${GITHUB_SHA}.tar.gz"
         else
-          packages="git+https://github.com/ultralytics/actions@main"
+          packages="https://github.com/ultralytics/actions/archive/refs/heads/main.tar.gz"
         fi
         if [ "$(uname)" = "Darwin" ]; then
           uv pip install --system --break-system-packages $packages

--- a/github-report/action.yml
+++ b/github-report/action.yml
@@ -55,9 +55,9 @@ runs:
         echo "::group::Install ultralytics-actions"
         if [ "$GITHUB_REPOSITORY" = "ultralytics/actions" ]; then
           echo "Installing from commit: $GITHUB_SHA"
-          packages="git+https://github.com/ultralytics/actions@${GITHUB_SHA}"
+          packages="https://github.com/ultralytics/actions/archive/${GITHUB_SHA}.tar.gz"
         else
-          packages="git+https://github.com/ultralytics/actions@main"
+          packages="https://github.com/ultralytics/actions/archive/refs/heads/main.tar.gz"
         fi
         if [ "$(uname)" = "Darwin" ]; then
           uv pip install --system --break-system-packages $packages

--- a/tests/test_update_markdown_codeblocks.py
+++ b/tests/test_update_markdown_codeblocks.py
@@ -6,7 +6,7 @@ from unittest.mock import mock_open, patch
 from actions.update_markdown_code_blocks import (
     add_indentation,
     extract_code_blocks,
-    format_bash_with_prettier,
+    format_bash_with_shfmt,
     generate_temp_filename,
     main,
     process_markdown_file,
@@ -110,11 +110,11 @@ def test():
 
 
 def test_format_bash_skips_when_no_shell_files(tmp_path):
-    """Test bash formatter skips Prettier when no shell snippets were extracted."""
+    """Test bash formatter skips shfmt when no shell snippets were extracted."""
     (tmp_path / "snippet.py").write_text("print('ok')", encoding="utf-8")
 
     with patch("subprocess.run") as mock_run:
-        format_bash_with_prettier(tmp_path)
+        format_bash_with_shfmt(tmp_path)
 
     mock_run.assert_not_called()
 


### PR DESCRIPTION
Cuts fixed setup overhead paid by every run in all 79 repos using `format.yml`. Measured from 747 recent runs: fleet median 25s, median p75 37s, and tool installation — not repo scanning — is the dominant cost (repos <2MB have p75 36s vs 48s for repos >50MB; `ultralytics/docs` is 2.2GB and finishes in 19s).

### 1. Install the package from a source tarball instead of `git+`

`git+https://…` clones the repository before building. The tarball skips the clone for identical content.

| install source | fresh venv, `--no-cache` |
|---|---|
| `git+https://github.com/ultralytics/actions@main` | 3.46s |
| `…/archive/refs/heads/main.tar.gz` | **1.67s** |

On runners this step measured 3.0–7.2s (stars 3.0s, ultralytics 3.4s, hub-app 6.3s, yolo-ios-app 7.2s), so it roughly halves. This applies to every repo on every event, including `closed` (PR summary) and `issues` runs.

Self-hosted testing now installs `$GITHUB_SHA` rather than `${GITHUB_REF#refs/heads/}`. For `pull_request` events `GITHUB_SHA` is the merge commit, which is exactly what `refs/pull/N/merge` resolved to before — same content, pinned instead of re-resolved.

`codeload.github.com` returns no `cache-control`/`age` header on branch tarballs, so tracking `main` stays as immediate as the git URL was.

### 2. Start the Prettier and swift-format installs in the background

These downloads are network-bound and independent of the Python install, but ran serially after it. They now start first and each formatter step waits on its marker file, so the download overlaps `uv pip install`, checkout, file headers, and Ruff.

Measured on runners: npm 4–6s (97% of repos enable prettier), `brew install swift-format` ~5.4s. In hub-app, installs are 29s of a 43s job.

Biome is deliberately left in its own step: its install is conditional on a `biome.json`/`biome.jsonc` that only exists after checkout, so starting it early would install it for repositories that skip Biome entirely.

### Measured on this PR

Same repo, same steps, composite start through end of Codespell:

| | Install Dependencies | Prettier step | setup+format window |
|---|---|---|---|
| before (run 30133928579) | 2.16s | 8.56s | 12.93s |
| before (run 30131332772) | 3.44s | 5.17s | 11.12s |
| **after (run 30165564140)** | **1.77s** | **1.88s** | **7.49s** |

The npm output appears immediately when the Prettier step starts, meaning the background install had already finished and the wait cost nothing.

### Notes

- Install gating is unchanged: the new step carries the same event/action condition as the formatter steps, with the same per-input gates inside, so no runner installs anything it did not install before.
- If a background install fails or never completes, the step falls back to installing in the foreground, preserving current behavior.

### Validated

- `bash -n` on every `run` block; YAML parses; `prettier --print-width 120` reports no changes.
- Cross-step backgrounding simulated with two separate `bash -e -o pipefail` processes: success path waits and proceeds, failed-install path triggers the foreground fallback, missing-marker path exits the bounded wait instead of hanging.
- Tarball installs verified for both branch and commit-SHA URLs, including `ultralytics-actions-info` running afterward.

### Considered and dropped

- **Gating `prettier-plugin-sh` on bash presence** — only 5 of 30 sampled repos have neither `.sh` files nor bash code fences, so 83%+ need it anyway.
- **Gating `codespell`/`tomli` on the Codespell step's condition** — no measurable install-time difference; uv resolves the extra wheels in parallel.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚡ Speeds up Ultralytics Actions installation and improves Bash formatting by replacing `prettier-plugin-sh` with `shfmt`.

### 📊 Key Changes

- 📦 Switched package installation from `git+` URLs to GitHub source tarballs:
  - Tests the exact commit using `GITHUB_SHA`.
  - Uses the `main` branch tarball for external repositories.
- 🚀 Reduced installation overhead, as source tarballs avoid cloning the repository.
- 🧹 Replaced `prettier-plugin-sh` with `shfmt` version 3.13.1 for Bash formatting.
- 🔧 Updated formatting workflows to run Bash formatting after other files, preventing Bash parse failures from interrupting earlier formatting steps.
- 📝 Updated Markdown code-block formatting to use `shfmt`.
- ✅ Updated related tests and bumped the package version from `0.2.39` to `0.2.40`.

### 🎯 Purpose & Impact

- ⚡ Faster GitHub Actions startup and dependency installation.
- 🎯 More reliable testing by installing the exact commit under test.
- 🐚 More focused and robust Bash formatting through the dedicated `shfmt` tool.
- 🛡️ Formatting failures in invalid Bash snippets are less likely to prevent other code and documentation from being formatted.
- 🔄 Existing users should benefit automatically without changing their workflow configuration.