### PR TITLE
Centralize diff filtering at retrieval

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -520,7 +520,7 @@ def generate_pr_review(
     full_files_section = ""
     if event and head_sha and not is_agent_review_model and len(file_list) <= 10:  # Reasonable file count limit
         file_contents, total_chars = [], len(augmented_diff) + len(guidelines_section) + len(history_section)
-        for file_path in file_list:  # already filtered by should_skip_file above
+        for file_path in file_list:
             text = _read_head_file(event, head_sha, local_checkout, file_path) or ""
             if not text or len(text) > 100_000:  # skip missing and >100KB files entirely
                 continue

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -177,8 +177,6 @@ def _read_head_file(event: Action, head_sha: str | None, local_checkout: bool, p
         target.relative_to(root)  # raises ValueError for paths or symlinks escaping the checkout
         if not target.is_file():
             return None
-        if target.stat().st_size > 500_000:
-            raise RuntimeError(f"{path} is too large to read")
         return target.read_text(encoding="utf-8", errors="ignore")
     if not (event and head_sha):
         return None
@@ -470,7 +468,7 @@ def parse_diff_files(diff_text: str) -> tuple[dict, str]:
 
 def generate_pr_review(
     repository: str,
-    diff_text: str,
+    diff: tuple[str, list[str]],
     pr_title: str,
     pr_description: str,
     event: Action = None,
@@ -478,30 +476,25 @@ def generate_pr_review(
     review_history: dict | None = None,
 ) -> dict:
     """Generate comprehensive PR review with line-specific comments and overall assessment."""
+    diff_text, skipped_files = diff
     review_history = review_history or {}
     prior_reviews = review_history.get("reviews") or []
     head_sha = head_sha or (event.get_pr_head_sha() if event else None)
     if diff_text.startswith("ERROR:"):
         return {"comments": [], "summary": f"{ERROR_MARKER}: {diff_text}", "head_sha": head_sha}
     if not diff_text:
+        if skipped_files:
+            return {
+                "comments": [],
+                "summary": f"All {len(skipped_files)} changed files are generated/vendored (skipped review)",
+                "skipped_files": skipped_files,
+                "head_sha": head_sha,
+            }
         return {"comments": [], "summary": "No changes detected in diff", "head_sha": head_sha}
 
     diff_files, augmented_diff = parse_diff_files(diff_text)
     if not diff_files:
         return {"comments": [], "summary": "No reviewable text changes detected in diff", "head_sha": head_sha}
-
-    # Filter out generated/vendored files
-    filtered_files = {p: s for p, s in diff_files.items() if not should_skip_file(p)}
-    skipped_files = [p for p in diff_files if p not in filtered_files]
-    diff_files = filtered_files
-
-    if not diff_files:
-        return {
-            "comments": [],
-            "summary": f"All {len(skipped_files)} changed files are generated/vendored (skipped review)",
-            "skipped_files": skipped_files,
-            "head_sha": head_sha,
-        }
 
     file_list = list(diff_files.keys())
     lines_changed = sum(len(sides["RIGHT"]) + len(sides["LEFT"]) for sides in diff_files.values())

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -40,9 +40,10 @@ def generate_merge_message(pr_summary, pr_credit, pr_url):
     return get_response(messages)
 
 
-def generate_pr_summary(repository, diff_text, title="", description=""):
+def generate_pr_summary(repository, diff, title="", description=""):
     """Generates a concise, professional summary of a PR using the OpenAI or Anthropic API."""
-    prompt, is_large, skipped_files = get_pr_summary_prompt(repository, diff_text, title, description)
+    prompt, is_large = get_pr_summary_prompt(repository, diff, title, description)
+    skipped_files = diff[1]
 
     messages = [
         {

--- a/actions/summarize_pr.py
+++ b/actions/summarize_pr.py
@@ -43,7 +43,7 @@ def generate_merge_message(pr_summary, pr_credit, pr_url):
 def generate_pr_summary(repository, diff, title="", description=""):
     """Generates a concise, professional summary of a PR using the OpenAI or Anthropic API."""
     prompt, is_large = get_pr_summary_prompt(repository, diff, title, description)
-    skipped_files = diff[1]
+    _, skipped_files = diff
 
     messages = [
         {

--- a/actions/summarize_release.py
+++ b/actions/summarize_release.py
@@ -8,18 +8,18 @@ import subprocess
 import time
 from datetime import datetime, timezone
 
-from .utils import GITHUB_API_URL, Action, get_response, remove_html_comments
+from .utils import GITHUB_API_URL, Action, filter_diff_text, get_response, remove_html_comments
 
 # Environment variables
 CURRENT_TAG = os.getenv("CURRENT_TAG")
 PREVIOUS_TAG = os.getenv("PREVIOUS_TAG")
 
 
-def get_release_diff(event, previous_tag: str, latest_tag: str) -> str:
+def get_release_diff(event, previous_tag: str, latest_tag: str) -> tuple[str, list[str]]:
     """Retrieves the differences between two specified Git tags in a GitHub repository."""
     url = f"{GITHUB_API_URL}/repos/{event.repository}/compare/{previous_tag}...{latest_tag}"
     r = event.get(url, headers=event.headers_diff)
-    return r.text if r.status_code == 200 else f"Failed to get diff: {r.text}"
+    return filter_diff_text(r.text if r.status_code == 200 else f"Failed to get diff: {r.text}")
 
 
 def get_prs_between_tags(event, previous_tag: str, latest_tag: str) -> list:
@@ -95,12 +95,13 @@ def get_new_contributors(event, prs: list) -> set:
 
 def generate_release_summary(
     event,
-    diff: str,
+    diff: tuple[str, list[str]],
     prs: list,
     latest_tag: str,
     previous_tag: str,
 ) -> str:
     """Generate a concise release summary with key changes, purpose, and impact for a new Ultralytics version."""
+    diff_text = diff[0]
     pr_summaries = "\n\n".join(
         [f"PR #{pr['number']}: {pr['title']} by @{pr['author']}\n{pr['body'][:1000]}" for pr in prs]
     )
@@ -146,7 +147,7 @@ def generate_release_summary(
             f"## 🎯 Purpose & Impact (bullet points explaining any benefits and potential impact to users)\n\n\n"
             f"Here's the information about the current PR:\n\n{current_pr_summary}\n\n"
             f"Here's the information about PRs merged between the previous release and this one:\n\n{pr_summaries[:30000]}\n\n"
-            f"Here's the release diff:\n\n{diff[:300000]}",
+            f"Here's the release diff:\n\n{diff_text[:300000]}",
         },
     ]
     return get_response(messages, temperature=1.0) + release_suffix

--- a/actions/summarize_release.py
+++ b/actions/summarize_release.py
@@ -8,7 +8,14 @@ import subprocess
 import time
 from datetime import datetime, timezone
 
-from .utils import GITHUB_API_URL, Action, filter_diff_text, get_response, remove_html_comments
+from .utils import (
+    GITHUB_API_URL,
+    Action,
+    filter_diff_text,
+    format_skipped_files_note,
+    get_response,
+    remove_html_comments,
+)
 
 # Environment variables
 CURRENT_TAG = os.getenv("CURRENT_TAG")
@@ -101,7 +108,7 @@ def generate_release_summary(
     previous_tag: str,
 ) -> str:
     """Generate a concise release summary with key changes, purpose, and impact for a new Ultralytics version."""
-    diff_text = diff[0]
+    diff_text, skipped_files = diff
     pr_summaries = "\n\n".join(
         [f"PR #{pr['number']}: {pr['title']} by @{pr['author']}\n{pr['body'][:1000]}" for pr in prs]
     )
@@ -147,7 +154,7 @@ def generate_release_summary(
             f"## 🎯 Purpose & Impact (bullet points explaining any benefits and potential impact to users)\n\n\n"
             f"Here's the information about the current PR:\n\n{current_pr_summary}\n\n"
             f"Here's the information about PRs merged between the previous release and this one:\n\n{pr_summaries[:30000]}\n\n"
-            f"Here's the release diff:\n\n{diff_text[:300000]}",
+            f"Here's the release diff:\n\n{diff_text[:300000]}{format_skipped_files_note(skipped_files)}",
         },
     ]
     return get_response(messages, temperature=1.0) + release_suffix

--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -43,6 +43,7 @@ SKIP_PATTERN_STRINGS = [
     r"\.bundle\.(js|css)$",
     r"(^|/)dist/",  # Generated/vendored directories
     r"(^|/)build/",
+    r"(^|/)generated/",
     r"(^|/)vendor/",
     r"(^|/)node_modules/",
     r"(^|/)coverage/",  # Coverage reports

--- a/actions/utils/github_utils.py
+++ b/actions/utils/github_utils.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import requests
 
 from actions import __version__
+from actions.utils.common_utils import filter_diff_text
 
 GITHUB_API_URL = "https://api.github.com"
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
@@ -246,19 +247,20 @@ class Action:
             return True
         return False
 
-    def get_pr_diff(self, refresh: bool = False) -> str:
-        """Retrieves the diff content for a specified pull request with caching."""
+    def get_pr_diff(self, refresh: bool = False) -> tuple[str, list[str]]:
+        """Retrieve and filter a pull request diff with caching."""
         if self._pr_diff_cache and not refresh:
             return self._pr_diff_cache
 
         url = f"{GITHUB_API_URL}/repos/{self.repository}/pulls/{self.pr.get('number')}"
         response = self.get(url, headers=self.headers_diff)
         if response.status_code == 200:
-            self._pr_diff_cache = response.text or "ERROR: EMPTY DIFF, NO CODE CHANGES IN THIS PR."
+            diff = response.text or "ERROR: EMPTY DIFF, NO CODE CHANGES IN THIS PR."
         elif response.status_code == 406:
-            self._pr_diff_cache = "ERROR: PR diff exceeds GitHub's 20,000 line limit, unable to retrieve diff."
+            diff = "ERROR: PR diff exceeds GitHub's 20,000 line limit, unable to retrieve diff."
         else:
-            self._pr_diff_cache = "ERROR: UNABLE TO RETRIEVE DIFF."
+            diff = "ERROR: UNABLE TO RETRIEVE DIFF."
+        self._pr_diff_cache = filter_diff_text(diff)
         return self._pr_diff_cache
 
     def get_pr_head_sha(self) -> str | None:
@@ -270,7 +272,7 @@ class Action:
             return sha
         return None
 
-    def get_pr_diff_snapshot(self) -> tuple[str, str]:
+    def get_pr_diff_snapshot(self) -> tuple[tuple[str, list[str]], str]:
         """Fetch a diff whose PR head stayed unchanged for the full request."""
         for _ in range(2):
             head_before = self.get_pr_head_sha()

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 import requests
 
-from actions.utils.common_utils import check_links_in_string, filter_diff_text, format_skipped_files_note
+from actions.utils.common_utils import check_links_in_string, format_skipped_files_note
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
@@ -137,16 +137,16 @@ def get_pr_summary_guidelines() -> str:
 
 
 def get_pr_summary_prompt(
-    repository: str, diff_text: str, title: str = "", description: str = ""
-) -> tuple[str, bool, list[str]]:
-    """Returns the complete PR summary generation prompt with filtered diff (used by PR update/merge)."""
-    filtered_diff, skipped_files = filter_diff_text(diff_text)
+    repository: str, diff: tuple[str, list[str]], title: str = "", description: str = ""
+) -> tuple[str, bool]:
+    """Return the complete PR summary generation prompt."""
+    diff_text, skipped_files = diff
     prompt = (
         f"{get_pr_summary_guidelines()}\n\nRepository: {repository}\nPR title: {title}\n"
-        f"PR description:\n{description[:8000]}\n\nPR diff:\n{filtered_diff[:MAX_PROMPT_CHARS]}"
+        f"PR description:\n{description[:8000]}\n\nPR diff:\n{diff_text[:MAX_PROMPT_CHARS]}"
     )
     prompt += format_skipped_files_note(skipped_files)
-    return prompt, len(filtered_diff) > MAX_PROMPT_CHARS, skipped_files
+    return prompt, len(diff_text) > MAX_PROMPT_CHARS
 
 
 def _is_anthropic_model(model: str) -> bool:
@@ -656,7 +656,7 @@ def get_response(
 
 def get_pr_open_response(
     repository: str,
-    diff_text: str,
+    diff: tuple[str, list[str]],
     title: str,
     username: str,
     available_labels: dict,
@@ -666,8 +666,8 @@ def get_pr_open_response(
     current_labels: list | None = None,
 ) -> dict:
     """Generate a PR summary and labels in a single API call."""
-    filtered_diff, skipped_files = filter_diff_text(diff_text)
-    is_large = len(filtered_diff) > MAX_PROMPT_CHARS
+    diff_text, skipped_files = diff
+    is_large = len(diff_text) > MAX_PROMPT_CHARS
 
     filtered_labels = filter_labels(available_labels, current_labels) if available_labels else {}
     labels_str = "\n".join(f"- {name}: {description}" for name, description in filtered_labels.items())
@@ -684,7 +684,7 @@ Repository context: {repository_context or "No additional metadata provided."}
 PR description: {description[:8000] or "No description provided."}
 
 Generate 2 outputs in a single JSON response for the PR titled '{title}' with the following diff:
-{filtered_diff[:MAX_PROMPT_CHARS]}{format_skipped_files_note(skipped_files)}
+{diff_text[:MAX_PROMPT_CHARS]}{format_skipped_files_note(skipped_files)}
 
 
 --- FIRST JSON OUTPUT (PR SUMMARY) ---

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -100,8 +100,8 @@ def test_open_pr_review_description(mock_action, mock_content, mock_response, mo
     event.should_skip_pr_author.return_value = False
     event.paginate.return_value = []
     event.pr = {"body": body}
-    event.get_pr_diff.return_value = "diff"
-    event.get_pr_diff_snapshot.return_value = ("review diff", "headsha")
+    event.get_pr_diff.return_value = ("diff", [])
+    event.get_pr_diff_snapshot.return_value = (("review diff", []), "headsha")
 
     first_interaction.main()
 
@@ -160,7 +160,7 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
 +old = False
 """
 
-    review = review_pr.generate_pr_review("ultralytics/actions", diff, "Test PR", "", event=mock_event)
+    review = review_pr.generate_pr_review("ultralytics/actions", (diff, []), "Test PR", "", event=mock_event)
 
     assert review["summary"] == "LGTM"
     mock_get_agent_response.assert_called_once()
@@ -190,6 +190,7 @@ def test_review_agent_search_scans_local_checkout_only(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "secret.py").write_text("secret = True\n", encoding="utf-8")
     (tmp_path / "patterns.py").write_text("literal = '(a+)+$'\n", encoding="utf-8")
+    (tmp_path / "large.json").write_text("x" * 500_001, encoding="utf-8")
     workflow = tmp_path / ".github" / "workflows" / "format.yml"
     workflow.parent.mkdir(parents=True)
     workflow.write_text("workflow = True\n", encoding="utf-8")
@@ -209,6 +210,7 @@ def test_review_agent_search_scans_local_checkout_only(tmp_path, monkeypatch):
     assert "secret.py:1:secret = True" in handlers["search_repo"](query="secret = True", path_glob=None)
     assert "No matches found." == handlers["search_repo"](query="secret.*True", path_glob=None)
     assert "patterns.py:1:literal = '(a+)+$'" in handlers["search_repo"](query="(a+)+$", path_glob=None)
+    assert "too large" in handlers["read_file"](path="large.json", start_line=None, end_line=None)
     assert ".github/workflows/format.yml:1:workflow = True" in handlers["search_repo"](
         query="workflow = True", path_glob=".github/**"
     )
@@ -236,11 +238,26 @@ def test_review_snapshot_retries_until_diff_and_head_match():
     """Test review snapshots refetch the diff when a push races the first request."""
     event = MagicMock()
     event.get_pr_head_sha.side_effect = ["old", "new", "new", "new"]
-    event.get_pr_diff.side_effect = ["old diff", "new diff"]
+    event.get_pr_diff.side_effect = [("old diff", []), ("new diff", ["generated/client.py"])]
 
-    assert review_pr.Action.get_pr_diff_snapshot(event) == ("new diff", "new")
+    assert review_pr.Action.get_pr_diff_snapshot(event) == (("new diff", ["generated/client.py"]), "new")
     assert event.get_pr_diff.call_args_list == [call(refresh=True), call(refresh=True)]
     assert event.get_pr_head_sha.call_count == 4
+
+
+def test_pr_diff_is_filtered_at_retrieval():
+    """Test every PR diff consumer receives the same filtered diff and skipped-file list."""
+    event = MagicMock(repository="org/repo", pr={"number": 1}, headers_diff={}, _pr_diff_cache=None)
+    event.get.return_value = MagicMock(
+        status_code=200,
+        text="diff --git a/code.py b/code.py\n+kept\ndiff --git a/generated/client.py b/generated/client.py\n+omitted",
+    )
+
+    diff, skipped_files = review_pr.Action.get_pr_diff(event)
+
+    assert "+kept" in diff
+    assert "generated/client.py" not in diff
+    assert skipped_files == ["generated/client.py"]
 
 
 def test_post_review_summary_numbers_reviews_and_logs_findings():
@@ -346,15 +363,14 @@ def test_incomplete_review_evidence_cannot_approve():
     event.pr = {"number": 7}
     event.get_pr_head_sha.return_value = "abc"
 
-    error = review_pr.generate_pr_review("org/repo", "ERROR: UNABLE TO RETRIEVE DIFF.", "PR", "", event, "abc")
+    error = review_pr.generate_pr_review("org/repo", ("ERROR: UNABLE TO RETRIEVE DIFF.", []), "PR", "", event, "abc")
     review_pr.post_review_summary(event, error)
     assert event.post.call_args.kwargs["json"]["event"] == "COMMENT"
 
     review_pr.post_review_summary(event, {"head_sha": "abc", "summary": "LGTM", "comments": [], "diff_truncated": True})
     assert event.post.call_args.kwargs["json"]["event"] == "COMMENT"
 
-    binary = "diff --git a/image.png b/image.png\nBinary files a/image.png and b/image.png differ"
-    binary_review = review_pr.generate_pr_review("org/repo", binary, "PR", "", event, "abc")
+    binary_review = review_pr.generate_pr_review("org/repo", ("", ["image.png"]), "PR", "", event, "abc")
     review_pr.post_review_summary(event, binary_review)
     assert event.post.call_args.kwargs["json"]["event"] == "COMMENT"
 

--- a/tests/test_summarize_pr.py
+++ b/tests/test_summarize_pr.py
@@ -9,7 +9,7 @@ from actions.summarize_pr import generate_merge_message, generate_pr_summary, la
 def test_generate_pr_summary(mock_get_response):
     """Test generating PR summary with expected formatting."""
     mock_get_response.return_value = "Test PR summary content"
-    summary = generate_pr_summary("test/repo", "diff content")
+    summary = generate_pr_summary("test/repo", ("diff content", []))
 
     assert summary.startswith("## 🛠️ PR Summary")
     assert "Test PR summary content" in summary

--- a/tests/test_summarize_release.py
+++ b/tests/test_summarize_release.py
@@ -105,12 +105,17 @@ def test_generate_release_summary(mock_get_response):
     # Mock new contributors function
     with patch("actions.summarize_release.get_new_contributors", return_value=["newuser"]):
         summary = generate_release_summary(
-            event=mock_event, diff=("diff content", []), prs=test_prs, latest_tag="v1.1.0", previous_tag="v1.0.0"
+            event=mock_event,
+            diff=("diff content", ["generated/client.py"]),
+            prs=test_prs,
+            latest_tag="v1.1.0",
+            previous_tag="v1.0.0",
         )
 
     assert "Release summary content" in summary
     assert "What's Changed" in summary
     assert "https://github.com/test/repo/compare/v1.0.0...v1.1.0" in summary
+    assert "generated/client.py" in mock_get_response.call_args.args[0][1]["content"]
     mock_get_response.assert_called_once()
 
 

--- a/tests/test_summarize_release.py
+++ b/tests/test_summarize_release.py
@@ -24,7 +24,7 @@ def test_get_release_diff():
 
     diff = get_release_diff(mock_event, "v1.0.0", "v1.1.0")
 
-    assert diff == "diff content"
+    assert diff == ("diff content", [])
     mock_event.get.assert_called_once_with(
         "https://api.github.com/repos/test/repo/compare/v1.0.0...v1.1.0", headers=mock_event.headers_diff
     )
@@ -105,7 +105,7 @@ def test_generate_release_summary(mock_get_response):
     # Mock new contributors function
     with patch("actions.summarize_release.get_new_contributors", return_value=["newuser"]):
         summary = generate_release_summary(
-            event=mock_event, diff="diff content", prs=test_prs, latest_tag="v1.1.0", previous_tag="v1.0.0"
+            event=mock_event, diff=("diff content", []), prs=test_prs, latest_tag="v1.1.0", previous_tag="v1.0.0"
         )
 
     assert "Release summary content" in summary


### PR DESCRIPTION
## Summary

- filter PR and release diffs once when they enter the system
- pass the canonical filtered diff and skipped-file list unchanged to summaries, labels, and reviews
- skip generated directories and let oversized review files return the existing bounded response instead of aborting
- remove duplicate summary and review filtering paths

## Validation

- `pytest tests -q` (146 passed)
- repository Ruff check and format validation
- `git diff --check`
- verified against `ultralytics/openapi#2`: 24 generated entries and `bun.lock` are skipped while generator/parser owners remain in the initial prompt budget

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

PR and release diffs are now filtered once during retrieval so summaries, labels, reviews, and release notes reuse the same diff and skipped-file list.

### 📊 Key Changes

- `Action.get_pr_diff()` and `get_release_diff()` now return a `(filtered_diff, skipped_files)` tuple, with filtering performed before downstream processing.
- Added `generated/` to the skipped-file patterns and propagated skipped files unchanged to PR summaries, labels, reviews, and release summaries.
- Removed duplicate generated/vendored-file filtering from `generate_pr_review()`, `get_pr_summary_prompt()`, and `get_pr_open_response()`.
- Reviews now report when all changed files were skipped, while oversized local files no longer raise an error during head-file loading and instead follow existing bounded handling.
- Updated the package version from `0.3.4` to `0.3.5` and adjusted affected tests for the new diff structure.

### 🎯 Purpose & Impact

- PR and release workflows avoid repeating diff-filtering work and provide consistent skipped-file information across generated outputs.
- Changes containing only generated or vendored files produce an explicit skipped-review summary instead of being treated as ordinary code changes.
- Release summaries include the filtered diff and a note listing skipped files.