### PR TITLE
Make URL tests deterministic

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -29,6 +29,18 @@ URLS = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def mock_url_checks():
+    """Keep URL parsing tests independent of third-party website availability."""
+
+    def fake_is_url(url, session=None, check=True, max_attempts=3, timeout=3, return_url=False, redirect=False):
+        valid = url in URLS
+        return (valid, url) if return_url else valid
+
+    with patch("actions.utils.common_utils.is_url", side_effect=fake_is_url):
+        yield
+
+
 @pytest.fixture
 def verbose():
     """Fixture that provides a verbose logging utility for detailed output during testing and debugging."""
@@ -38,7 +50,7 @@ def verbose():
 def test_is_url():
     """Test each URL using is_url function."""
     for url in URLS:
-        assert is_url(url), f"URL check failed: {url}"
+        assert is_url(url, check=False), f"URL check failed: {url}"
 
 
 def test_links_in_string_func():


### PR DESCRIPTION
## Summary

- replace live third-party URL checks in URL parsing tests with deterministic mocked results
- retain structural URL validation through `is_url(..., check=False)`
- remove the Apple App Store availability dependency that failed scheduled run 30725796540

## Validation

- `PYTHONPATH=. uv run --active pytest tests -v` (144 passed)
- `uv run --active ruff check --extend-select F,I,D,UP,RUF,FA --target-version py38 --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 .`
- `uv run --active ruff format --line-length 120 --check .`

Fixes https://github.com/ultralytics/actions/actions/runs/30725796540

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧪 Updated URL tests to avoid relying on external website availability.

### 📊 Key Changes

- Added an automatic pytest fixture that mocks `is_url` during tests.
- The mock validates URLs against the local test URL list instead of making network requests.
- Updated `test_is_url` to disable live URL checking with `check=False`.

### 🎯 Purpose & Impact

- ✅ Makes tests more reliable and deterministic, even when websites are unavailable.
- ⚡ Reduces network calls and speeds up the test suite.
- 🛡️ Prevents third-party outages or connectivity issues from causing unrelated test failures.
- 🔍 Keeps URL parsing behavior covered while isolating tests from external services.