### PR TITLE
Refresh the PR review prompt around evidence

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.41"
+__version__ = "0.2.42"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -429,13 +429,13 @@ def generate_pr_review(
     diff_truncated = len(augmented_diff) > diff_budget
     is_large_pr = diff_truncated or len(file_list) > 30
     if is_agent_review_model:  # must match the get_agent_response fallback gate
-        visibility_section = (  # tool descriptions ship with the tool schemas; only cross-tool rules belong here
+        visibility_section = (  # function tools carry their own schema descriptions; only cross-tool rules belong here
             "EVIDENCE - every finding needs it:\n"
             "- Start from the diff, then read the enclosing function, definitions, callers, and existing patterns before judging a hunk\n"
-            "- A claim about this repository (a name, import, or reference is missing or wrong) requires reading the file first\n"
+            "- A claim that a name, import, or reference in this repository is missing or wrong requires reading the file first\n"
             "- A claim about anything outside it (model IDs, API parameters, package versions, vendor behavior) requires "
-            "web_search first: your knowledge predates this PR, so current docs outrank recall, an unconfirmed suspicion "
-            "is not a finding, and a version or identifier bump is never a finding by itself\n"
+            "web_search first: your knowledge predates this PR, so current docs outrank recall, an external claim the "
+            "search does not confirm is not a finding, and a version or identifier bump is never a finding on recall alone\n"
             "- Batch independent tool calls into one turn (turns and cost are budgeted) and never quote large tool output back\n"
             "- If PROJECT GUIDELINES (CLAUDE.md/AGENTS.md) are provided, respect project-specific conventions and standards\n\n"
         )
@@ -444,7 +444,7 @@ def generate_pr_review(
             "LIMITED VISIBILITY - IMPORTANT:\n"
             "- You see only the diff and partial file contents, and you cannot verify anything beyond them\n"
             "- Assume the author is knowledgeable about: new package versions, imports to functions defined elsewhere, dependencies, and codebase architecture\n"
-            "- Do NOT flag: version or identifier bumps, new imports that appear unused in the diff, or references to code outside the diff\n"
+            "- Do NOT flag: version or model-ID bumps, new imports that appear unused in the diff, or references to code outside the diff\n"
             "- If unsure whether something is an error, assume the author knows what they're doing\n"
             "- If PROJECT GUIDELINES (CLAUDE.md/AGENTS.md) are provided, respect project-specific conventions and standards\n\n"
         )
@@ -480,12 +480,13 @@ def generate_pr_review(
         '  L   45 -code here      <- \'L\' means LEFT (old file), number is 45, use {"line": 45, "side": "LEFT"}\n'
         "         context         <- no prefix = unchanged context, don't comment on these\n"
         "- Suggestions ONLY work on RIGHT (added) lines, never LEFT (removed) lines\n"
-        "- ONLY use line numbers you see explicitly prefixed with R or L in the initial diff or read_diff output\n\n"
+        f"- ONLY use line numbers you see explicitly prefixed with R or L in the initial diff"
+        f"{' or read_diff output' if is_agent_review_model else ''}\n\n"
         "Return JSON: "
         '{"comments": [{"file": "exact/path", "line": N, "side": "RIGHT", "severity": "HIGH", "message": "..."}], "summary": "..."}\n\n'
         "JSON rules: exact paths (no ./), severity: CRITICAL|HIGH|MEDIUM|LOW|SUGGESTION\n"
         f"Files changed: {len(file_list)} ({', '.join(file_list[:30])}{'...' if len(file_list) > 30 else ''}), Lines: {lines_changed}\n"
-        f"{'Large or truncated PR: use list_changed_files and read_diff to inspect changed files not shown in the initial prompt. ' if is_large_pr else ''}\n"
+        f"{'Large or truncated PR: use list_changed_files and read_diff to inspect changed files not shown in the initial prompt. ' if is_large_pr and is_agent_review_model else ''}\n"
     )
 
     messages = [

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -429,40 +429,22 @@ def generate_pr_review(
     diff_truncated = len(augmented_diff) > diff_budget
     is_large_pr = diff_truncated or len(file_list) > 30
     if is_agent_review_model:  # must match the get_agent_response fallback gate
-        visibility_section = (
-            "CONTEXT AND VERIFICATION:\n"
-            "- Start from the diff, then use tools to inspect full files or related code when context affects a finding\n"
-            "- Verify suspected issues before commenting: read the enclosing function, and check definitions, callers, and existing patterns\n"
-            "- Never claim a name, import, or reference is missing without reading the relevant file first\n"
-            "- Do NOT flag version updates\n"
-            "- Report every issue the tool evidence confirms; drop a suspicion only when the evidence shows the code is correct\n"
+        visibility_section = (  # tool descriptions ship with the tool schemas; only cross-tool rules belong here
+            "EVIDENCE - every finding needs it:\n"
+            "- Start from the diff, then read the enclosing function, definitions, callers, and existing patterns before judging a hunk\n"
+            "- A claim about this repository (a name, import, or reference is missing or wrong) requires reading the file first\n"
+            "- A claim about anything outside it (model IDs, API parameters, package versions, vendor behavior) requires "
+            "web_search first: your knowledge predates this PR, so current docs outrank recall, an unconfirmed suspicion "
+            "is not a finding, and a version or identifier bump is never a finding by itself\n"
+            "- Batch independent tool calls into one turn (turns and cost are budgeted) and never quote large tool output back\n"
             "- If PROJECT GUIDELINES (CLAUDE.md/AGENTS.md) are provided, respect project-specific conventions and standards\n\n"
-            "AVAILABLE TOOLS:\n"
-            "- list_changed_files: list every changed file in the PR with added/removed counts; use this for large "
-            "PRs or when the initial diff is truncated\n"
-            "- read_diff: inspect the line-numbered diff for a changed file; use this to review files not visible in "
-            "the initial prompt and to recover exact R/L line numbers for comments\n"
-            "- read_file: inspect bounded line ranges from repository files, including unchanged files; contents are "
-            "the PR head, so file line numbers match RIGHT-side diff line numbers\n"
-            + (
-                "- search_repo: find related definitions, dependencies, tests, config, or existing patterns across "
-                "the repository\n"
-                if local_checkout
-                else ""
-            )
-            + "- list_files: locate repository files by glob\n"
-            "- web_search: verify current public docs, package docs, release notes, issues, or vendor behavior when a "
-            "review finding depends on external behavior\n"
-            "- Tool turns and cost are budgeted: batch independent tool calls in the same turn, e.g. read several "
-            "diffs or files at once\n"
-            "- Do not quote large tool output. Use tools only to verify concise, actionable review findings.\n\n"
         )
     else:
         visibility_section = (
             "LIMITED VISIBILITY - IMPORTANT:\n"
-            "- You can only see the diff and partial file contents, not the full codebase\n"
+            "- You see only the diff and partial file contents, and you cannot verify anything beyond them\n"
             "- Assume the author is knowledgeable about: new package versions, imports to functions defined elsewhere, dependencies, and codebase architecture\n"
-            "- Do NOT flag: version updates, new imports that appear unused in the diff, or references to code outside the diff\n"
+            "- Do NOT flag: version or identifier bumps, new imports that appear unused in the diff, or references to code outside the diff\n"
             "- If unsure whether something is an error, assume the author knows what they're doing\n"
             "- If PROJECT GUIDELINES (CLAUDE.md/AGENTS.md) are provided, respect project-specific conventions and standards\n\n"
         )
@@ -482,7 +464,7 @@ def generate_pr_review(
         "- Issues in unchanged context lines\n\n"
         f"{visibility_section}"
         "QUALITY OVER QUANTITY:\n"
-        "- Zero comments is valid for clean PRs - don't invent issues, but don't withhold genuine verified ones\n"
+        "- Zero comments is valid for clean PRs: never invent an issue, never withhold an evidence-backed one\n"
         "- Each comment must be actionable with clear reasoning\n"
         "- Combine related issues into one comment\n"
         f"- Hard cap: {MAX_REVIEW_COMMENTS} comments maximum\n\n"
@@ -492,14 +474,11 @@ def generate_pr_review(
         "- Single-line fixes only: provide 'suggestion' without 'start_line' to replace the line at 'line'\n"
         "- Match the exact indentation of the original code\n"
         "- Avoid triple backticks (```) in suggestions as they break Markdown formatting\n\n"
-        "SUMMARY:\n"
-        "- Brief overall assessment: what's good, what needs attention\n"
-        "- If no issues found, acknowledge the PR is clean\n\n"
+        "SUMMARY: brief overall assessment of what's good and what needs attention; say so plainly when the PR is clean.\n\n"
         "DIFF LINE FORMAT (how to read line numbers):\n"
         '  R  123 +code here      <- \'R\' means RIGHT (new file), number is 123, use {"line": 123, "side": "RIGHT"}\n'
         '  L   45 -code here      <- \'L\' means LEFT (old file), number is 45, use {"line": 45, "side": "LEFT"}\n'
         "         context         <- no prefix = unchanged context, don't comment on these\n"
-        "- Extract the integer after R or L prefix (e.g., 'R  123' -> line 123, 'L   45' -> line 45)\n"
         "- Suggestions ONLY work on RIGHT (added) lines, never LEFT (removed) lines\n"
         "- ONLY use line numbers you see explicitly prefixed with R or L in the initial diff or read_diff output\n\n"
         "Return JSON: "

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -433,9 +433,10 @@ def generate_pr_review(
             "EVIDENCE - every finding needs it:\n"
             "- Start from the diff, then read the enclosing function, definitions, callers, and existing patterns before judging a hunk\n"
             "- A claim that a name, import, or reference in this repository is missing or wrong requires reading the file first\n"
-            "- A claim about anything outside it (package versions, external identifiers, API parameters, vendor "
-            "behavior) requires web_search first: your knowledge predates this PR, so current docs outrank recall, and "
-            "an external claim the search does not confirm is not a finding\n"
+            "- A claim about anything outside this repository (package versions, external identifiers, API parameters, "
+            "vendor behavior) requires web_search first: your knowledge predates this PR, so let current docs settle it "
+            "either way - an official source that lacks what the diff uses is evidence against it, and a claim the "
+            "search does not settle is not a finding\n"
             "- Batch independent tool calls into one turn (turns and cost are budgeted) and never quote large tool output back\n"
             "- If PROJECT GUIDELINES (CLAUDE.md/AGENTS.md) are provided, respect project-specific conventions and standards\n\n"
         )
@@ -444,7 +445,7 @@ def generate_pr_review(
             "LIMITED VISIBILITY - IMPORTANT:\n"
             "- You see only the diff and partial file contents, and you cannot verify anything beyond them\n"
             "- Assume the author is knowledgeable about: new package versions, imports to functions defined elsewhere, dependencies, and codebase architecture\n"
-            "- Do NOT flag what you cannot confirm from the diff itself: external names, versions, or behavior; imports that appear unused; references to code outside the diff\n"
+            "- Do NOT flag what you cannot confirm from the diff or the file contents provided: external names, versions, or behavior; imports that appear unused; references to code you cannot see\n"
             "- If unsure whether something is an error, assume the author knows what they're doing\n"
             "- If PROJECT GUIDELINES (CLAUDE.md/AGENTS.md) are provided, respect project-specific conventions and standards\n\n"
         )
@@ -480,13 +481,14 @@ def generate_pr_review(
         '  L   45 -code here      <- \'L\' means LEFT (old file), number is 45, use {"line": 45, "side": "LEFT"}\n'
         "         context         <- no prefix = unchanged context, don't comment on these\n"
         "- Suggestions ONLY work on RIGHT (added) lines, never LEFT (removed) lines\n"
-        f"- ONLY use line numbers you see explicitly prefixed with R or L in the initial diff"
+        "- ONLY use line numbers you see explicitly prefixed with R or L in the initial diff"
         f"{' or read_diff output' if is_agent_review_model else ''}\n\n"
         "Return JSON: "
         '{"comments": [{"file": "exact/path", "line": N, "side": "RIGHT", "severity": "HIGH", "message": "..."}], "summary": "..."}\n\n'
         "JSON rules: exact paths (no ./), severity: CRITICAL|HIGH|MEDIUM|LOW|SUGGESTION\n"
         f"Files changed: {len(file_list)} ({', '.join(file_list[:30])}{'...' if len(file_list) > 30 else ''}), Lines: {lines_changed}\n"
-        f"{'Large or truncated PR: use list_changed_files and read_diff to inspect changed files not shown in the initial prompt. ' if is_large_pr and is_agent_review_model else ''}\n"
+        f"{'Large or truncated PR: the diff below is incomplete. ' if is_large_pr else ''}"
+        f"{'Use list_changed_files and read_diff to inspect changed files not shown in the initial prompt. ' if is_large_pr and is_agent_review_model else ''}\n"
     )
 
     messages = [

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -433,9 +433,9 @@ def generate_pr_review(
             "EVIDENCE - every finding needs it:\n"
             "- Start from the diff, then read the enclosing function, definitions, callers, and existing patterns before judging a hunk\n"
             "- A claim that a name, import, or reference in this repository is missing or wrong requires reading the file first\n"
-            "- A claim about anything outside it (model IDs, API parameters, package versions, vendor behavior) requires "
-            "web_search first: your knowledge predates this PR, so current docs outrank recall, an external claim the "
-            "search does not confirm is not a finding, and a version or identifier bump is never a finding on recall alone\n"
+            "- A claim about anything outside it (package versions, external identifiers, API parameters, vendor "
+            "behavior) requires web_search first: your knowledge predates this PR, so current docs outrank recall, and "
+            "an external claim the search does not confirm is not a finding\n"
             "- Batch independent tool calls into one turn (turns and cost are budgeted) and never quote large tool output back\n"
             "- If PROJECT GUIDELINES (CLAUDE.md/AGENTS.md) are provided, respect project-specific conventions and standards\n\n"
         )
@@ -444,7 +444,7 @@ def generate_pr_review(
             "LIMITED VISIBILITY - IMPORTANT:\n"
             "- You see only the diff and partial file contents, and you cannot verify anything beyond them\n"
             "- Assume the author is knowledgeable about: new package versions, imports to functions defined elsewhere, dependencies, and codebase architecture\n"
-            "- Do NOT flag: version or model-ID bumps, new imports that appear unused in the diff, or references to code outside the diff\n"
+            "- Do NOT flag what you cannot confirm from the diff itself: external names, versions, or behavior; imports that appear unused; references to code outside the diff\n"
             "- If unsure whether something is an error, assume the author knows what they're doing\n"
             "- If PROJECT GUIDELINES (CLAUDE.md/AGENTS.md) are provided, respect project-specific conventions and standards\n\n"
         )


### PR DESCRIPTION
### 🌟 Summary

Rewrites the agent-path review prompt around a single evidence rule, fixing the false-positive class seen on #843 while making the prompt 22% smaller.

### 📊 Key Changes

- **Deleted the `AVAILABLE TOOLS` block.** Every function tool already ships a `description` (including when to use it) in its schema, and `search_repo` is already dropped from `tools` when there is no local checkout — so the block restated what the model is handed anyway. Only the cross-tool rules a schema cannot express survive (batch calls per turn, don't quote large output).
- **Replaced `CONTEXT AND VERIFICATION` with `EVIDENCE`.** The old burden-of-proof rule covered only in-repo names ("never claim a name, import, or reference is missing without reading the relevant file first"). It now covers external claims too — model IDs, API parameters, package versions, vendor behavior — and states that the reviewer's knowledge predates the PR, that current docs outrank recall, and that an unconfirmed suspicion is not a finding.
- **Folded `Do NOT flag version updates` into that rule** as "a version or identifier bump is never a finding by itself", so the guard now also covers identifier swaps rather than only package bumps.
- **Merged overlapping bullets:** report-everything-evidence-confirms + zero-comments-is-valid became one line; `SUMMARY` collapsed from two bullets to one; dropped the "extract the integer after R or L" bullet that restates the format example directly above it.
- **Mirrored the fix on the no-tools path:** the Anthropic reviewer gets no tools at all, so its `LIMITED VISIBILITY` list now says it cannot verify anything beyond the diff and extends its do-not-flag list from "version updates" to "version or identifier bumps".

Rendered system prompt: **3785 → 2941 chars**, a net deletion despite the added rule.

### 🎯 Purpose & Impact

- 🐛 Closes the failure mode from #843: the reviewer called the documented model ID `claude-opus-5` nonexistent and named `claude-opus-4-8` as current. Run logs show it *did* call `web_search` twice — the tool was wired up and used, but nothing obliged it to prefer what it found over what it remembered.
- ✂️ Less prompt to cache and re-bill each turn, and one place to change the verification rules instead of two overlapping ones.
- 🔒 No code-path change: the tools, schema, budgets, and JSON contract are untouched — this edits prompt text only, so the blast radius is review output quality.

### 🔍 Verification

`ruff check` / `ruff format` clean, 129 tests pass. Both prompt variants rendered locally and read end-to-end. This repo prints the full system prompt in the review job logs, so the merged result is inspectable on the next PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧠 Improved PR review prompts to require stronger evidence, better tool usage, and clearer handling of limited repository visibility.

### 📊 Key Changes
- Updated the package version from `0.2.41` to `0.2.42`.
- Refined agent-review guidance to:
  - Verify findings by inspecting surrounding code, definitions, callers, and repository patterns.
  - Use web search for claims involving external packages, APIs, versions, or vendor behavior.
  - Batch independent tool calls and avoid quoting large tool outputs.
- Simplified tool descriptions by relying on each function’s built-in schema documentation.
- Clarified limited-visibility behavior so reviewers do not flag issues they cannot confirm.
- Strengthened quality guidance: reviewers should report all evidence-backed issues while avoiding speculation.
- Improved line-number instructions and large/truncated PR handling for agent-based reviews.

### 🎯 Purpose & Impact
- ✅ Produces more accurate, evidence-based code reviews with fewer false positives.
- 🔍 Encourages verification of both local repository context and current external documentation.
- 📉 Reduces speculative comments when the reviewer has incomplete visibility.
- ⚡ Makes tool use more efficient by promoting batched calls and concise evidence gathering.
- 🛠️ Helps ensure review comments are actionable, correctly located, and focused on genuine issues.