### PR TITLE
Let .github headers follow repo privacy type

### DIFF
--- a/actions/update_file_headers.py
+++ b/actions/update_file_headers.py
@@ -12,9 +12,6 @@ from actions.utils import Action
 # Base header text
 HEADER = os.getenv("HEADER")
 
-# Applied to public repos, and to .github/ files in every repo including private ones
-AGPL_HEADER = "Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license"
-
 # Map file extensions to comment styles
 COMMENT_MAP = {
     # Python style
@@ -193,13 +190,12 @@ def main(*args, **kwargs):
     repository = (event.repository or "").lower()
 
     # Only process repos owned by the Ultralytics organization
-    org_repo = repository.startswith("ultralytics/")
-    if org_repo:
+    if repository.startswith("ultralytics/"):
         if event.is_repo_private():
             notice = f"© 2014-{current_year} Ultralytics Inc. 🚀"
             header = f"{notice} All rights reserved. CONFIDENTIAL: Unauthorized use or distribution prohibited."
         else:
-            header = AGPL_HEADER
+            header = "Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license"
     elif HEADER and str(HEADER).lower() not in {"true", "false", "none"}:
         header = HEADER
     else:
@@ -220,9 +216,7 @@ def main(*args, **kwargs):
                 continue
 
             total += 1
-            # .github/ files are public-facing org configuration, so they keep the AGPL header even in private repos
-            file_header = AGPL_HEADER if org_repo and relative_path.startswith(".github/") else header
-            if update_file(file_path, prefix, block_start, block_end, file_header):
+            if update_file(file_path, prefix, block_start, block_end, header):
                 print(f"Updated: {relative_path}")
                 changed += 1
             else:


### PR DESCRIPTION
Reverts the `.github/`-always-AGPL carve-out from #856, which implemented a misreading of the policy. Keeps the ignore-path fix from that PR.

Correct policy: the org has two header types and every file — including everything under `.github/` — follows its **repo's** type. AGPL in public repos, the proprietary CONFIDENTIAL notice in private repos. "Same headers in public and private" meant `.github/` files are headered consistently with their repo, not one header org-wide.

## Changes

- Removed the `.github/` header override, so `.github/` paths now go through the identical privacy-based selection as every other path.
- Removed the `AGPL_HEADER` constant introduced alongside it; with one call site remaining, the literal is inlined exactly as it was before #856, which also removes a comment that had become wrong.
- **Kept** the ignore-path fix: `".git"` → `".git/"` plus matching on the repo-relative POSIX path. This is what lets the bot reach `.github/` files at all, so it now enforces the correct per-repo-type header there.

Diffed against the commit preceding #856, the only remaining change is that ignore fix.

## Behavior

| repo | path | before this PR | after |
|---|---|---|---|
| private | `.github/**` | AGPL (wrong) | CONFIDENTIAL |
| private | all other paths | CONFIDENTIAL | CONFIDENTIAL — unchanged |
| public | `.github/**` | AGPL | AGPL — unchanged |
| public | all other paths | AGPL | AGPL — unchanged |
| non-org with `header:` | all paths | custom header | custom header — unchanged |

## Verification

144 tests pass; ruff format and the CI lint flag set clean. There is no test module for this script, so behavior was verified by driving `main()` against fixture trees covering both directions and the ignore regressions:

- private org repo — `.github/workflows/ci.yml`, `.github/dependabot.yml` and `.github/scripts/h.py` all become CONFIDENTIAL, `src/model.py` stays CONFIDENTIAL.
- public org repo — the same three `.github/` files stay AGPL, `src/model.py` stays AGPL.
- ignore entries unregressed in both runs: `.git/hooks/pre.py`, `uv.lock` and `assets/app.min.js` are all left untouched, confirming the suffix and directory patterns still match.

Note for the private-repo cleanup: the bot can correct non-workflow `.github/` files itself, but `action.yml` unstages `.github/workflows/` before committing because the default token cannot push workflow changes, so workflow-file headers still need a human PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔒 Simplifies file-header handling by applying consistent licensing rules across Ultralytics repositories, including private repositories’ `.github/` files.

### 📊 Key Changes

- Removed the separate `AGPL_HEADER` constant.
- Applies the selected repository header uniformly to all processed files.
- Public Ultralytics repositories continue using the AGPL-3.0 license header.
- Private Ultralytics repositories now use the confidential, all-rights-reserved notice for every processed file, including `.github/` files.
- Preserves support for custom `HEADER` values in non-Ultralytics repositories.

### 🎯 Purpose & Impact

- Ensures private repository files are consistently marked as confidential. 🔐
- Prevents `.github/` files in private repositories from receiving a public AGPL header.
- Makes the header-update workflow simpler and easier to maintain.
- Public repositories retain their existing licensing behavior, so user-facing impact should be minimal.