### PR TITLE
Mute intentional empty-workdir warnings

### DIFF
--- a/cla/action.yml
+++ b/cla/action.yml
@@ -17,6 +17,8 @@ runs:
   using: "composite"
   steps:
     - uses: ultralytics/actions/setup-uv@main
+      with:
+        ignore-empty-workdir: true
 
     - name: Check CLA
       env:

--- a/dependabot/action.yml
+++ b/dependabot/action.yml
@@ -30,6 +30,8 @@ runs:
   using: "composite"
   steps:
     - uses: ultralytics/actions/setup-uv@main
+      with:
+        ignore-empty-workdir: true
 
     - name: Install ultralytics-actions
       env:

--- a/github-report/action.yml
+++ b/github-report/action.yml
@@ -46,6 +46,8 @@ runs:
   using: "composite"
   steps:
     - uses: ultralytics/actions/setup-uv@main
+      with:
+        ignore-empty-workdir: true
 
     - name: Install ultralytics-actions
       env:


### PR DESCRIPTION
## Summary
- mark the CLA, Dependabot, and GitHub Report setup steps as intentional empty-workdir callers
- preserve the shared setup-uv default warning for all other consumers

## Validation
- Prettier check passed for all three composite action manifests
- `git diff --check` passed
- consumer workflow logs will be rerun after merge to verify the warning is gone

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the CLA, Dependabot, and GitHub Report composite actions to suppress expected empty-workdir warnings while retaining the default warning for other `setup-uv` users.

### 📊 Key Changes
- Passed `ignore-empty-workdir: true` to `ultralytics/actions/setup-uv@main` in the CLA action.
- Passed the same option in the Dependabot action.
- Passed the same option in the GitHub Report action.
- Left the shared `setup-uv` default behavior unchanged for all other consumers.

### 🎯 Purpose & Impact
- These three workflows no longer request the shared setup action’s empty-workdir warning when an empty work directory is intentional.
- Other `setup-uv` consumers continue to receive the existing warning by default.