### PR TITLE
Update default models to Sonnet 5 and Opus 5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Key flow: GitHub workflow event → `action.yml` step (gated by `github.event_na
 `actions/utils/` is the shared core:
 
 - **`github_utils.py`** — the `Action` class, the central abstraction. Initializes from GitHub Actions env vars (`GITHUB_TOKEN`, `GITHUB_EVENT_NAME`, `GITHUB_EVENT_PATH`), wraps REST (`get`/`post`/`patch`/...) and GraphQL requests with unified status checking, and provides high-level operations (PR diffs, labels, comments, discussions, alerts).
-- **`openai_utils.py`** — AI provider abstraction supporting OpenAI and Anthropic. The provider/model is auto-detected from which API key env var is set; defaults live here as single source of truth (`OPENAI_MODEL_DEFAULT`, `ANTHROPIC_MODEL_DEFAULT`, `PR_REVIEW_MODEL_DEFAULT`, `MODEL_COSTS`). Also holds shared prompt-building and response sanitization.
+- **`openai_utils.py`** — AI provider abstraction supporting OpenAI and Anthropic. The provider/model is auto-detected from which API key env var is set; defaults live here as single source of truth (`OPENAI_MODEL_DEFAULT`, `ANTHROPIC_MODEL_DEFAULT`, `OPENAI_REVIEW_MODEL_DEFAULT`, `ANTHROPIC_REVIEW_MODEL_DEFAULT`, `MODEL_COSTS`). Also holds shared prompt-building and response sanitization.
 - **`common_utils.py`** — URL/redirect checking, diff filtering, file-skip patterns, HTML comment removal.
 - **`version_utils.py`** — PyPI/pub.dev version checks used for publish gating.
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ AI-powered formatting, labeling, and PR summaries for Python, JavaScript/TypeScr
 
 Choose between [OpenAI](https://developers.openai.com/) or [Anthropic](https://www.anthropic.com/) for AI-powered features:
 
-| Provider  | Default Model       | API Key             |
-| --------- | ------------------- | ------------------- |
-| OpenAI    | `gpt-5.6-luna`      | `openai_api_key`    |
-| Anthropic | `claude-sonnet-4-6` | `anthropic_api_key` |
+| Provider  | Default Model     | Default PR Review Model | API Key             |
+| --------- | ----------------- | ----------------------- | ------------------- |
+| OpenAI    | `gpt-5.6-luna`    | `gpt-5.6-terra`         | `openai_api_key`    |
+| Anthropic | `claude-sonnet-5` | `claude-opus-5`         | `anthropic_api_key` |
 
-The model is auto-detected based on which API key you provide. Override with the `model` input, or use `review_model` to override PR review only.
+The provider is auto-detected based on which API key you provide, and PR reviews default to a stronger model than the other AI features. Override with the `model` input, or use `review_model` to override PR review only.
 
 ### 🛠️ How It Works
 
@@ -112,7 +112,7 @@ jobs:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # model: gpt-5.6-luna  # Optional: set model explicitly
-          # review_model: claude-opus-4-7  # Optional: override PR review model
+          # review_model: claude-opus-5  # Optional: override PR review model
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,12 +47,12 @@
 
 可选择 [OpenAI](https://developers.openai.com/) 或 [Anthropic](https://www.anthropic.com/) 启用 AI 功能：
 
-| 提供商    | 默认模型            | API Key             |
-| --------- | ------------------- | ------------------- |
-| OpenAI    | `gpt-5.6-luna`      | `openai_api_key`    |
-| Anthropic | `claude-sonnet-4-6` | `anthropic_api_key` |
+| 提供商    | 默认模型          | 默认 PR Review 模型 | API Key             |
+| --------- | ----------------- | ------------------- | ------------------- |
+| OpenAI    | `gpt-5.6-luna`    | `gpt-5.6-terra`     | `openai_api_key`    |
+| Anthropic | `claude-sonnet-5` | `claude-opus-5`     | `anthropic_api_key` |
 
-模型会根据提供的 API key 自动检测。可通过 `model` 输入覆盖默认模型，也可使用 `review_model` 仅覆盖 PR review 模型。
+提供商会根据提供的 API key 自动检测，PR review 默认使用比其他 AI 功能更强的模型。可通过 `model` 输入覆盖默认模型，也可使用 `review_model` 仅覆盖 PR review 模型。
 
 ### 🛠️ 工作方式
 
@@ -112,7 +112,7 @@ jobs:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # model: gpt-5.6-luna  # Optional: set model explicitly
-          # review_model: claude-opus-4-7  # Optional: override PR review model
+          # review_model: claude-opus-5  # Optional: override PR review model
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -76,10 +76,10 @@ inputs:
     description: "Anthropic API Key"
     required: false
   model:
-    description: "AI Model - defaults to GPT-5.6 Luna or Sonnet 4.6 based on API key"
+    description: "AI Model - defaults to gpt-5.6-luna or claude-sonnet-5 based on API key"
     required: false
   review_model:
-    description: "AI Model for PR reviews (optional, defaults to gpt-5.6-terra with medium reasoning)"
+    description: "AI Model for PR reviews (optional, defaults to gpt-5.6-terra or claude-opus-5 based on API key)"
     required: false
   first_issue_response:
     description: "Example response to a new issue"

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.40"
+__version__ = "0.2.41"

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -52,7 +52,7 @@ MODEL_COSTS = {  # (input, output) per 1M tokens
     "claude-opus-4-7": (5.00, 25.00),
     "claude-opus-4-8": (5.00, 25.00),
     "claude-opus-5": (5.00, 25.00),
-    "claude-sonnet-5": (3.00, 15.00),  # standard rate; introductory (2.00, 10.00) expires 2026-08-31
+    "claude-sonnet-5": (2.00, 10.00),  # introductory pricing through 2026-08-31, then (3.00, 15.00)
     "claude-fable-5": (10.00, 50.00),
 }
 SYSTEM_PROMPT_ADDITION = """Guidance:

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -23,8 +23,9 @@ WEB_SEARCH_CALL_COST = 0.01  # $10 per 1K calls
 
 # Default models (single source of truth)
 OPENAI_MODEL_DEFAULT = "gpt-5.6-luna"
-ANTHROPIC_MODEL_DEFAULT = "claude-sonnet-4-6"
-PR_REVIEW_MODEL_DEFAULT = "gpt-5.6-terra"
+ANTHROPIC_MODEL_DEFAULT = "claude-sonnet-5"
+OPENAI_REVIEW_MODEL_DEFAULT = "gpt-5.6-terra"
+ANTHROPIC_REVIEW_MODEL_DEFAULT = "claude-opus-5"
 
 MODEL_COSTS = {  # (input, output) per 1M tokens
     # OpenAI models
@@ -44,12 +45,14 @@ MODEL_COSTS = {  # (input, output) per 1M tokens
     # Anthropic Claude models
     "claude-sonnet-4-5-20250929": (3.00, 15.00),
     "claude-sonnet-4-6": (3.00, 15.00),
+    "claude-haiku-4-5": (1.00, 5.00),
     "claude-haiku-4-5-20251001": (1.00, 5.00),
     "claude-opus-4-5-20251101": (5.00, 25.00),
     "claude-opus-4-6": (5.00, 25.00),
     "claude-opus-4-7": (5.00, 25.00),
-    "claude-sonnet-5": (2.00, 10.00),  # introductory pricing through 2026-08-31, then (3.00, 15.00)
     "claude-opus-4-8": (5.00, 25.00),
+    "claude-opus-5": (5.00, 25.00),
+    "claude-sonnet-5": (3.00, 15.00),  # standard rate; introductory (2.00, 10.00) expires 2026-08-31
     "claude-fable-5": (10.00, 50.00),
 }
 SYSTEM_PROMPT_ADDITION = """Guidance:
@@ -169,8 +172,10 @@ def _get_default_model() -> str:
 
 
 def get_review_model() -> str:
-    """Get model for PR reviews, using REVIEW_MODEL if set, otherwise PR_REVIEW_MODEL_DEFAULT."""
-    return REVIEW_MODEL or PR_REVIEW_MODEL_DEFAULT
+    """Get model for PR reviews: REVIEW_MODEL if set, else the review default of the auto-detected provider."""
+    if REVIEW_MODEL:
+        return REVIEW_MODEL
+    return ANTHROPIC_REVIEW_MODEL_DEFAULT if _is_anthropic_model(_get_default_model()) else OPENAI_REVIEW_MODEL_DEFAULT
 
 
 def _poll_openai_response(response_json: dict, headers: dict, timeout: int = 900) -> dict:

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -6,9 +6,11 @@ import pytest
 import requests
 
 from actions.utils.openai_utils import (
+    ANTHROPIC_MODEL_DEFAULT,
+    ANTHROPIC_REVIEW_MODEL_DEFAULT,
     MODEL_COSTS,
     OPENAI_MODEL_DEFAULT,
-    PR_REVIEW_MODEL_DEFAULT,
+    OPENAI_REVIEW_MODEL_DEFAULT,
     _is_anthropic_model,
     _openai_usage_cost,
     _response_tool_calls,
@@ -22,9 +24,16 @@ from actions.utils.openai_utils import (
 def test_default_models():
     """Test canonical default models are priced so max_cost budgets stay enforceable."""
     assert OPENAI_MODEL_DEFAULT == "gpt-5.6-luna"
-    assert PR_REVIEW_MODEL_DEFAULT == "gpt-5.6-terra"
-    assert OPENAI_MODEL_DEFAULT in MODEL_COSTS  # unpriced models disable max_cost budgets
-    assert PR_REVIEW_MODEL_DEFAULT in MODEL_COSTS
+    assert OPENAI_REVIEW_MODEL_DEFAULT == "gpt-5.6-terra"
+    assert ANTHROPIC_MODEL_DEFAULT == "claude-sonnet-5"
+    assert ANTHROPIC_REVIEW_MODEL_DEFAULT == "claude-opus-5"
+    for model in (
+        OPENAI_MODEL_DEFAULT,
+        OPENAI_REVIEW_MODEL_DEFAULT,
+        ANTHROPIC_MODEL_DEFAULT,
+        ANTHROPIC_REVIEW_MODEL_DEFAULT,
+    ):
+        assert model in MODEL_COSTS  # unpriced models disable max_cost budgets and misreport cost telemetry
     assert MODEL_COSTS["gpt-5.6-sol"] == (5.00, 30.00)
     assert MODEL_COSTS["gpt-5.6-terra"] == (2.50, 15.00)
     assert MODEL_COSTS["gpt-5.6-luna"] == (1.00, 6.00)
@@ -95,9 +104,17 @@ def test_get_review_model_override():
 
 
 def test_get_review_model_fallback():
-    """Test review model fallback to default model."""
-    with patch("actions.utils.openai_utils.REVIEW_MODEL", None):
-        assert get_review_model() == PR_REVIEW_MODEL_DEFAULT
+    """Test review model falls back to the review default of the auto-detected provider."""
+    with patch("actions.utils.openai_utils.REVIEW_MODEL", None), patch("actions.utils.openai_utils.MODEL", None):
+        with patch("actions.utils.openai_utils.ANTHROPIC_API_KEY", None):
+            assert get_review_model() == OPENAI_REVIEW_MODEL_DEFAULT
+        with patch("actions.utils.openai_utils.ANTHROPIC_API_KEY", "test-key"):  # Anthropic-only setups must not
+            assert get_review_model() == ANTHROPIC_REVIEW_MODEL_DEFAULT  # fall back to a model needing an OpenAI key
+
+    with patch("actions.utils.openai_utils.REVIEW_MODEL", None), patch(
+        "actions.utils.openai_utils.MODEL", "claude-sonnet-5"
+    ):
+        assert get_review_model() == ANTHROPIC_REVIEW_MODEL_DEFAULT
 
 
 @patch("requests.post")


### PR DESCRIPTION
### 🌟 Summary

Moves the Anthropic defaults to the current generation (Sonnet 5 / Opus 5), gives PR reviews a provider-matched default model, and refreshes `MODEL_COSTS` against published pricing.

### 📊 Key Changes

- **Anthropic default:** `claude-sonnet-4-6` → `claude-sonnet-5` for summaries, labels, and other AI features.
- **PR review defaults are now provider-matched:** `PR_REVIEW_MODEL_DEFAULT` splits into `OPENAI_REVIEW_MODEL_DEFAULT` (`gpt-5.6-terra`, unchanged) and `ANTHROPIC_REVIEW_MODEL_DEFAULT` (`claude-opus-5`). `get_review_model()` reuses the existing `_get_default_model()` provider detection, so `REVIEW_MODEL` → explicit `model` → API key all resolve consistently.
- **Bug fix:** reviews previously always fell back to `gpt-5.6-terra`, so an Anthropic-only setup hit `assert OPENAI_API_KEY` and could not run PR reviews at all.
- **Pricing:** added `claude-opus-5` ($5/$25) and the `claude-haiku-4-5` alias ($1/$5); `claude-sonnet-5` now carries its standard $3/$15 rate instead of the introductory $2/$10 that expires 2026-08-31. All other OpenAI and Anthropic rates verified against the current published pricing pages — no changes needed.
- **Docs:** both READMEs now show a separate "Default PR Review Model" column; `action.yml` input descriptions and `AGENTS.md` constant names updated.

### 🎯 Purpose & Impact

- 🚀 Anthropic users get current-generation models, with a stronger model reserved for code review where it matters most.
- 🐛 Anthropic-only configurations can now run PR reviews instead of failing on a missing OpenAI key.
- 💸 Cost telemetry never under-reports Sonnet 5 spend once introductory pricing ends.
- 📖 The README table makes the review-vs-everything-else split explicit.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🤖 Updates AI model defaults so PR reviews use a provider-specific, higher-capability model with improved Anthropic support.

### 📊 Key Changes

- Added separate default models for OpenAI and Anthropic PR reviews:
  - OpenAI: `gpt-5.6-terra`
  - Anthropic: `claude-opus-5`
- Updated general Anthropic model default to `claude-sonnet-5`.
- PR review model selection now follows the automatically detected provider unless `review_model` is explicitly set.
- Added pricing metadata for new Anthropic models, supporting accurate cost tracking and budget enforcement.
- Updated action metadata, README documentation, Chinese documentation, and developer guidance.
- Added and updated tests covering provider-specific model selection and pricing.
- Bumped the package version from `0.2.40` to `0.2.41`.

### 🎯 Purpose & Impact

- ✅ Anthropic-only configurations now correctly use an Anthropic PR review model instead of falling back to an OpenAI model.
- 🧠 PR reviews can use stronger, dedicated models while regular AI features retain their standard defaults.
- 💰 Cost telemetry and maximum-cost limits remain accurate for all supported default models.
- ⚙️ Existing users can continue overriding models through `model` and `review_model`; provider-specific defaults apply automatically when no override is provided.
- 📚 Documentation now clearly explains the new model behavior and configuration options.