### PR TITLE
Add TBE to shared codespell dictionary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -270,7 +270,7 @@ runs:
           --write-changes \
           --uri-ignore-words-list "*" \
           --ignore-regex '\b[a-z]+[A-Z][a-zA-Z]*\b' \
-          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN" \
+          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,tbe" \
           --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml"
       shell: bash
       continue-on-error: true

--- a/action.yml
+++ b/action.yml
@@ -270,7 +270,7 @@ runs:
           --write-changes \
           --uri-ignore-words-list "*" \
           --ignore-regex '\b[a-z]+[A-Z][a-zA-Z]*\b' \
-          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN,tbe,TBE" \
+          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN,tbe" \
           --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml"
       shell: bash
       continue-on-error: true

--- a/action.yml
+++ b/action.yml
@@ -270,7 +270,7 @@ runs:
           --write-changes \
           --uri-ignore-words-list "*" \
           --ignore-regex '\b[a-z]+[A-Z][a-zA-Z]*\b' \
-          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,tbe" \
+          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN,tbe,TBE" \
           --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml"
       shell: bash
       continue-on-error: true

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.43"
+__version__ = "0.2.44"

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -42,7 +42,7 @@ CODESPELL = [
     "--ignore-regex",
     r"\b[a-z]+[A-Z][a-zA-Z]*\b",
     "--ignore-words-list",
-    "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,tbe",
+    "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN,tbe,TBE",
     "--skip",
     "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml",
 ]

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -42,7 +42,7 @@ CODESPELL = [
     "--ignore-regex",
     r"\b[a-z]+[A-Z][a-zA-Z]*\b",
     "--ignore-words-list",
-    "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN",
+    "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,tbe",
     "--skip",
     "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml",
 ]

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -42,7 +42,7 @@ CODESPELL = [
     "--ignore-regex",
     r"\b[a-z]+[A-Z][a-zA-Z]*\b",
     "--ignore-words-list",
-    "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN,tbe,TBE",
+    "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN,tbe",
     "--skip",
     "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml",
 ]


### PR DESCRIPTION
## Summary
- move Portal lowercase Huawei tbe terminology into the shared codespell configuration
- cover both the uppercase TBE acronym and lowercase ai_core/tbe filesystem paths
- keep the packaged formatter command aligned with the composite action
- bump the package version to 0.2.44

## Validation
- 144 tests passed
- Ruff check and format check passed
- Portal tree passes codespell with the shared list and no local config

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Updated the formatting action to ignore the valid term `tbe` and released version `0.2.44`.

### 📊 Key Changes

- Added `tbe` to the spelling and formatting checker’s ignored-word list in:
  - `action.yml`
  - `actions/format_code.py`
- Bumped the package version from `0.2.43` to `0.2.44`.

### 🎯 Purpose & Impact

- ✅ Prevents false-positive spelling warnings for the recognized term `tbe`.
- 🔄 Keeps the GitHub Action configuration and Python formatter settings consistent.
- 📦 Publishes a minor patch release with no changes to core functionality or user-facing APIs.