### PR TITLE
Run Lychee link checks on macOS runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -406,7 +406,7 @@ runs:
           Darwin-arm64) target=aarch64-apple-darwin ;;
           Darwin-x86_64) target=x86_64-apple-darwin ;;
         esac
-        curl -sfL "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-${target}.tar.gz" | tar -xz -C "$RUNNER_TEMP"
+        curl -sfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-${target}.tar.gz" | tar -xz -C "$RUNNER_TEMP"
         "$RUNNER_TEMP/lychee-${target}/lychee" \
         --scheme https \
         --timeout 60 \

--- a/action.yml
+++ b/action.yml
@@ -385,27 +385,35 @@ runs:
       continue-on-error: true
 
     # Broken links -----------------------------------------------------------------------------------------------------
+    # lychee-action only ships Linux binaries, so install lychee directly to support macOS runners (Swift repos) too.
     - name: Broken Link Checker
       if: inputs.links == 'true' && github.event_name == 'pull_request' && github.event.action != 'closed'
-      uses: lycheeverse/lychee-action@v2.9.0
-      with:
-        # Check all markdown and html files in repo. Ignores the following status codes to reduce false positives:
-        #   - 401(generic, "unauthorized")
-        #   - 403(OpenVINO, "forbidden")
-        #   - 429(Instagram, "too many requests")
-        #   - 500(Zenodo, "cached")
-        #   - 502(Zenodo, "bad gateway")
-        #   - 999(LinkedIn, "unknown status code")
-        args: |
-          --scheme https
-          --timeout 60
-          --insecure
-          --accept 100..=103,200..=299,401,403,429,500,502,999
-          --exclude-all-private
-          --exclude "https?://(www\.)?(github\.com|linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)"
-          "./**/*.md"
-          "./**/*.html"
-        token: ${{ inputs.token }}
-        output: ../lychee/results.md
-        fail: true
-      continue-on-error: false
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      # Check all markdown and html files in repo. Ignores the following status codes to reduce false positives:
+      #   - 401(generic, "unauthorized")
+      #   - 403(OpenVINO, "forbidden")
+      #   - 429(Instagram, "too many requests")
+      #   - 500(Zenodo, "cached")
+      #   - 502(Zenodo, "bad gateway")
+      #   - 999(LinkedIn, "unknown status code")
+      run: |
+        echo "::group::Broken Link Checker"
+        trap 'echo "::endgroup::"' EXIT
+        case "$(uname -s)-$(uname -m)" in
+          Linux-x86_64) target=x86_64-unknown-linux-gnu ;;
+          Linux-aarch64) target=aarch64-unknown-linux-gnu ;;
+          Darwin-arm64) target=aarch64-apple-darwin ;;
+          Darwin-x86_64) target=x86_64-apple-darwin ;;
+        esac
+        curl -sfL "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-${target}.tar.gz" | tar -xz -C "$RUNNER_TEMP"
+        "$RUNNER_TEMP/lychee-${target}/lychee" \
+        --scheme https \
+        --timeout 60 \
+        --insecure \
+        --accept 100..=103,200..=299,401,403,429,500,502,999 \
+        --exclude-all-private \
+        --exclude "https?://(www\.)?(github\.com|linkedin\.com|twitter\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)" \
+        "./**/*.md" \
+        "./**/*.html"
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -406,8 +406,9 @@ runs:
           Darwin-arm64) target=aarch64-apple-darwin ;;
           Darwin-x86_64) target=x86_64-apple-darwin ;;
         esac
-        curl -sfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-${target}.tar.gz" | tar -xz -C "$RUNNER_TEMP"
-        "$RUNNER_TEMP/lychee-${target}/lychee" \
+        mkdir -p "$RUNNER_TEMP/lychee"
+        curl -sfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-${target}.tar.gz" | tar -xz -C "$RUNNER_TEMP/lychee"
+        "$(find "$RUNNER_TEMP/lychee" -type f -name lychee)" \
         --scheme https \
         --timeout 60 \
         --insecure \


### PR DESCRIPTION
lycheeverse/lychee-action only ships Linux tarballs, so `links: true` fails on macOS runners (Swift repos: iSky, yolo-ios-app, yolo-flutter-app). Install the lychee binary for the runner platform directly from the latest lychee release and run the identical arguments, so link checks work everywhere. Tracking the latest release is deliberate: Dependabot cannot bump a download URL, so a version pin here would freeze forever, and this repository already consumes evergreen refs (`ultralytics/actions@main`, `setup-uv@main`). Verified the aarch64-apple-darwin binary locally against ultralytics/iSky (73 links, 0 errors).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Replaced the Linux-only Lychee GitHub Action with a platform-aware direct Lychee installation so link checks can run on Linux and macOS runners.

### 📊 Key Changes

- Maps Linux and macOS runner architectures to the corresponding Lychee release binaries.
- Downloads the latest Lychee binary into `$RUNNER_TEMP` and executes it directly.
- Preserves the existing link-check arguments, URL exclusions, accepted status codes, Markdown and HTML file patterns, and pull-request conditions.
- Passes the configured token through the `GITHUB_TOKEN` environment variable and keeps failures non-optional.

### 🎯 Purpose & Impact

- Enables `links: true` checks for macOS-based Swift repositories, including Apple Silicon and Intel runners, while retaining the existing Linux workflows.
- The workflow now tracks the latest Lychee release rather than a fixed action version.
- No product runtime behavior changes; this updates repository CI link-check execution.