### PR TITLE
Bump Prettier 3.6.2 to 3.8.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -216,7 +216,7 @@ runs:
       run: |
         echo "::group::Run Prettier"
         trap 'echo "::endgroup::"' EXIT
-        npm install -g prettier@3.6.2
+        npm install -g prettier@3.8.5
         curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt"
         chmod +x "$(npm prefix -g)/bin/shfmt"
         ultralytics-actions-update-markdown-code-blocks

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.40"
+__version__ = "0.2.41"

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -19,7 +19,7 @@ RUFF_CHECK = [
 RUFF_FORMAT = ["ruff", "format", "--line-length=120", "."]
 DOCSTRINGS = ["ultralytics-actions-format-python-docstrings", "."]
 PRETTIER = """
-npm install -g prettier@3.6.2
+npm install -g prettier@3.8.5
 curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt"
 chmod +x "$(npm prefix -g)/bin/shfmt"
 ultralytics-actions-update-markdown-code-blocks


### PR DESCRIPTION
Moves the pinned Prettier from `3.6.2` (June 2025) to `3.8.5`, the newest release before the 3.9.x Markdown regression.

### Why 3.8.5 and not 3.9.6

Prettier [3.9.0](https://prettier.io/blog/2026/06/27/3.9.0) replaced the Markdown parser (`remark-parse` v8 → `micromark` v4) and regressed multi-line template statements: the line following a table is absorbed into the table. On `ultralytics/ultralytics` that corrupted 4 `docs/macros/*.md` Jinja templates (consumed by 13–18 docs pages each) into invalid templates — `jinja2` raises `TemplateSyntaxError: unexpected '|'`.

Reported upstream as [prettier/prettier#19723](https://github.com/prettier/prettier/issues/19723) with a minimal repro. Bisected: clean through 3.8.5, broken from 3.9.0 through 3.9.6.

Worth noting the corruption is **not self-healing** — reformatting with 3.6.2 afterwards preserves the injected table row rather than restoring the file.

### Impact of 3.6.2 → 3.8.5

Full three-pass run over `ultralytics/ultralytics`: **2 files changed, +19/−19**, both pure table column-width realignment (`docs/en/guides/nvidia-jetson.md`, `docs/en/integrations/comet.md`). All 23 `docs/macros/*.md` templates parse. Preview: ultralytics/ultralytics#25429.

Speed is a wash — 549 markdown files: 3.6.2 = 2.59s, 3.8.5 = 2.63s. The case for moving is 2 minor releases of bug fixes, not throughput.

### Notes

- `__version__` bumped to 0.2.41 so `publish.yml` ships it.
- Merge this before ultralytics/ultralytics#25429, otherwise the bot reformats those 2 files back with 3.6.2.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Upgraded Prettier to version 3.8.5 and released Ultralytics Actions version 0.2.41. ✨

### 📊 Key Changes

- Updated the globally installed Prettier version from 3.6.2 to 3.8.5 in:
  - The GitHub Action workflow.
  - The Python code-formatting utility.
- Incremented the package version from `0.2.40` to `0.2.41`.

### 🎯 Purpose & Impact

- Keeps JavaScript, Markdown, and related formatting aligned with the latest Prettier release. 🧹
- Ensures both automated workflows and local formatting commands use the same Prettier version.
- May introduce minor formatting changes where Prettier 3.8.5 applies updated formatting rules.