### PR TITLE
List CLA and Setup uv actions in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,6 +33,8 @@ body:
         - "Cleanup Disk Action"
         - "GitHub Report Action"
         - "Dependabot Action"
+        - "CLA Action"
+        - "Setup uv Action"
         - "Python package (`ultralytics-actions`)"
         - "Repository documentation / README"
         - "Other"

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -33,6 +33,8 @@ body:
         - "Cleanup Disk Action"
         - "GitHub Report Action"
         - "Dependabot Action"
+        - "CLA Action"
+        - "Setup uv Action"
         - "Python package (`ultralytics-actions`)"
         - "Repository documentation / README"
         - "Other"

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -31,6 +31,8 @@ body:
         - "Cleanup Disk Action"
         - "GitHub Report Action"
         - "Dependabot Action"
+        - "CLA Action"
+        - "Setup uv Action"
         - "Python package (`ultralytics-actions`)"
         - "Repository documentation / README"
         - "Other"


### PR DESCRIPTION
Follow-up to #854. The "Ultralytics Actions area" dropdown stopped at Dependabot in all three issue templates, so reporters had no way to attribute an issue to two shipped composite actions.

The repo has six standalone actions, each with its own `action.yml` and README: retry, cleanup-disk, github-report, dependabot, cla, setup-uv. Added `CLA Action` and `Setup uv Action` to the dropdown in `bug-report.yml`, `feature-request.yml`, and `question.yml`.

This is the same gap #854 fixed in README.zh-CN.md, which had documented only the first four. All three files re-parse as valid YAML.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds **CLA Action** and **Setup uv Action** options to all GitHub issue templates. 🛠️

### 📊 Key Changes

- Updated the bug report, feature request, and question templates.
- Added **“CLA Action”** and **“Setup uv Action”** to the component selection list.

### 🎯 Purpose & Impact

- Makes it easier for users to correctly identify which action their issue relates to. 🎯
- Improves issue triage and routing for maintainers.
- Helps ensure reports and requests for the newer actions are categorized consistently. ✅