### PR TITLE
Raise review agent read timeout to 300s

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.2.46"
+__version__ = "0.2.47"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -552,7 +552,6 @@ def generate_pr_review(
             max_turns=MAX_AGENT_TURNS,
             max_cost=REVIEW_COST_SOFT_LIMIT,
             parallel_tools=True,  # review tools are read-only GitHub/diff reads, safe to batch concurrently
-            request_timeout=(30, 120),
             retries=1,  # one transient failure on any of the sequential turns would otherwise abort the whole review
             # Do not pass background=True; queued background reviews can consume the full 900s poll timeout.
         )

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -388,7 +388,7 @@ def get_agent_response(
     max_cost: float = 0.0,
     parallel_tools: bool = False,
     retries: int = 2,
-    request_timeout: tuple[int, int] = (30, 120),
+    request_timeout: tuple[int, int] = (30, 300),  # responses are unstreamed, so the read timeout caps generation
 ) -> str | dict:
     """Run an iterative OpenAI Responses API agent with application-managed function tools.
 

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -175,7 +175,6 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
     assert kwargs["max_turns"] == review_pr.MAX_AGENT_TURNS
     assert kwargs["max_cost"] == review_pr.REVIEW_COST_SOFT_LIMIT
     assert kwargs["reasoning_effort"] == "high"
-    assert kwargs["request_timeout"] == (30, 120)
     assert "FULL FILE CONTENTS" not in mock_get_agent_response.call_args.args[0][1]["content"]
     assert (
         "Do not flag package or version availability based on web search"


### PR DESCRIPTION
## Problem

PR reviews on large PRs fail *after* completing all their work, posting a traceback instead of a review.

**Reproduced on [ultralytics/portal#3245](https://github.com/ultralytics/portal/pull/3245#pullrequestreview-4883386620)** — "Copy images between datasets, remapping labels by class name", 53 files, +2642/-764. [Run 31183891541](https://github.com/ultralytics/portal/actions/runs/31183891541), review submitted 2026-08-07 13:47:21Z:

```
✓ POST https://api.openai.com/v1/responses → 200 (4.8s)
gpt-5.6-luna: 65519→313 tokens (105 thinking), $0.02, 4.8s, turn 1/16, 7 tools
…
gpt-5.6-luna: 169442→745 tokens (701 thinking), $0.00595, 10.5s, turn 16/16, 1 tools
Review generation failed: HTTPSConnectionPool(host='api.openai.com', port=443):
  Read timed out. (read timeout=120)
```

All 16 tool turns succeeded in 3–33s each, accumulating 169k input tokens for ~$0.10. The call that died is the **17th** — the forced synthesis turn (`tool_choice: "none"`) that emits the entire structured review, every comment plus the summary, in one response.

What the log rules out: not a diff-parsing bug, not a tool failure, not a model refusal or API error. The request was still in flight at 120s. Because responses are unstreamed, no bytes arrive until generation completes, so the `requests` read timeout — nominally a per-read idle limit — acts as a hard cap on total generation time. The response very likely completed server-side moments later (`store: True`), but its id is only returned in the response we never received, so it is unrecoverable.

It's fatal rather than a hiccup because `ReadTimeout` is deliberately excluded from the retry branch in `_post_openai_response` (it subclasses `Timeout`, not `ConnectionError`) to avoid double-billing a request that may have completed. So `retries=1` cannot help, and 16 turns of gathered context are discarded.

## Investigation: the timeout was calibrated for low effort, and effort has been raised twice since

The 120s value has never moved since it was introduced. The review's model and reasoning effort have, twice each:

| Date | PR | Review model | Reasoning effort | Read timeout |
|---|---|---|---|---|
| 2026-07-04 | #786 | `gpt-5.5` | **low** (implicit — no `reasoning_effort` passed, so `or "low"` applied) | 120s ← introduced here |
| 2026-07-10 | #805 | `gpt-5.6-terra` | **medium** | 120s (untouched) |
| 2026-08-04 | #858 | `gpt-5.6-luna` | **high** | 120s (untouched) |
| 2026-08-07 | portal#3245 | — | — | ✗ first observed timeout |

`#858` is where it tipped over, raising both knobs at once three days before the failure:

```diff
-            reasoning_effort="medium",
+            reasoning_effort="high",
```
plus `OPENAI_REVIEW_MODEL_DEFAULT`: `gpt-5.6-terra` → `gpt-5.6-luna`.

The effect of high effort is visible in the log, where per-call latency tracks thinking volume:

| Turn | Thinking tokens | Latency |
|---|---|---|
| 2 | 22 | 3.5s |
| 5 | 26 | 3.5s |
| 10 | 1063 | 32.7s |
| 13 | 1438 | 17.1s |
| 15 | 2070 | 21.2s |

The correlation is loose — turn 13 did more thinking than turn 10 in half the time, so server-side variance matters too — but the direction is unambiguous: the cheap turns are the ones that barely think, and high effort routinely pushed later turns into the 20–33s range on *small* outputs.

The synthesis call is strictly the worst case on every axis at once: the largest context of the run (~170k tokens), high effort, no tools to defer to, and the single largest output required (every review comment for 53 files, plus the summary). Under low effort on `gpt-5.5`, 120s was ample. Under high effort on a 170k context, it is not.

Honest limit on the evidence: because the call was killed mid-flight, we know only that it needed **more than** 120s, not how much more. That argues for meaningful headroom rather than a token +60s bump that might fail on the very same PR.

## Fix

Read timeout 120s → 300s, and delete the `review_pr.py` override that duplicated the default verbatim. `review_pr.py` is the only caller of `get_agent_response`, so the timeout now lives in exactly one place rather than a default plus a redundant copy that could drift — which is precisely how a value survives two effort escalations unnoticed.

Why 300s specifically:

- ~2.5x headroom over the ~120–200s a large synthesis plausibly needs (turn 15 ran ~104 output tok/s; latency isn't linear in output tokens since reasoning time can't be separated out, so treat this as order-of-magnitude).
- Over-generosity is nearly free. A `ReadTimeout` aborts immediately rather than retrying, so the worst case is one longer idle stretch before the same failure. No workflow or step sets `timeout-minutes`, leaving GitHub's 6h job default, so there is no runner-side pressure.
- Under-generosity is expensive: a complete review, 17 API calls, and ~3 minutes of API work, replaced by a traceback on the PR.
- It stays bounded. The limit is per call and the review makes up to 17, so the theoretical ceiling for legitimately-slow-but-successful turns is ~85 min at 300s (vs ~2.8h at 600s). Never realistic at 3–33s per turn, but it's the reason not to reach for a bigger round number just because it looks free.

## Why model and effort are left alone

Neither knob is the defect, and both were changed deliberately in `#858` ("Luna **high**"):

- **Effort:** reverting to medium would fix a timeout by buying less thinking — trading review quality for a network constant. Wrong variable.
- **Model:** cost isn't the pressure. Luna is 10x cheaper than terra (`0.20/1.20` vs `2.00/12.00` per 1M tokens), which is what makes high effort affordable — the entire 17-call run cost ~$0.10. And a larger model would be *slower*, not faster.

The timeout is the one value that fell out of date, so it's the one value this PR changes.

## Validation

- `pytest tests` → 129 passed (excluding the live-HTTP `test_urls.py`)
- `ruff check` / `ruff format --check` with the flag set from `action.yml` → clean, 43 files already formatted
- Dropped the test assertion pinning the removed kwarg. Deliberately not replaced with a `== (30, 300)` check, which would just re-pin a tuning constant in a second place; the adjacent `assert "background" not in kwargs` stays, since that one guards a real design decision.

Note this repo dogfoods itself: `format.yml` reviews this PR with the *currently published* action, so the review landing here still runs at 120s. This diff is small enough not to reproduce the timeout, so it won't validate the fix either — real confirmation comes from the next large PR elsewhere after this publishes.

## Not included

`ReadTimeout` remains non-retryable, so a genuine network stall still discards a completed run. Making the synthesis call recoverable via an `Idempotency-Key` would close that gap cheaply: with `store: True` and `previous_response_id`, the 16 turns of context are already server-side, so a retry re-bills only that one mostly-cached turn (~$0.006) instead of losing the review. Left out to keep this minimal — happy to fold it into this PR if wanted.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Increases the OpenAI agent response timeout to support longer PR reviews and updates the package version to `0.2.47`. ⏱️

### 📊 Key Changes
- Increased the default response read timeout in `get_agent_response` from 120 to 300 seconds.
- Removed the review-specific timeout override so PR reviews use the new global default.
- Updated the test to reflect the removal of the explicit timeout assertion.
- Bumped the `actions` package version from `0.2.46` to `0.2.47`.

### 🎯 Purpose & Impact
- 🛠️ Allows unstreamed OpenAI responses more time to complete, reducing timeouts during lengthy reviews.
- ✅ Simplifies timeout configuration by using one shared default.
- 🔄 Improves reliability for complex or large PR reviews with minimal impact on existing behavior.