### PR TITLE
Clean up shared action warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,6 +108,8 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - uses: ultralytics/actions/setup-uv@main
+      with:
+        ignore-empty-workdir: true
     - name: Install Dependencies
       # Note tomli required for codespell with pyproject.toml
       env:

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -114,7 +114,7 @@ def main(*args, **kwargs):
     if event.pr.get("merged"):
         print("PR is merged, labeling fixed issues...")
         pr_credit = label_fixed_issues(event, summary)
-        if any(label["name"] == "TODO" for label in event.pr.get("labels", [])):
+        if any(label["name"].casefold() == "todo" for label in event.pr.get("labels", [])):
             print("Removing TODO label from PR...")
             event.remove_labels(event.pr["number"], labels=("TODO",))
         if pr_credit:

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -114,8 +114,9 @@ def main(*args, **kwargs):
     if event.pr.get("merged"):
         print("PR is merged, labeling fixed issues...")
         pr_credit = label_fixed_issues(event, summary)
-        print("Removing TODO label from PR...")
-        event.remove_labels(event.pr["number"], labels=("TODO",))
+        if any(label["name"] == "TODO" for label in event.pr.get("labels", [])):
+            print("Removing TODO label from PR...")
+            event.remove_labels(event.pr["number"], labels=("TODO",))
         if pr_credit:
             print("Posting PR author thank you message...")
             event.add_comment(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dynamic = ["version"]
 description = "Ultralytics Actions for GitHub automation and PR management."
 readme = "README.md"
 requires-python = ">=3.8"
-license = "AGPL-3.0-or-later"
 keywords = [
     "github-actions",
     "ci-cd",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynamic = ["version"]
 description = "Ultralytics Actions for GitHub automation and PR management."
 readme = "README.md"
 requires-python = ">=3.8"
-license = { text = "AGPL-3.0" }
+license = "AGPL-3.0-or-later"
 keywords = [
     "github-actions",
     "ci-cd",
@@ -50,7 +50,6 @@ maintainers = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/setup-uv/README.md
+++ b/setup-uv/README.md
@@ -21,3 +21,4 @@ Provides Ultralytics defaults for the official [uv setup action](https://github.
 | `activate-environment`  | Create and activate a `.venv` environment | No       | `false`      |
 | `enable-cache`          | Cache uv downloads between workflow runs  | No       | `false`      |
 | `cache-dependency-glob` | Dependency files used to invalidate cache | No       | `**/uv.lock` |
+| `ignore-empty-workdir`  | Suppress warnings for an empty workdir    | No       | `false`      |

--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Dependency files used to invalidate the uv cache"
     required: false
     default: "**/uv.lock"
+  ignore-empty-workdir:
+    description: "Suppress the warning when the working directory is intentionally empty"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -29,4 +33,5 @@ runs:
         activate-environment: ${{ inputs.activate-environment }}
         enable-cache: ${{ inputs.enable-cache }}
         cache-dependency-glob: ${{ inputs.cache-dependency-glob }}
+        ignore-empty-workdir: ${{ inputs.ignore-empty-workdir }}
         ignore-nothing-to-cache: true


### PR DESCRIPTION
## Summary

- declare the intentionally empty pre-checkout workspace to setup-uv
- update package licensing metadata to current SPDX form
- remove the TODO label only when the merged PR actually has it
- bump ultralytics-actions to 0.3.4

## Validation

- 10 focused tests passed
- Ruff check and format check passed
- wheel build completed without the setuptools license deprecations seen in downstream logs

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated shared GitHub Actions to suppress intentional empty-workdir warnings, avoid unnecessary TODO-label removals, modernize package license metadata, and release version 0.3.4.

### 📊 Key Changes

- Added the `ignore-empty-workdir` input to `setup-uv`, passed it to the underlying uv setup action, and enabled it in the main action.
- Removed the legacy license field and AGPL classifier from `pyproject.toml`.
- Changed merged-PR handling to remove the `TODO` label only when the PR currently has a case-insensitive matching label.
- Bumped the package version from `0.3.3` to `0.3.4` and documented the new setup-uv input.

### 🎯 Purpose & Impact

- Workflows using the shared action no longer emit the empty-workdir warning when that state is intentional.
- Merged PRs without a `TODO` label no longer trigger an unnecessary label-removal call.
- Package metadata no longer contains the removed legacy license declarations.