### PR TITLE
Avoid Luna cache writes on one-shot calls

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.44"
+__version__ = "0.2.45"

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -288,15 +288,17 @@ def _format_tool_calls(calls: list[str]) -> str:
 def _print_openai_usage(
     response_json: dict, model: str, elapsed: float, metadata: str = "", billed_cost: float | None = None
 ) -> None:
-    """Print token/cost telemetry: 'model: 136036→289 tokens (72% cached, 31 thinking), $0.69, 8.9s'."""
+    """Print token/cost telemetry: 'model: 136036→289 tokens (72% cached, 8% cache write), $0.69, 8.9s'."""
     if usage := response_json.get("usage"):
-        input_tokens, cached_tokens, _ = _normalize_usage_tokens(usage)
+        input_tokens, cached_tokens, cache_write_tokens = _normalize_usage_tokens(usage)
         output_tokens = usage.get("output_tokens", 0)  # includes thinking, noted in the parenthetical
         thinking_tokens = (usage.get("output_tokens_details") or {}).get("reasoning_tokens", 0)
         cost = _openai_usage_cost(usage, model) if billed_cost is None else billed_cost
         notes = []
         if cached_tokens:
             notes.append(f"{round(100 * cached_tokens / input_tokens)}% cached")
+        if cache_write_tokens:
+            notes.append(f"{round(100 * cache_write_tokens / input_tokens)}% cache write")
         if thinking_tokens:
             notes.append(f"{thinking_tokens} thinking")
         note_str = f" ({', '.join(notes)})" if notes else ""
@@ -571,6 +573,8 @@ def get_response(
                 data["system"] = (data.get("system") or "") + json_instruction
         else:
             data = {"model": model, "input": messages, "store": background, "temperature": temperature}
+            if model.startswith("gpt-5.6-luna"):
+                data["prompt_cache_options"] = {"mode": "explicit"}  # disable costly implicit writes for one-shot calls
             if background:
                 data["background"] = True
             if "gpt-5" in model:

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -145,6 +145,7 @@ def test_get_response(mock_post):
 
     assert result == "Test response from OpenAI"
     mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["json"]["prompt_cache_options"] == {"mode": "explicit"}
 
 
 @patch("time.sleep")
@@ -311,7 +312,7 @@ def test_get_agent_response_calls_function_tools(mock_post):
     printed = "\n".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
     assert "turn 1/6, 2 tools (lookup_value, web_search)" in printed
     assert "turn 2/6, 0 tools" in printed
-    assert "30→12 tokens (40% cached), $0.01" in printed
+    assert "30→12 tokens (40% cached, 30% cache write), $0.01" in printed
     assert "agent total, 2 turns, 2 tools (lookup_value, web_search)" in printed
     assert "Agent tool turn" not in printed  # tool names live in the per-turn usage line now
 


### PR DESCRIPTION
## Summary

- disable GPT-5.6 Luna implicit prompt caching for one-shot Responses calls
- preserve caching for iterative Terra/Sol agent runs
- report cache-write percentages in usage telemetry

Recent Actions runs showed zero cached input across sampled Luna calls, while cache-eligible prompts paid the 25% write premium. Explicit mode without breakpoints avoids those writes.

## Validation

- `PYTHONPATH=. pytest tests -v` (144 passed)
- repository Ruff check and format commands
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves OpenAI usage telemetry and enables explicit prompt caching for `gpt-5.6-luna`, with updated tests and a patch version bump. 🚀

### 📊 Key Changes

- Added cache-write percentages to OpenAI token and cost telemetry.
- Enabled `prompt_cache_options={"mode": "explicit"}` for `gpt-5.6-luna` requests.
- Updated tests to verify prompt-cache configuration and revised usage output.
- Bumped the package version from `0.2.44` to `0.2.45`.

### 🎯 Purpose & Impact

- 💰 Helps reduce unnecessary implicit cache-write costs for one-shot `gpt-5.6-luna` calls.
- 📈 Gives developers clearer visibility into cached and cache-written tokens.
- ✅ Maintains expected behavior through expanded automated test coverage.
- 🔄 The changes are isolated to OpenAI request handling and telemetry, minimizing impact on other actions.