### PR TITLE
Always apply AGPL header to .github files

### DIFF
--- a/actions/update_file_headers.py
+++ b/actions/update_file_headers.py
@@ -214,13 +214,14 @@ def main(*args, **kwargs):
         prefix, block_start, block_end = comment_style
 
         for file_path in directory.rglob(f"*{ext}"):
-            if not file_path.is_file() or any(part in str(file_path) for part in IGNORE_PATHS):
+            # Match against the repo-relative POSIX path so directory entries behave the same on Windows
+            relative_path = file_path.relative_to(directory).as_posix()
+            if not file_path.is_file() or any(part in relative_path for part in IGNORE_PATHS):
                 continue
 
             total += 1
             # .github/ files are public-facing org configuration, so they keep the AGPL header even in private repos
-            relative_path = file_path.relative_to(directory)
-            file_header = AGPL_HEADER if org_repo and relative_path.as_posix().startswith(".github/") else header
+            file_header = AGPL_HEADER if org_repo and relative_path.startswith(".github/") else header
             if update_file(file_path, prefix, block_start, block_end, file_header):
                 print(f"Updated: {relative_path}")
                 changed += 1

--- a/actions/update_file_headers.py
+++ b/actions/update_file_headers.py
@@ -12,6 +12,9 @@ from actions.utils import Action
 # Base header text
 HEADER = os.getenv("HEADER")
 
+# Applied to public repos, and to .github/ files in every repo including private ones
+AGPL_HEADER = "Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license"
+
 # Map file extensions to comment styles
 COMMENT_MAP = {
     # Python style
@@ -51,7 +54,7 @@ IGNORE_PATHS = {
     ".venv",
     "env/",
     "node_modules",
-    ".git",
+    ".git/",  # trailing slash so this does not also match .github/
     "__pycache__",
     "mkdocs_github_authors.yaml",
     # Build and distribution directories
@@ -190,12 +193,13 @@ def main(*args, **kwargs):
     repository = (event.repository or "").lower()
 
     # Only process repos owned by the Ultralytics organization
-    if repository.startswith("ultralytics/"):
+    org_repo = repository.startswith("ultralytics/")
+    if org_repo:
         if event.is_repo_private():
             notice = f"© 2014-{current_year} Ultralytics Inc. 🚀"
             header = f"{notice} All rights reserved. CONFIDENTIAL: Unauthorized use or distribution prohibited."
         else:
-            header = "Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license"
+            header = AGPL_HEADER
     elif HEADER and str(HEADER).lower() not in {"true", "false", "none"}:
         header = HEADER
     else:
@@ -214,8 +218,11 @@ def main(*args, **kwargs):
                 continue
 
             total += 1
-            if update_file(file_path, prefix, block_start, block_end, header):
-                print(f"Updated: {file_path.relative_to(directory)}")
+            # .github/ files are public-facing org configuration, so they keep the AGPL header even in private repos
+            relative_path = file_path.relative_to(directory)
+            file_header = AGPL_HEADER if org_repo and relative_path.as_posix().startswith(".github/") else header
+            if update_file(file_path, prefix, block_start, block_end, file_header):
+                print(f"Updated: {relative_path}")
                 changed += 1
             else:
                 unchanged += 1


### PR DESCRIPTION
Makes org policy explicit: files under `.github/` carry the standard AGPL header in every Ultralytics repo, public or private.

## Why the bot was not reverting these headers

Neither the privacy branch nor the `git reset HEAD -- .github/workflows/` step in `action.yml` explains it. The real cause is a substring collision in `IGNORE_PATHS`.

The skip test is `any(part in str(file_path) for part in IGNORE_PATHS)` — an unanchored substring match — and `IGNORE_PATHS` contained `".git"`, which is a prefix of `".github"`. So every path like `/repo/.github/dependabot.yml` matched `".git"` and was skipped. `.github/` files have never been processed by this script, in public or private repos alike.

That is why the 17 private repos keep their new AGPL headers, and it also explains the odd run accounting: `total` never counted `.github/` files, so a repo reporting `Headers: 17` was silently excluding them. It is one root cause, not two issues. It also means the earlier static analysis was right that `.github/` is absent from `IGNORE_PATHS` — but `.git` was catching it anyway.

Because the files were never visited, the previous behavior was only *tolerating* whatever headers happened to be committed. Enforcing the policy requires the script to actually visit them, so this PR does both.

## Changes

- `IGNORE_PATHS`: `".git"` → `".git/"`. The real `.git` directory is still ignored (its contents always contain `.git/`), while `.github/` is no longer swallowed.
- `.github/` files use the AGPL header regardless of `is_repo_private()`, for Ultralytics org repos only. Repos using the `header:` input are unaffected — they keep applying their own header everywhere, including `.github/`.
- Hoisted the AGPL string into an `AGPL_HEADER` constant since it now has two call sites.
- The `.github/` test matches the path relative to the repo root, so a checkout whose own absolute path contains `.github/` cannot misclassify every file.

## Behavior change

| repo | path | before | after |
|---|---|---|---|
| public | `.github/**` | never visited | AGPL (added if missing) |
| public | all other paths | AGPL | AGPL — unchanged |
| private | `.github/**` | never visited | AGPL (added if missing, and corrected if a CONFIDENTIAL notice is present) |
| private | all other paths | CONFIDENTIAL | CONFIDENTIAL — unchanged |
| non-org with `header:` | all paths | custom header | custom header — unchanged |

Workflow files under `.github/workflows/` are now updated on disk, but the commit step already unstages that directory because the default token cannot push workflow changes, so nothing new is pushed there.

## Verification

`pytest tests` — 144 passed. Ruff format and the CI lint flag set both clean.

Ran `main()` directly against fixture trees for each branch:

- private org repo: `.github/workflows/ci.yml`, `.github/ISSUE_TEMPLATE/bug-report.yml` and `.github/dependabot.yml` all keep AGPL while `src/foo.py` becomes CONFIDENTIAL; the scan count went from `Headers: 1` to `Headers: 4`, confirming the three `.github/` files were previously invisible.
- public org repo: all four files AGPL, `Updated: 0` — unchanged from before.
- enforcement: a `.github/` file with no header gains AGPL, and one wrongly carrying the CONFIDENTIAL notice is corrected to AGPL.
- `.git/hooks/x.py` is still skipped.
- non-org repo with `HEADER` set: `.github/` and source both get the custom header, not AGPL.
- a checkout rooted at a path containing `.github/` still classifies `src/a.py` as non-`.github`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves repository file-header automation with consistent AGPL licensing for public and `.github/` files, plus more reliable cross-platform path handling. 🚀

### 📊 Key Changes

- Adds a shared `AGPL_HEADER` constant for the standard Ultralytics AGPL-3.0 license text.
- Applies the AGPL header to:
  - Public Ultralytics repositories.
  - `.github/` files in all Ultralytics repositories, including private ones.
- Preserves confidential copyright headers for other files in private repositories.
- Updates `.git` ignore matching to avoid accidentally excluding `.github/`.
- Uses repository-relative POSIX paths for consistent behavior across operating systems, including Windows.
- Simplifies update logging by printing normalized relative file paths.

### 🎯 Purpose & Impact

- Ensures public-facing GitHub configuration files consistently display the appropriate open-source license. 📄
- Protects private repository files by retaining confidential headers where required.
- Prevents path-matching issues that could cause files to be incorrectly skipped, especially on Windows.
- Makes automated header updates more predictable and maintainable across the Ultralytics organization. ✅