### PR TITLE
Publish reviews when the PR head moves mid-review

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -865,20 +865,27 @@ def post_review_summary(event: Action, review_data: dict, review_number: int = 1
         return
 
     commit_sha = review_data["head_sha"]
-    if event.get_pr_head_sha() != commit_sha:
-        raise RuntimeError("PR head changed during review generation")
+    if head_moved := event.get_pr_head_sha() != commit_sha:
+        print(f"PR head moved during review; anchoring findings to reviewed commit {commit_sha[:7]}")
 
     comments = review_data.get("comments", [])
     summary = review_data.get("summary") or ""
 
-    # Don't approve if error occurred, inline comments exist, or medium-or-higher severity issues
+    # Don't approve if error occurred, head moved, inline comments exist, or medium-or-higher severity issues
     has_error = not summary or ERROR_MARKER in summary
     has_evidence = bool(review_data.get("diff_files"))
     has_inline_comments = review_data.get("comments_before_filtering", 0) > 0
     has_issues = any(c.get("severity") not in ["LOW", "SUGGESTION", None] for c in comments)
     event_type = (
         "COMMENT"
-        if (has_error or not has_evidence or has_inline_comments or has_issues or review_data.get("diff_truncated"))
+        if (
+            has_error
+            or head_moved
+            or not has_evidence
+            or has_inline_comments
+            or has_issues
+            or review_data.get("diff_truncated")
+        )
         else "APPROVE"
     )
 

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -360,6 +360,14 @@ def test_incomplete_review_evidence_cannot_approve():
     )
     assert event.post.call_args.kwargs["json"]["event"] == "COMMENT"
 
+    # A push during review generation posts against the reviewed commit instead of approving or failing the job
+    event.get_pr_head_sha.return_value = "def"
+    review_pr.post_review_summary(
+        event, {"head_sha": "abc", "summary": "LGTM", "comments": [], "diff_files": {"a": {}}}
+    )
+    assert event.post.call_args.kwargs["json"]["event"] == "COMMENT"
+    assert event.post.call_args.kwargs["json"]["commit_id"] == "abc"
+
 
 def test_review_agent_tools_read_pr_head_via_api(tmp_path, monkeypatch):
     """Test review tools serve PR-head content via the GitHub API regardless of local checkout."""


### PR DESCRIPTION
## Motivation

The review in [ultralytics/lite#37](https://github.com/ultralytics/lite/actions/runs/31205705718/job/92956082648) crashed the `Autolabel Issues and PRs` step with `RuntimeError: PR head changed during review generation` (exit code 1, error annotation).

Timeline: the PR opened at 18:10:02 on `68a48f5`, review generation started at 18:10:41, the author pushed `f03ad1d8` at 18:10:55, and the review finished at 18:11:45 against the now-stale head. A complete review with two HIGH findings was thrown away.

The loss is total, not deferred: auto-review only runs on `opened` (`action.yml` gates the step on `github.event.action == 'opened' || 'created'`) and on `review_requested`, so the `synchronize` run does not regenerate it. PR #37 ended up with zero reviews. A 14-second-later follow-up push is ordinary author behavior, so this race is common.

## Changes

`post_review_summary` already anchors `commit_id` to `review_data["head_sha"]` — the exact commit reviewed — which is what #792 threaded it through for. GitHub documents posting against a non-latest `commit_id` and renders those comments as outdated, so the findings land correctly without the live-head equality check.

Deleted the `RuntimeError` and replaced it with a `head_moved` flag that forces `event_type` to `COMMENT`. #805's safety goal — never approve code the agent did not see — is preserved, since only the approval was ever unsafe; the findings were not.

Version bumped to `0.3.1`.

## Validation

- `pytest tests -q` — 130 passed
- `ruff check` and `ruff format`
- Extended `test_incomplete_review_evidence_cannot_approve` with the moved-head case: posts `COMMENT` anchored to the reviewed SHA instead of raising

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves PR review reliability by safely handling commits pushed while a review is being generated. 🛡️

### 📊 Key Changes

- Updated `post_review_summary()` to detect when the PR head changes during review generation.
- Anchors review findings to the originally reviewed commit instead of failing the review process.
- Prevents approval when the PR head has moved, posting a general comment instead.
- Logs the reviewed commit SHA for clearer diagnostics.
- Added regression coverage for pushes occurring during review generation.
- Bumped the package version from `0.3.0` to `0.3.1`.

### 🎯 Purpose & Impact

- 🧑‍💻 Prevents reviews from being attached to a newer, unreviewed commit.
- ✅ Avoids failed jobs when contributors push updates during review generation.
- 🔍 Ensures review comments remain tied to the exact code that was analyzed.
- 🚦 Reduces the risk of incorrectly approving changes that were not reviewed.