### PR TITLE
Checkout pull requests by head SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         token: ${{ inputs.token }}
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 2
 
     # File header ------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- check out the immutable pull-request head SHA instead of its branch name
- keep formatting and review runs alive when a branch is deleted immediately after merge

## Deleted

- dependency on the pull-request branch ref remaining available during checkout

## Validation

- `uv run --extra dev pytest tests/test_format_code.py -q`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the pull-request checkout to use the immutable head commit SHA instead of the source branch name, allowing workflows to continue when that branch is deleted after merging.

### 📊 Key Changes
- Changed `action.yml` to pass `github.event.pull_request.head.sha` as the checkout `ref`.
- Continued checking out code from the pull request’s source repository with the configured token and shallow fetch depth.
- Removed the checkout dependency on the pull-request branch reference remaining available.

### 🎯 Purpose & Impact
- Formatting and review workflows can check out the pull-request commit even if its source branch is deleted immediately after merging.