### PR TITLE
Number reviews from the second one

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.1"
+__version__ = "0.3.0"

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -882,7 +882,8 @@ def post_review_summary(event: Action, review_data: dict, review_number: int = 1
         else "APPROVE"
     )
 
-    body = f"{REVIEW_MARKER} {review_number}\n\n{ACTIONS_CREDIT}\n\n{summary[:3000]}\n\n"
+    title = REVIEW_MARKER if review_number < 2 else f"{REVIEW_MARKER} {review_number}"  # first review carries no number
+    body = f"{title}\n\n{ACTIONS_CREDIT}\n\n{summary[:3000]}\n\n"
 
     if comments:
         # Log findings in the review body: inline comments are deleted when the next review supersedes this one

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -238,7 +238,7 @@ def test_review_snapshot_retries_until_diff_and_head_match():
 
 
 def test_post_review_summary_numbers_reviews_and_logs_findings():
-    """Test review publication is required and each review is numbered with a findings log that outlives it."""
+    """Test review publication is required and re-reviews are numbered with a findings log that outlives them."""
     event = MagicMock()
     event.repository = "org/repo"
     event.pr = {"number": 7}
@@ -247,7 +247,7 @@ def test_post_review_summary_numbers_reviews_and_logs_findings():
     review_pr.post_review_summary(event, {"head_sha": "abc", "summary": "LGTM", "comments": []})
 
     assert event.post.call_args.kwargs["hard"] is True
-    assert event.post.call_args.kwargs["json"]["body"].startswith(f"{review_pr.REVIEW_MARKER} 1")
+    assert event.post.call_args.kwargs["json"]["body"].startswith(f"{review_pr.REVIEW_MARKER}\n")  # first: no number
 
     comment = {"file": "a.py", "line": 3, "side": "RIGHT", "severity": "HIGH", "message": "retry loop never exits"}
     review_pr.post_review_summary(event, {"head_sha": "abc", "summary": "Fix", "comments": [comment]}, 3)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

First PR reviews now use an unnumbered marker, while subsequent reviews retain numbered labels. 📝

### 📊 Key Changes

- Updated review summary generation in `actions/review_pr.py`:
  - The first review uses only the standard review marker.
  - Re-reviews continue to include their review number.
- Updated the related test to verify the new first-review format.
- Clarified test documentation to distinguish initial reviews from re-reviews.

### 🎯 Purpose & Impact

- Makes the initial automated review easier to identify and read. ✨
- Preserves numbering for follow-up reviews, improving review history tracking.
- Keeps existing findings-log behavior and review replacement handling unchanged. ✅