### PR TITLE
Revert Biome to @latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -201,7 +201,7 @@ runs:
         echo "::group::Run Biome"
         trap 'echo "::endgroup::"' EXIT
         if [ -f "biome.json" ] || [ -f "biome.jsonc" ]; then
-          npm install -g @biomejs/biome@2.5.5
+          npm install -g @biomejs/biome@latest
           npx biome --version
           npx biome check --write --line-width=120 --max-diagnostics=1000 --diagnostic-level=error --unsafe .
         else


### PR DESCRIPTION
Reverts #847, restoring `@biomejs/biome@latest`.

Biome was intentionally unpinned so it tracks upstream automatically. #847 pinned it to 2.5.5 on my recommendation, which was the wrong call for this tool — that was my misread, not a decision anyone asked for.

Prettier stays pinned at 3.8.5 for the specific reason documented in #845: 3.9.0 silently corrupted Jinja docs macros in `ultralytics/ultralytics`, and that regression is still open upstream ([prettier/prettier#19723](https://github.com/prettier/prettier/issues/19723)).

No `__version__` bump — `action.yml` only, no package behavior change.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the GitHub Action to always install the latest Biome release for code formatting and linting. 🚀

### 📊 Key Changes
- Replaces the fixed `@biomejs/biome@2.5.5` version with `@biomejs/biome@latest`.
- Keeps the existing Biome checks, automatic fixes, and error-level diagnostics unchanged.

### 🎯 Purpose & Impact
- Ensures workflows use the newest Biome features, improvements, and bug fixes. ✨
- Reduces maintenance by removing the need to manually update the pinned Biome version.
- May introduce unexpected formatting or linting changes if future Biome releases modify behavior, so workflow stability could vary over time. ⚠️