### PR TITLE
Pin Biome to 2.5.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -201,7 +201,7 @@ runs:
         echo "::group::Run Biome"
         trap 'echo "::endgroup::"' EXIT
         if [ -f "biome.json" ] || [ -f "biome.jsonc" ]; then
-          npm install -g @biomejs/biome@latest
+          npm install -g @biomejs/biome@2.5.5
           npx biome --version
           npx biome check --write --line-width=120 --max-diagnostics=1000 --diagnostic-level=error --unsafe .
         else

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.41"
+__version__ = "0.2.42"

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.42"
+__version__ = "0.2.41"


### PR DESCRIPTION
`action.yml` installed `@biomejs/biome@latest`, so Biome's formatting output could change without any change on our side — the same failure mode Prettier 3.9.0 just demonstrated (#845), where a formatter release silently corrupted Jinja docs macros in `ultralytics/ultralytics`.

Pins to `2.5.5`, what `@latest` resolves to today, so upgrades become a deliberate, reviewable diff. This was the last unpinned formatter; Prettier is `3.8.5` and shfmt is `v3.13.1`.

Currently only `ultralytics/portal` enables `biome: true`, so the blast radius of a bad release is small — but it is the same class of risk.

No `__version__` bump: this touches `action.yml` only, not the Python package.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Pins the Biome formatter and linter to version `2.5.5` for more consistent GitHub Action runs. 🔒

### 📊 Key Changes

- Replaces `@biomejs/biome@latest` with the fixed version `@biomejs/biome@2.5.5`.
- Keeps the existing Biome formatting and checking workflow unchanged.
- Ensures the installed Biome version is still displayed before checks run.

### 🎯 Purpose & Impact

- Prevents unexpected formatting or linting changes caused by future Biome releases. ✅
- Improves reproducibility and stability across CI runs.
- Updates to Biome will now require an intentional dependency version change.