### PR TITLE
Converse in review threads instead of deleting bot comments

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.44"
+__version__ = "0.2.45"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -686,7 +686,11 @@ def generate_pr_review(
         print(f"AI generated {comments_before_filtering} comments")
 
         # Validate, filter, and deduplicate comments
-        thread_anchors = {(t["path"], t["side"], t["line"]) for t in threads.values() if t.get("line")}
+        thread_anchors = {
+            (t["path"], t["side"], t["line"]): SEVERITY_RANK.get(t.get("severity") or "CRITICAL", 0)
+            for t in threads.values()
+            if t.get("line")
+        }
         unique_comments = {}
         for c in response.get("comments", []):
             file_path, line_num = c.get("file"), c.get("line", 0)
@@ -706,8 +710,9 @@ def generate_pr_review(
                 print(f"Filtered out {file_path}:{line_num} (side={side}, available: {available})")
                 continue
 
-            # An existing thread already anchors here; the model must use a thread action, not a duplicate comment
-            if (file_path, side, line_num) in thread_anchors:
+            # An existing thread anchors here: only a strictly more severe new finding may share the anchor
+            anchor_rank = thread_anchors.get((file_path, side, line_num))
+            if anchor_rank is not None and SEVERITY_RANK.get(c.get("severity"), 5) >= anchor_rank:
                 print(f"Filtered out {file_path}:{line_num} (existing review thread anchors here)")
                 continue
 
@@ -779,7 +784,7 @@ def generate_pr_review(
                 continue
             thread_actions[ref] = {"thread": ref, "action": verb, "message": message}
         # Only findings-level threads gate approval: LOW/SUGGESTION threads advise without blocking
-        blocking = {ref for ref, t in threads.items() if t.get("blocking", True)}
+        blocking = {ref for ref, t in threads.items() if t.get("severity") not in ("LOW", "SUGGESTION")}
         resolved = {ref for ref, a in thread_actions.items() if a["action"] == "resolve"}
 
         response.update(
@@ -886,7 +891,7 @@ def get_review_threads(event: Action) -> dict[str, dict]:
                 "line": node.get("line"),
                 "side": node.get("diffSide") or "RIGHT",
                 "outdated": bool(node.get("isOutdated")),
-                "blocking": not severity or severity.group(1) not in ("LOW", "SUGGESTION"),
+                "severity": severity.group(1) if severity else None,
                 "comments": [
                     {"author": (c.get("author") or {}).get("login") or "unknown", "body": c.get("body") or ""}
                     for c in comments
@@ -912,7 +917,7 @@ def apply_thread_actions(event: Action, review_data: dict, threads: dict[str, di
         # New replies don't change the head SHA: never act on a conversation the model didn't see
         if fresh.get(thread["id"]) != thread["comments"]:
             print(f"Skipping {action['action']} on thread {thread['id']}: conversation changed during review")
-            if action["action"] == "resolve" and thread.get("blocking", True):
+            if action["action"] == "resolve" and thread.get("severity") not in ("LOW", "SUGGESTION"):
                 review_data["open_threads"] += 1  # the thread stays open: keep the APPROVE gate honest
             continue
         if (message := action.get("message")) and (root_id := thread.get("root_comment_id")):

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -49,12 +49,19 @@ query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
                     diffSide
                     path
                     line
-                    comments(first: 30) {
+                    root: comments(first: 1) {
                         nodes {
                             fullDatabaseId
                             author { login }
                             body
                             pullRequestReview { body }
+                        }
+                    }
+                    latest: comments(last: 30) {
+                        nodes {
+                            fullDatabaseId
+                            author { login }
+                            body
                         }
                     }
                 }
@@ -850,14 +857,16 @@ def get_review_threads(event: Action) -> dict[str, dict]:
             "reviewThreads"
         ) or {}
         for node in connection.get("nodes") or []:
-            comments = (node.get("comments") or {}).get("nodes") or []
-            root = comments[0] if comments else {}
+            root = ((node.get("root") or {}).get("nodes") or [{}])[0]
             if (
                 node.get("isResolved")
                 or (root.get("author") or {}).get("login") != bot_username
                 or REVIEW_MARKER not in ((root.get("pullRequestReview") or {}).get("body") or "")
             ):
                 continue
+            comments = (node.get("latest") or {}).get("nodes") or []  # newest replies: the last-word guard needs them
+            if not comments or comments[0].get("fullDatabaseId") != root.get("fullDatabaseId"):
+                comments = [root, *comments]  # thread longer than the fetched tail: keep the root finding visible
             threads[f"T{len(threads) + 1}"] = {
                 "id": node["id"],
                 "root_comment_id": root.get("fullDatabaseId"),
@@ -878,8 +887,12 @@ def get_review_threads(event: Action) -> dict[str, dict]:
 
 def apply_thread_actions(event: Action, review_data: dict, threads: dict[str, dict]) -> None:
     """Reply to and resolve existing review threads as decided by the review model."""
+    if not (actions := review_data.get("thread_actions")):
+        return
+    if event.get_pr_head_sha() != review_data["head_sha"]:  # don't mutate threads from a stale review
+        raise RuntimeError("PR head changed during review generation")
     pr_number = event.pr["number"]
-    for action in review_data.get("thread_actions", []):
+    for action in actions:
         thread = threads[action["thread"]]
         if (message := action.get("message")) and (root_id := thread.get("root_comment_id")):
             event.post(

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -893,6 +893,7 @@ def apply_thread_actions(event: Action, review_data: dict, threads: dict[str, di
         raise RuntimeError("PR head changed during review generation")
     fresh = {t["id"]: t["comments"] for t in get_review_threads(event).values()}
     pr_number = event.pr["number"]
+    applied = []
     for action in actions:
         thread = threads[action["thread"]]
         # New replies don't change the head SHA: never act on a conversation the model didn't see
@@ -911,6 +912,8 @@ def apply_thread_actions(event: Action, review_data: dict, threads: dict[str, di
             result = event.graphql_request(GRAPHQL_RESOLVE_REVIEW_THREAD, variables={"threadId": thread["id"]})
             if "data" not in result or result.get("errors"):
                 raise RuntimeError(f"Failed to resolve review thread {thread['id']}: {result}")
+        applied.append(action)
+    review_data["thread_actions"] = applied  # the summary's thread count reports only what actually happened
 
 
 def post_review_summary(event: Action, review_data: dict) -> None:

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -34,6 +34,43 @@ MAX_TOOL_FILE_LINES = 240
 MAX_AGENT_TURNS = 16
 REVIEW_COST_SOFT_LIMIT = 2.00  # stop requesting tools after cumulative spend reaches this amount
 SEVERITY_RANK = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "SUGGESTION": 4, None: 5}
+MAX_THREADS_SECTION_CHARS = 8000
+
+GRAPHQL_PR_REVIEW_THREADS = """
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+            reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                    id
+                    isResolved
+                    isOutdated
+                    diffSide
+                    path
+                    line
+                    comments(first: 30) {
+                        nodes {
+                            fullDatabaseId
+                            author { login }
+                            body
+                            pullRequestReview { body }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+GRAPHQL_RESOLVE_REVIEW_THREAD = """
+mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+        thread { id }
+    }
+}
+"""
 
 
 def _clip_tool_output(text: str, limit: int = MAX_TOOL_OUTPUT_CHARS) -> str:
@@ -361,6 +398,32 @@ def parse_diff_files(diff_text: str) -> tuple[dict, str]:
     return files, "\n".join(augmented_lines)
 
 
+def format_review_threads(threads: dict[str, dict]) -> tuple[str, set[str]]:
+    """Format unresolved review threads as a bounded prompt section, returning the refs actually shown."""
+    blocks, shown, total = [], set(), 0
+    for ref, thread in threads.items():
+        anchor = f"{thread['path']}:{thread['line']} ({thread['side']})" if thread.get("line") else thread["path"]
+        outdated = " [outdated: the anchored code changed since]" if thread["outdated"] else ""
+        comments = thread["comments"]
+        if len(comments) > 10:  # root finding plus the latest replies: the newest rebuttal matters most
+            comments = [comments[0], *comments[-9:]]
+        convo = "\n".join(f"  {c['author']}: {c['body'][:1000]}" for c in comments)
+        block = _clip_tool_output(f"[{ref}] {anchor}{outdated}\n{convo}", MAX_THREADS_SECTION_CHARS)
+        if total + len(block) > MAX_THREADS_SECTION_CHARS and blocks:  # whole threads only, never cut mid-thread
+            print(f"Dropping {len(threads) - len(shown)} review threads from prompt (section budget)")
+            break
+        blocks.append(block)
+        shown.add(ref)
+        total += len(block) + 2
+    if not blocks:
+        return "", shown
+    section = "\n\n".join(blocks)
+    return (
+        f"EXISTING REVIEW THREADS (your unresolved findings from previous reviews, with replies):\n{section}\n\n",
+        shown,
+    )
+
+
 def generate_pr_review(
     repository: str,
     diff_text: str,
@@ -368,6 +431,7 @@ def generate_pr_review(
     pr_description: str,
     event: Action = None,
     head_sha: str | None = None,
+    threads: dict[str, dict] | None = None,
 ) -> dict:
     """Generate comprehensive PR review with line-specific comments and overall assessment."""
     head_sha = head_sha or (event.get_pr_head_sha() if event else None)
@@ -424,8 +488,11 @@ def generate_pr_review(
         if file_contents:
             full_files_section = f"FULL FILE CONTENTS:\n{chr(10).join(file_contents)}\n\n"
 
+    threads = threads or {}
+    threads_section, shown_threads = format_review_threads(threads)
+
     # Calculate remaining budget for diff and check if truncation needed
-    diff_budget = max(1000, MAX_PROMPT_CHARS - len(guidelines_section) - len(full_files_section))
+    diff_budget = max(1000, MAX_PROMPT_CHARS - len(guidelines_section) - len(full_files_section) - len(threads_section))
     diff_truncated = len(augmented_diff) > diff_budget
     is_large_pr = diff_truncated or len(file_list) > 30
     if is_agent_review_model:  # must match the get_agent_response fallback gate
@@ -452,6 +519,22 @@ def generate_pr_review(
             "- If PROJECT GUIDELINES (CLAUDE.md/AGENTS.md) are provided, respect project-specific conventions and standards\n\n"
         )
 
+    threads_rules = (
+        (
+            "EXISTING REVIEW THREADS:\n"
+            "- The user prompt lists your unresolved threads from previous reviews with any replies to them\n"
+            "- For each thread return at most one thread_actions entry: 'resolve' when the current code fixes the "
+            "issue or a reply rebuts it on substance, 'reply' when the finding still stands and a reply deserves an "
+            "answer; omit the thread when there is nothing new to say\n"
+            "- Accept a rebuttal only when it is technically substantiated (code, docs, measurements) - confident "
+            "assertion alone changes nothing\n"
+            "- Never post a new comment for an issue that already has a thread - use a 'reply' thread action instead\n"
+            "- 'message' is posted as a reply in the thread: required for 'reply', a brief reason or empty for 'resolve'\n\n"
+        )
+        if threads
+        else ""
+    )
+
     content = (
         "You are an expert code reviewer for Ultralytics. Review code changes and provide inline comments ONLY for genuine issues.\n\n"
         "WHEN TO COMMENT (priority order):\n"
@@ -477,6 +560,7 @@ def generate_pr_review(
         "- Single-line fixes only: provide 'suggestion' without 'start_line' to replace the line at 'line'\n"
         "- Match the exact indentation of the original code\n"
         "- Avoid triple backticks (```) in suggestions as they break Markdown formatting\n\n"
+        f"{threads_rules}"
         "SUMMARY: brief overall assessment of what's good and what needs attention; say so plainly when the PR is clean.\n\n"
         "DIFF LINE FORMAT (how to read line numbers):\n"
         '  R  123 +code here      <- \'R\' means RIGHT (new file), number is 123, use {"line": 123, "side": "RIGHT"}\n'
@@ -486,7 +570,9 @@ def generate_pr_review(
         "- ONLY use line numbers you see explicitly prefixed with R or L in the initial diff"
         f"{' or read_diff output' if is_agent_review_model else ''}\n\n"
         "Return JSON: "
-        '{"comments": [{"file": "exact/path", "line": N, "side": "RIGHT", "severity": "HIGH", "message": "..."}], "summary": "..."}\n\n'
+        '{"comments": [{"file": "exact/path", "line": N, "side": "RIGHT", "severity": "HIGH", "message": "..."}], '
+        '"summary": "...", "thread_actions": [{"thread": "T1", "action": "resolve", "message": "..."}]}\n'
+        "thread_actions must be [] when no existing review threads are listed\n\n"
         "JSON rules: exact paths (no ./), severity: CRITICAL|HIGH|MEDIUM|LOW|SUGGESTION\n"
         f"Files changed: {len(file_list)} ({', '.join(file_list[:30])}{'...' if len(file_list) > 30 else ''}), Lines: {lines_changed}\n"
         f"{'Large or truncated PR: the diff below is incomplete. ' if is_large_pr else ''}"
@@ -503,6 +589,7 @@ def generate_pr_review(
                 f"BODY:\n{remove_html_comments(pr_description or '')[:1000]}\n\n"
                 f"{guidelines_section}"
                 f"{full_files_section}"
+                f"{threads_section}"
                 f"DIFF:\n{augmented_diff[:diff_budget]}\n\n"
                 "Now review this diff according to the rules above. Return JSON with comments array and summary."
             ),
@@ -536,8 +623,21 @@ def generate_pr_review(
                     },
                 },
                 "summary": {"type": "string"},
+                "thread_actions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "thread": {"type": "string"},
+                            "action": {"type": "string", "enum": ["resolve", "reply"]},
+                            "message": {"type": "string"},
+                        },
+                        "required": ["thread", "action", "message"],
+                        "additionalProperties": False,
+                    },
+                },
             },
-            "required": ["comments", "summary"],
+            "required": ["comments", "summary", "thread_actions"],
             "additionalProperties": False,
         }
 
@@ -570,6 +670,7 @@ def generate_pr_review(
         print(f"AI generated {comments_before_filtering} comments")
 
         # Validate, filter, and deduplicate comments
+        thread_anchors = {(t["path"], t["side"], t["line"]) for t in threads.values() if t.get("line")}
         unique_comments = {}
         for c in response.get("comments", []):
             file_path, line_num = c.get("file"), c.get("line", 0)
@@ -587,6 +688,11 @@ def generate_pr_review(
             if line_num not in side_map:
                 available = {s: list(diff_files[file_path][s].keys())[:10] for s in ["RIGHT", "LEFT"]}
                 print(f"Filtered out {file_path}:{line_num} (side={side}, available: {available})")
+                continue
+
+            # An existing thread already anchors here; the model must use a thread action, not a duplicate comment
+            if (file_path, side, line_num) in thread_anchors:
+                print(f"Filtered out {file_path}:{line_num} (existing review thread anchors here)")
                 continue
 
             # GitHub rejects suggestions on removed lines
@@ -637,10 +743,33 @@ def generate_pr_review(
             print(f"Trimming comments from {len(filtered_comments)} to {MAX_REVIEW_COMMENTS}")
             filtered_comments = filtered_comments[:MAX_REVIEW_COMMENTS]
 
+        # Validate thread actions against the threads shown to the model, first action per thread wins
+        thread_actions = {}
+        for action in response.get("thread_actions", []):
+            ref, verb = action.get("thread"), action.get("action")
+            message = sanitize_ai_text(action.get("message") or "").strip()
+            if (
+                ref not in shown_threads  # never act on a thread the model was not shown
+                or ref in thread_actions
+                or verb not in ("resolve", "reply")  # the Anthropic fallback does not enforce the schema enum
+                or (verb == "reply" and not message)
+            ):
+                print(f"Filtered out thread action {ref}: {verb}")
+                continue
+            # Never reply on top of the bot's own last word: without a new human reply there is nothing to answer
+            comments = threads[ref]["comments"]
+            if verb == "reply" and comments[-1]["author"] == comments[0]["author"]:
+                print(f"Filtered out thread action {ref}: reply (no new replies since the bot's last comment)")
+                continue
+            thread_actions[ref] = {"thread": ref, "action": verb, "message": message}
+        resolved = sum(a["action"] == "resolve" for a in thread_actions.values())
+
         response.update(
             {
                 "comments": filtered_comments,
                 "comments_before_filtering": comments_before_filtering,
+                "thread_actions": list(thread_actions.values()),
+                "open_threads": len(threads) - resolved,
                 "diff_files": diff_files,
                 "diff_truncated": diff_truncated,
                 "skipped_files": skipped_files,
@@ -687,29 +816,81 @@ def _verified_local_checkout(head_sha: str | None) -> bool:
         return False
 
 
-def clear_previous_review(event: Action) -> None:
-    """Dismiss the bot's active review decisions and delete its superseded inline comments."""
+def dismiss_previous_reviews(event: Action) -> None:
+    """Dismiss the bot's stale review decisions so an outdated APPROVED state never counts for new commits."""
     pr_number, bot_username = event.pr.get("number"), event.get_username()
     reviews_base = f"{GITHUB_API_URL}/repos/{event.repository}/pulls/{pr_number}/reviews"
     reviews = event.get(reviews_base, params={"per_page": 100}, hard=True).json()
-    owned_reviews = {
-        review["id"]
-        for review in reviews
-        if review.get("user", {}).get("login") == bot_username and REVIEW_MARKER in (review.get("body") or "")
-    }
     for review in reviews:
-        if review.get("id") in owned_reviews and review.get("state") in ("APPROVED", "CHANGES_REQUESTED"):
+        if (
+            review.get("user", {}).get("login") == bot_username
+            and REVIEW_MARKER in (review.get("body") or "")
+            and review.get("state") in ("APPROVED", "CHANGES_REQUESTED")
+        ):
             event.put(
                 f"{reviews_base}/{review['id']}/dismissals",
                 json={"message": "Superseded by new review"},
                 hard=True,
             )
 
-    comments_base = f"{GITHUB_API_URL}/repos/{event.repository}/pulls/{pr_number}/comments"
-    comments = event.get(comments_base, params={"per_page": 100}, hard=True).json()
-    for comment in comments:
-        if comment.get("pull_request_review_id") in owned_reviews:
-            event.delete(f"{GITHUB_API_URL}/repos/{event.repository}/pulls/comments/{comment['id']}", hard=True)
+
+def get_review_threads(event: Action) -> dict[str, dict]:
+    """Fetch the bot's unresolved review threads keyed by short refs (T1, T2, ...) the model can echo back."""
+    if not (bot_username := event.get_username()):  # never degrade to "no threads": that re-creates duplicates
+        raise RuntimeError("Failed to resolve bot username for review threads")
+    threads, cursor = {}, None
+    while True:
+        result = event.graphql_request(
+            GRAPHQL_PR_REVIEW_THREADS,
+            variables={"owner": event.owner, "name": event.repo_name, "number": event.pr["number"], "cursor": cursor},
+        )
+        if "data" not in result or result.get("errors"):
+            raise RuntimeError(f"Review threads query failed: {result.get('errors')}")
+        connection = (((result["data"] or {}).get("repository") or {}).get("pullRequest") or {}).get(
+            "reviewThreads"
+        ) or {}
+        for node in connection.get("nodes") or []:
+            comments = (node.get("comments") or {}).get("nodes") or []
+            root = comments[0] if comments else {}
+            if (
+                node.get("isResolved")
+                or (root.get("author") or {}).get("login") != bot_username
+                or REVIEW_MARKER not in ((root.get("pullRequestReview") or {}).get("body") or "")
+            ):
+                continue
+            threads[f"T{len(threads) + 1}"] = {
+                "id": node["id"],
+                "root_comment_id": root.get("fullDatabaseId"),
+                "path": node.get("path"),
+                "line": node.get("line"),
+                "side": node.get("diffSide") or "RIGHT",
+                "outdated": bool(node.get("isOutdated")),
+                "comments": [
+                    {"author": (c.get("author") or {}).get("login") or "unknown", "body": c.get("body") or ""}
+                    for c in comments
+                ],
+            }
+        page_info = connection.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            return threads
+        cursor = page_info.get("endCursor")
+
+
+def apply_thread_actions(event: Action, review_data: dict, threads: dict[str, dict]) -> None:
+    """Reply to and resolve existing review threads as decided by the review model."""
+    pr_number = event.pr["number"]
+    for action in review_data.get("thread_actions", []):
+        thread = threads[action["thread"]]
+        if (message := action.get("message")) and (root_id := thread.get("root_comment_id")):
+            event.post(
+                f"{GITHUB_API_URL}/repos/{event.repository}/pulls/{pr_number}/comments/{root_id}/replies",
+                json={"body": message},
+                hard=True,
+            )
+        if action["action"] == "resolve":
+            result = event.graphql_request(GRAPHQL_RESOLVE_REVIEW_THREAD, variables={"threadId": thread["id"]})
+            if "data" not in result or result.get("errors"):
+                raise RuntimeError(f"Failed to resolve review thread {thread['id']}: {result}")
 
 
 def post_review_summary(event: Action, review_data: dict) -> None:
@@ -724,14 +905,22 @@ def post_review_summary(event: Action, review_data: dict) -> None:
     comments = review_data.get("comments", [])
     summary = review_data.get("summary") or ""
 
-    # Don't approve if error occurred, inline comments exist, or medium-or-higher severity issues
+    # Don't approve if error occurred, inline comments or open threads exist, or medium-or-higher severity issues
     has_error = not summary or ERROR_MARKER in summary
     has_evidence = bool(review_data.get("diff_files"))
     has_inline_comments = review_data.get("comments_before_filtering", 0) > 0
+    has_open_threads = bool(review_data.get("open_threads"))
     has_issues = any(c.get("severity") not in ["LOW", "SUGGESTION", None] for c in comments)
     event_type = (
         "COMMENT"
-        if (has_error or not has_evidence or has_inline_comments or has_issues or review_data.get("diff_truncated"))
+        if (
+            has_error
+            or not has_evidence
+            or has_inline_comments
+            or has_open_threads
+            or has_issues
+            or review_data.get("diff_truncated")
+        )
         else "APPROVE"
     )
 
@@ -739,6 +928,9 @@ def post_review_summary(event: Action, review_data: dict) -> None:
 
     if comments:
         body += f"💬 Posted {len(comments)} inline comment{'s' if len(comments) != 1 else ''}\n"
+
+    if thread_actions := review_data.get("thread_actions"):
+        body += f"🧵 Updated {len(thread_actions)} existing review thread{'s' if len(thread_actions) != 1 else ''}\n"
 
     if review_data.get("diff_truncated"):
         body += "\n⚠️ **Large PR**: Review focused on critical issues. Some details may not be covered.\n"
@@ -804,10 +996,14 @@ def main(*args, **kwargs):
     except RuntimeError as e:
         print(f"Skipping stale PR review: {e}")
         return
-    clear_previous_review(event)
+    dismiss_previous_reviews(event)
+    threads = get_review_threads(event)
+    if threads:
+        print(f"Found {len(threads)} unresolved review threads from previous reviews")
     review = generate_pr_review(
-        event.repository, diff, event.pr.get("title") or "", event.pr.get("body") or "", event, head_sha
+        event.repository, diff, event.pr.get("title") or "", event.pr.get("body") or "", event, head_sha, threads
     )
+    apply_thread_actions(event, review, threads)  # before the summary, which claims these actions and may APPROVE
     post_review_summary(event, review)
     print("PR review completed")
 

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -412,10 +412,10 @@ def format_review_threads(threads: dict[str, dict]) -> tuple[str, set[str]]:
         anchor = f"{thread['path']}:{thread['line']} ({thread['side']})" if thread.get("line") else thread["path"]
         outdated = " [outdated: the anchored code changed since]" if thread["outdated"] else ""
         comments = thread["comments"]
-        if len(comments) > 10:  # root finding plus the latest replies: the newest rebuttal matters most
-            comments = [comments[0], *comments[-9:]]
+        if len(comments) > 7:  # root finding plus the newest replies; 7 clipped comments always fit the budget
+            comments = [comments[0], *comments[-6:]]
         convo = "\n".join(f"  {c['author']}: {c['body'][:1000]}" for c in comments)
-        block = _clip_tool_output(f"[{ref}] {anchor}{outdated}\n{convo}", MAX_THREADS_SECTION_CHARS)
+        block = f"[{ref}] {anchor}{outdated}\n{convo}"
         if total + len(block) > MAX_THREADS_SECTION_CHARS and blocks:  # whole threads only, never cut mid-thread
             print(f"Dropping {len(threads) - len(shown)} review threads from prompt (section budget)")
             break
@@ -530,9 +530,10 @@ def generate_pr_review(
         (
             "EXISTING REVIEW THREADS:\n"
             "- The user prompt lists your unresolved threads from previous reviews with any replies to them\n"
-            "- For each thread return at most one thread_actions entry: 'resolve' when the current code fixes the "
-            "issue or a reply rebuts it on substance, 'reply' when the finding still stands and a reply deserves an "
-            "answer; omit the thread when there is nothing new to say\n"
+            "- Re-check every thread against the current code first: 'resolve' when the code now addresses the "
+            "issue or a reply rebuts it on substance - never leave an addressed thread unresolved. 'reply' when the "
+            "finding still stands and a reply deserves an answer; omit the thread only when it still stands and "
+            "there is nothing new to say\n"
             "- Accept a rebuttal only when it is technically substantiated (code, docs, measurements) - confident "
             "assertion alone changes nothing\n"
             "- Never post a new comment for an issue that already has a thread - use a 'reply' thread action instead\n"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -414,7 +414,7 @@ def format_review_threads(threads: dict[str, dict]) -> tuple[str, set[str]]:
         comments = thread["comments"]
         if len(comments) > 7:  # root finding plus the newest replies; 7 clipped comments always fit the budget
             comments = [comments[0], *comments[-6:]]
-        convo = "\n".join(f"  {c['author']}: {c['body'][:1000]}" for c in comments)
+        convo = "\n".join(f"  {c['author']}: {_clip_tool_output(c['body'], 1000)}" for c in comments)
         block = f"[{ref}] {anchor}{outdated}\n{convo}"
         if total + len(block) > MAX_THREADS_SECTION_CHARS and blocks:  # whole threads only, never cut mid-thread
             print(f"Dropping {len(threads) - len(shown)} review threads from prompt (section budget)")
@@ -534,6 +534,8 @@ def generate_pr_review(
             "issue or a reply rebuts it on substance - never leave an addressed thread unresolved. 'reply' when the "
             "finding still stands and a reply deserves an answer; omit the thread only when it still stands and "
             "there is nothing new to say\n"
+            "- Judge each thread by its original finding: once its substantive risk is addressed, resolve - do not "
+            "pivot the thread to a narrower residue of the same concern\n"
             "- Accept a rebuttal only when it is technically substantiated (code, docs, measurements) - confident "
             "assertion alone changes nothing\n"
             "- Never post a new comment for an issue that already has a thread - use a 'reply' thread action instead\n"
@@ -555,12 +557,18 @@ def generate_pr_review(
         "- Style/formatting (handled by ruff/prettier)\n"
         "- Minor naming preferences\n"
         "- 'Consider using X' without clear benefit\n"
-        "- Issues in unchanged context lines\n\n"
+        "- Issues in unchanged context lines\n"
+        "- Residual hardening of a risk the code already guards: if the remaining worst case is a degraded message, "
+        "a cosmetic inaccuracy, or a narrower rerun of an addressed concern, it is not a finding - findings must "
+        "clear the same minimal-scope bar the PROJECT GUIDELINES set for code changes\n\n"
         f"{visibility_section}"
         "QUALITY OVER QUANTITY:\n"
         "- Zero comments is valid for clean PRs: never invent an issue, never withhold an evidence-backed one\n"
         "- Each comment must be actionable with clear reasoning\n"
         "- Combine related issues into one comment\n"
+        "- Severity reflects the worst realistic consequence: CRITICAL/HIGH require wrong behavior, data loss, "
+        "security exposure, or wrong merge decisions; degraded messages, rare-race cosmetics, and hardening "
+        "suggestions are LOW or SUGGESTION\n"
         f"- Hard cap: {MAX_REVIEW_COMMENTS} comments maximum\n\n"
         "SUGGESTIONS:\n"
         "- Provide 'suggestion' field with ready-to-merge code when you can confidently fix the issue\n"
@@ -770,14 +778,16 @@ def generate_pr_review(
                 print(f"Filtered out thread action {ref}: reply (no new replies since the bot's last comment)")
                 continue
             thread_actions[ref] = {"thread": ref, "action": verb, "message": message}
-        resolved = sum(a["action"] == "resolve" for a in thread_actions.values())
+        # Only findings-level threads gate approval: LOW/SUGGESTION threads advise without blocking
+        blocking = {ref for ref, t in threads.items() if t.get("blocking", True)}
+        resolved = {ref for ref, a in thread_actions.items() if a["action"] == "resolve"}
 
         response.update(
             {
                 "comments": filtered_comments,
                 "comments_before_filtering": comments_before_filtering,
                 "thread_actions": list(thread_actions.values()),
-                "open_threads": len(threads) - resolved,
+                "open_threads": len(blocking - resolved),
                 "diff_files": diff_files,
                 "diff_truncated": diff_truncated,
                 "skipped_files": skipped_files,
@@ -868,6 +878,7 @@ def get_review_threads(event: Action) -> dict[str, dict]:
             comments = (node.get("latest") or {}).get("nodes") or []  # newest replies: the last-word guard needs them
             if not comments or comments[0].get("fullDatabaseId") != root.get("fullDatabaseId"):
                 comments = [root, *comments]  # thread longer than the fetched tail: keep the root finding visible
+            severity = re.match(r"\S+ \*\*(\w+)\*\*:", root.get("body") or "")  # posted as "{emoji} **{severity}**:"
             threads[f"T{len(threads) + 1}"] = {
                 "id": node["id"],
                 "root_comment_id": root.get("fullDatabaseId"),
@@ -875,6 +886,7 @@ def get_review_threads(event: Action) -> dict[str, dict]:
                 "line": node.get("line"),
                 "side": node.get("diffSide") or "RIGHT",
                 "outdated": bool(node.get("isOutdated")),
+                "blocking": not severity or severity.group(1) not in ("LOW", "SUGGESTION"),
                 "comments": [
                     {"author": (c.get("author") or {}).get("login") or "unknown", "body": c.get("body") or ""}
                     for c in comments
@@ -900,7 +912,7 @@ def apply_thread_actions(event: Action, review_data: dict, threads: dict[str, di
         # New replies don't change the head SHA: never act on a conversation the model didn't see
         if fresh.get(thread["id"]) != thread["comments"]:
             print(f"Skipping {action['action']} on thread {thread['id']}: conversation changed during review")
-            if action["action"] == "resolve":
+            if action["action"] == "resolve" and thread.get("blocking", True):
                 review_data["open_threads"] += 1  # the thread stays open: keep the APPROVE gate honest
             continue
         if (message := action.get("message")) and (root_id := thread.get("root_comment_id")):
@@ -955,6 +967,9 @@ def post_review_summary(event: Action, review_data: dict) -> None:
 
     if thread_actions := review_data.get("thread_actions"):
         body += f"🧵 Updated {len(thread_actions)} existing review thread{'s' if len(thread_actions) != 1 else ''}\n"
+
+    if comments or review_data.get("open_threads"):
+        body += "🔁 Reply in the threads and re-request my review to continue the conversation\n"
 
     if review_data.get("diff_truncated"):
         body += "\n⚠️ **Large PR**: Review focused on critical issues. Some details may not be covered.\n"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -898,6 +898,8 @@ def apply_thread_actions(event: Action, review_data: dict, threads: dict[str, di
         # New replies don't change the head SHA: never act on a conversation the model didn't see
         if fresh.get(thread["id"]) != thread["comments"]:
             print(f"Skipping {action['action']} on thread {thread['id']}: conversation changed during review")
+            if action["action"] == "resolve":
+                review_data["open_threads"] += 1  # the thread stays open: keep the APPROVE gate honest
             continue
         if (message := action.get("message")) and (root_id := thread.get("root_comment_id")):
             event.post(

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -891,9 +891,14 @@ def apply_thread_actions(event: Action, review_data: dict, threads: dict[str, di
         return
     if event.get_pr_head_sha() != review_data["head_sha"]:  # don't mutate threads from a stale review
         raise RuntimeError("PR head changed during review generation")
+    fresh = {t["id"]: t["comments"] for t in get_review_threads(event).values()}
     pr_number = event.pr["number"]
     for action in actions:
         thread = threads[action["thread"]]
+        # New replies don't change the head SHA: never act on a conversation the model didn't see
+        if fresh.get(thread["id"]) != thread["comments"]:
+            print(f"Skipping {action['action']} on thread {thread['id']}: conversation changed during review")
+            continue
         if (message := action.get("message")) and (root_id := thread.get("root_comment_id")):
             event.post(
                 f"{GITHUB_API_URL}/repos/{event.repository}/pulls/{pr_number}/comments/{root_id}/replies",

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -439,6 +439,7 @@ def generate_pr_review(
     event: Action = None,
     head_sha: str | None = None,
     threads: dict[str, dict] | None = None,
+    settled: list[str] | None = None,
 ) -> dict:
     """Generate comprehensive PR review with line-specific comments and overall assessment."""
     head_sha = head_sha or (event.get_pr_head_sha() if event else None)
@@ -497,9 +498,23 @@ def generate_pr_review(
 
     threads = threads or {}
     threads_section, shown_threads = format_review_threads(threads)
+    settled_section = (
+        "SETTLED FINDINGS (resolved in earlier rounds - do not re-raise or rehash them in any form):\n"
+        + "\n".join(f"- {s}" for s in settled[:20])
+        + "\n\n"
+        if settled
+        else ""
+    )
 
     # Calculate remaining budget for diff and check if truncation needed
-    diff_budget = max(1000, MAX_PROMPT_CHARS - len(guidelines_section) - len(full_files_section) - len(threads_section))
+    diff_budget = max(
+        1000,
+        MAX_PROMPT_CHARS
+        - len(guidelines_section)
+        - len(full_files_section)
+        - len(threads_section)
+        - len(settled_section),
+    )
     diff_truncated = len(augmented_diff) > diff_budget
     is_large_pr = diff_truncated or len(file_list) > 30
     if is_agent_review_model:  # must match the get_agent_response fallback gate
@@ -538,6 +553,11 @@ def generate_pr_review(
             "pivot the thread to a narrower residue of the same concern\n"
             "- Accept a rebuttal only when it is technically substantiated (code, docs, measurements) - confident "
             "assertion alone changes nothing\n"
+            "- A 'reply' that keeps a finding alive must cite the current code (path and line) that sustains it; "
+            "if you cannot cite it, resolve\n"
+            "- Two replies per thread is the debate limit: if the author still disagrees after your second reply, "
+            "resolve with a brief dissent note for the record or leave the thread to the author - further argument "
+            "is not available\n"
             "- Never post a new comment for an issue that already has a thread - use a 'reply' thread action instead\n"
             "- 'message' is posted as a reply in the thread: required for 'reply', a brief reason or empty for 'resolve'\n\n"
         )
@@ -606,6 +626,7 @@ def generate_pr_review(
                 f"{guidelines_section}"
                 f"{full_files_section}"
                 f"{threads_section}"
+                f"{settled_section}"
                 f"DIFF:\n{augmented_diff[:diff_budget]}\n\n"
                 "Now review this diff according to the rules above. Return JSON with comments array and summary."
             ),
@@ -782,6 +803,10 @@ def generate_pr_review(
             if verb == "reply" and comments[-1]["author"] == comments[0]["author"]:
                 print(f"Filtered out thread action {ref}: reply (no new replies since the bot's last comment)")
                 continue
+            # Two standing replies end the debate: from here the bot may only concede or leave it to the author
+            if verb == "reply" and sum(c["author"] == comments[0]["author"] for c in comments[1:]) >= 2:
+                print(f"Filtered out thread action {ref}: reply (debate limit reached, resolve or stand aside)")
+                continue
             thread_actions[ref] = {"thread": ref, "action": verb, "message": message}
         # Only findings-level threads gate approval: LOW/SUGGESTION threads advise without blocking
         blocking = {ref for ref, t in threads.items() if t.get("severity") not in ("LOW", "SUGGESTION")}
@@ -857,11 +882,11 @@ def dismiss_previous_reviews(event: Action) -> None:
             )
 
 
-def get_review_threads(event: Action) -> dict[str, dict]:
-    """Fetch the bot's unresolved review threads keyed by short refs (T1, T2, ...) the model can echo back."""
+def get_review_threads(event: Action) -> tuple[dict[str, dict], list[str]]:
+    """Fetch the bot's unresolved review threads keyed by short refs (T1, T2, ...), plus settled finding summaries."""
     if not (bot_username := event.get_username()):  # never degrade to "no threads": that re-creates duplicates
         raise RuntimeError("Failed to resolve bot username for review threads")
-    threads, cursor = {}, None
+    threads, settled, cursor = {}, [], None
     while True:
         result = event.graphql_request(
             GRAPHQL_PR_REVIEW_THREADS,
@@ -874,11 +899,12 @@ def get_review_threads(event: Action) -> dict[str, dict]:
         ) or {}
         for node in connection.get("nodes") or []:
             root = ((node.get("root") or {}).get("nodes") or [{}])[0]
-            if (
-                node.get("isResolved")
-                or (root.get("author") or {}).get("login") != bot_username
-                or REVIEW_MARKER not in ((root.get("pullRequestReview") or {}).get("body") or "")
+            if (root.get("author") or {}).get("login") != bot_username or REVIEW_MARKER not in (
+                (root.get("pullRequestReview") or {}).get("body") or ""
             ):
+                continue
+            if node.get("isResolved"):
+                settled.append((root.get("body") or "")[:200])  # remembered so settled findings are never re-raised
                 continue
             comments = (node.get("latest") or {}).get("nodes") or []  # newest replies: the last-word guard needs them
             if not comments or comments[0].get("fullDatabaseId") != root.get("fullDatabaseId"):
@@ -899,7 +925,7 @@ def get_review_threads(event: Action) -> dict[str, dict]:
             }
         page_info = connection.get("pageInfo") or {}
         if not page_info.get("hasNextPage"):
-            return threads
+            return threads, settled
         cursor = page_info.get("endCursor")
 
 
@@ -909,7 +935,7 @@ def apply_thread_actions(event: Action, review_data: dict, threads: dict[str, di
         return
     if event.get_pr_head_sha() != review_data["head_sha"]:  # don't mutate threads from a stale review
         raise RuntimeError("PR head changed during review generation")
-    fresh = {t["id"]: t["comments"] for t in get_review_threads(event).values()}
+    fresh = {t["id"]: t["comments"] for t in get_review_threads(event)[0].values()}
     pr_number = event.pr["number"]
     applied = []
     for action in actions:
@@ -1041,11 +1067,18 @@ def main(*args, **kwargs):
         print(f"Skipping stale PR review: {e}")
         return
     dismiss_previous_reviews(event)
-    threads = get_review_threads(event)
-    if threads:
-        print(f"Found {len(threads)} unresolved review threads from previous reviews")
+    threads, settled = get_review_threads(event)
+    if threads or settled:
+        print(f"Found {len(threads)} unresolved and {len(settled)} settled review threads from previous reviews")
     review = generate_pr_review(
-        event.repository, diff, event.pr.get("title") or "", event.pr.get("body") or "", event, head_sha, threads
+        event.repository,
+        diff,
+        event.pr.get("title") or "",
+        event.pr.get("body") or "",
+        event,
+        head_sha,
+        threads,
+        settled,
     )
     apply_thread_actions(event, review, threads)  # before the summary, which claims these actions and may APPROVE
     post_review_summary(event, review)

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -253,40 +253,29 @@ def test_post_review_summary_fails_when_github_rejects_review():
     assert event.post.call_args.kwargs["hard"] is True
 
 
-def test_clear_previous_review_preserves_summaries_and_deletes_inline_comments():
-    """Test replacement reviews invalidate bot decisions and remove only bot inline comments."""
+def test_dismiss_previous_reviews_preserves_comments():
+    """Test replacement reviews invalidate stale bot decisions without deleting inline comments."""
     event = MagicMock()
     event.repository = "org/repo"
     event.pr = {"number": 7}
     event.get_username.return_value = "review-bot"
-    event.get.side_effect = [
-        MagicMock(
-            json=lambda: [
-                {"id": 1, "state": "APPROVED", "body": review_pr.REVIEW_MARKER, "user": {"login": "review-bot"}},
-                {"id": 2, "state": "COMMENTED", "body": review_pr.REVIEW_MARKER, "user": {"login": "review-bot"}},
-                {"id": 3, "state": "APPROVED", "body": "Human review", "user": {"login": "human"}},
-                {"id": 6, "state": "COMMENTED", "body": "Other automation", "user": {"login": "review-bot"}},
-            ]
-        ),
-        MagicMock(
-            json=lambda: [
-                {"id": 4, "pull_request_review_id": 1, "user": {"login": "review-bot"}},
-                {"id": 5, "pull_request_review_id": 6, "user": {"login": "review-bot"}},
-            ]
-        ),
-    ]
+    event.get.return_value = MagicMock(
+        json=lambda: [
+            {"id": 1, "state": "APPROVED", "body": review_pr.REVIEW_MARKER, "user": {"login": "review-bot"}},
+            {"id": 2, "state": "COMMENTED", "body": review_pr.REVIEW_MARKER, "user": {"login": "review-bot"}},
+            {"id": 3, "state": "APPROVED", "body": "Human review", "user": {"login": "human"}},
+            {"id": 6, "state": "COMMENTED", "body": "Other automation", "user": {"login": "review-bot"}},
+        ]
+    )
 
-    review_pr.clear_previous_review(event)
+    review_pr.dismiss_previous_reviews(event)
 
     event.put.assert_called_once_with(
         "https://api.github.com/repos/org/repo/pulls/7/reviews/1/dismissals",
         json={"message": "Superseded by new review"},
         hard=True,
     )
-    event.delete.assert_called_once_with(
-        "https://api.github.com/repos/org/repo/pulls/comments/4",
-        hard=True,
-    )
+    event.delete.assert_not_called()
 
 
 def test_incomplete_review_evidence_cannot_approve():


### PR DESCRIPTION
## Summary

The PR review bot currently deletes all of its previous inline comments before each new review and never sees replies, so it re-raises findings the author already rebutted — every round is a cold re-review and thread pushback can never converge.

**Motivation:** this fix is inspired by ultralytics/assistant#2978, where the bot kept bringing up the same finding round after round even after the author pushed back explaining the issue was not introduced by that PR and not considered important — because each new review deleted the previous comments and never read the replies, the pushback could never register and the only way to silence the bot was changing the code.

This PR makes review threads persistent and conversational:

- **Stop deleting inline comments.** `clear_previous_review` becomes `dismiss_previous_reviews`: it still dismisses stale APPROVED/CHANGES_REQUESTED states (so an outdated approval never counts for new commits) but the comment-deletion loop is removed.
- **Feed existing threads to the model.** `get_review_threads` fetches the bot's unresolved threads via paginated GraphQL `reviewThreads`, scoped to reviews carrying the bot's `REVIEW_MARKER` (threads from other tools sharing the `github-actions[bot]` login are ignored). Threads are rendered into the review prompt keyed `T1/T2/...` — root finding plus latest replies, whole threads only. Injected into the prompt (not a tool) so it also works on the Anthropic single-shot fallback, which strips function tools.
- **Per-thread verbs.** The model returns `thread_actions`: `resolve` (code now fixes it, or the rebuttal holds on substance) or `reply` (finding stands — answer posted in-thread). Applied via the REST replies endpoint and the `resolveReviewThread` mutation, before the summary posts so the review only ever claims actions that actually happened.

## Guardrails

- **Bounded debates:** two replies per thread is the limit — if the author still disagrees after the bot's second reply, the bot must resolve with a recorded dissent note or stand aside (enforced in code, not just prompt). No stalemate can block a PR forever.
- **Settled memory:** resolved bot threads are fed back as one-line "settled findings — do not re-raise" context, so conceded findings never return, on any line.
- **Severity calibration:** CRITICAL/HIGH require wrong behavior, data loss, security exposure, or wrong merge decisions; LOW/SUGGESTION threads persist as advice but do not block APPROVE.
- **Anchor dedup with escalation:** new comments on a line owned by an existing thread are filtered unless strictly more severe — no duplicate nagging, but a serious regression can never hide behind an advisory nit.
- Replies are suppressed when the bot already has the last word (no nag loops); rebuttals are accepted only on technical substance, and a reply that keeps a finding alive must cite the current code sustaining it.
- Actions are validated against the threads actually shown to the model; thread mutations are guarded against stale heads and conversations that changed during generation.
- Thread fetch and resolve fail loudly (missing username, GraphQL errors, rate-limit bodies) instead of degrading to "no threads".
- APPROVE is blocked while unresolved MEDIUM+ bot threads remain; the summary shows a 🔁 hint telling authors how to continue the conversation.

## Seen live on this PR

The whole loop ran on this PR itself (`format.yml` dogfoods the PR head): 9 findings across 11 review rounds — 5 fixed, 4 rebutted in-thread with every rebuttal evaluated and accepted, nothing resolved ever re-raised. When one truncation debate stalled after three exchanges, the debate limit ended it exactly as designed, with the reviewer recording its dissent and resolving its own thread: https://github.com/ultralytics/actions/pull/851#discussion_r3684391448 — and once every thread was fixed, conceded, or dissent-closed, the bot issued its APPROVE.

## Notes

- Threads fetch the root finding plus the `last: 30` replies so the newest rebuttal is always visible to the model and the last-word guard; bodies over 1,000 chars carry an explicit truncation marker.
- Uses `fullDatabaseId` (not the 32-bit `databaseId`, which modern comment IDs overflow) for reply targets.
- The author can get a response without pushing by re-requesting review from the bot.
- Existing test updated to assert comments are never deleted; `review_pr.py` is coverage-omitted, validation done via mocked-network smoke tests of all new paths (pagination, marker scoping, escalation, debate limits, failure modes).
- Bumps `__version__` to 0.2.45.