### PR TITLE
Use latest uv release by default

### DIFF
--- a/setup-uv/README.md
+++ b/setup-uv/README.md
@@ -17,7 +17,6 @@ Provides Ultralytics defaults for the official [uv setup action](https://github.
 
 | Input                   | Description                               | Required | Default      |
 | ----------------------- | ----------------------------------------- | -------- | ------------ |
-| `version`               | uv version or selector to install         | No       | `latest`     |
 | `python-version`        | Python version for uv commands            | No       | -            |
 | `activate-environment`  | Create and activate a `.venv` environment | No       | `false`      |
 | `enable-cache`          | Cache uv downloads between workflow runs  | No       | `false`      |

--- a/setup-uv/README.md
+++ b/setup-uv/README.md
@@ -1,6 +1,6 @@
 # Setup uv Action
 
-Provides Ultralytics defaults for the official [uv setup action](https://github.com/astral-sh/setup-uv), with optional Python environment activation and dependency caching. Set `version: latest-known` to select the newest checksum-verified uv release without a manifest request.
+Provides Ultralytics defaults for the official [uv setup action](https://github.com/astral-sh/setup-uv), using its latest checksum-verified uv release without a manifest request and optionally activating a Python environment and dependency caching.
 
 ## Usage
 
@@ -15,11 +15,11 @@ Provides Ultralytics defaults for the official [uv setup action](https://github.
 
 ## Inputs
 
-| Input                   | Description                               | Required | Default      |
-| ----------------------- | ----------------------------------------- | -------- | ------------ |
-| `version`               | uv version or selector to install         | No       | -            |
-| `python-version`        | Python version for uv commands            | No       | -            |
-| `activate-environment`  | Create and activate a `.venv` environment | No       | `false`      |
-| `enable-cache`          | Cache uv downloads between workflow runs  | No       | `false`      |
-| `cache-dependency-glob` | Dependency files used to invalidate cache | No       | `**/uv.lock` |
-| `ignore-empty-workdir`  | Suppress warnings for an empty workdir    | No       | `false`      |
+| Input                   | Description                               | Required | Default        |
+| ----------------------- | ----------------------------------------- | -------- | -------------- |
+| `version`               | uv version or selector to install         | No       | `latest-known` |
+| `python-version`        | Python version for uv commands            | No       | -              |
+| `activate-environment`  | Create and activate a `.venv` environment | No       | `false`        |
+| `enable-cache`          | Cache uv downloads between workflow runs  | No       | `false`        |
+| `cache-dependency-glob` | Dependency files used to invalidate cache | No       | `**/uv.lock`   |
+| `ignore-empty-workdir`  | Suppress warnings for an empty workdir    | No       | `false`        |

--- a/setup-uv/README.md
+++ b/setup-uv/README.md
@@ -1,6 +1,6 @@
 # Setup uv Action
 
-Provides Ultralytics defaults for the official [uv setup action](https://github.com/astral-sh/setup-uv), using its latest checksum-verified uv release without a manifest request and optionally activating a Python environment and dependency caching.
+Provides Ultralytics defaults for the official [uv setup action](https://github.com/astral-sh/setup-uv), using the latest uv release and optionally activating a Python environment and dependency caching.
 
 ## Usage
 
@@ -15,11 +15,11 @@ Provides Ultralytics defaults for the official [uv setup action](https://github.
 
 ## Inputs
 
-| Input                   | Description                               | Required | Default        |
-| ----------------------- | ----------------------------------------- | -------- | -------------- |
-| `version`               | uv version or selector to install         | No       | `latest-known` |
-| `python-version`        | Python version for uv commands            | No       | -              |
-| `activate-environment`  | Create and activate a `.venv` environment | No       | `false`        |
-| `enable-cache`          | Cache uv downloads between workflow runs  | No       | `false`        |
-| `cache-dependency-glob` | Dependency files used to invalidate cache | No       | `**/uv.lock`   |
-| `ignore-empty-workdir`  | Suppress warnings for an empty workdir    | No       | `false`        |
+| Input                   | Description                               | Required | Default      |
+| ----------------------- | ----------------------------------------- | -------- | ------------ |
+| `version`               | uv version or selector to install         | No       | `latest`     |
+| `python-version`        | Python version for uv commands            | No       | -            |
+| `activate-environment`  | Create and activate a `.venv` environment | No       | `false`      |
+| `enable-cache`          | Cache uv downloads between workflow runs  | No       | `false`      |
+| `cache-dependency-glob` | Dependency files used to invalidate cache | No       | `**/uv.lock` |
+| `ignore-empty-workdir`  | Suppress warnings for an empty workdir    | No       | `false`      |

--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -3,10 +3,6 @@
 name: "Setup uv"
 description: "Install uv with optional Python environment activation and dependency caching"
 inputs:
-  version:
-    description: "uv version or selector to install"
-    required: false
-    default: "latest"
   python-version:
     description: "Python version for uv commands"
     required: false
@@ -33,7 +29,7 @@ runs:
   steps:
     - uses: astral-sh/setup-uv@v10.0.0
       with:
-        version: ${{ inputs.version }}
+        version: latest
         python-version: ${{ inputs.python-version }}
         activate-environment: ${{ inputs.activate-environment }}
         enable-cache: ${{ inputs.enable-cache }}

--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: "uv version or selector to install"
     required: false
-    default: "latest-known"
+    default: "latest"
   python-version:
     description: "Python version for uv commands"
     required: false

--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: "uv version or selector to install"
     required: false
-    default: ""
+    default: "latest-known"
   python-version:
     description: "Python version for uv commands"
     required: false


### PR DESCRIPTION
## Summary

- make the shared Ultralytics setup action always install `latest` uv
- keep the policy at its single owner instead of repeating arguments in consumers
- intentionally replace project-level uv version discovery with the organization-wide latest policy

## Validation

- Prettier
- clean diff
- Actions CI exercises Linux, macOS, and Windows

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The shared `setup-uv` action now always installs the latest uv release, centralizing version selection and removing its configurable `version` input.

### 📊 Key Changes

- Set the underlying `astral-sh/setup-uv@v10.0.0` action to use `version: latest`.
- Removed the `version` input from `setup-uv/action.yml`.
- Updated `setup-uv/README.md` to document latest-release behavior and removed the `version` input from the usage table.
- Kept Python version selection, environment activation, and dependency caching unchanged.

### 🎯 Purpose & Impact

- Consumers of the shared action no longer select or discover a project-specific uv version; their workflows use the latest uv release by default.
- Existing configuration for Python versions, virtual environments, and caching remains available.