### PR TITLE
Resolve Dart packages before formatting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -253,12 +253,15 @@ runs:
       if: github.event_name == 'pull_request' && inputs.dart == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
         echo "::group::Run Dart Formatter"
-        # Formatting never creates files: always drop generated pub/Flutter metadata and restore tracked lockfiles
-        trap 'git clean -fdqx; git ls-files -z "*pubspec.lock" | xargs -0 -r git checkout --; echo "::endgroup::"' EXIT
+        trap 'echo "::endgroup::"' EXIT
+        ok=true
         while IFS= read -r -d '' pubspec; do
-          (cd "$(dirname "$pubspec")" && flutter pub get)
+          (cd "$(dirname "$pubspec")" && flutter pub get) || ok=false
         done < <(find . -name pubspec.yaml -not -path '*/.*' -print0)
-        dart format .
+        $ok && dart format . || ok=false # never format with an unresolved language version
+        git clean -fdqx # formatting never creates files, so drop generated pub and Flutter metadata
+        git ls-files -z '*pubspec.lock' | xargs -0 -r git checkout --
+        $ok
       shell: bash
       continue-on-error: true # Important so that commit step can pick up changes
 

--- a/action.yml
+++ b/action.yml
@@ -254,6 +254,7 @@ runs:
       run: |
         echo "::group::Run Dart Formatter"
         trap 'echo "::endgroup::"' EXIT
+        echo ".dart_tool/" >> .git/info/exclude # keep resolution artifacts out of the auto-format commit
         find . -name pubspec.yaml -not -path '*/.*' -execdir flutter pub get \;
         dart format .
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -254,9 +254,12 @@ runs:
       run: |
         echo "::group::Run Dart Formatter"
         trap 'echo "::endgroup::"' EXIT
-        echo ".dart_tool/" >> .git/info/exclude # keep resolution artifacts out of the auto-format commit
-        find . -name pubspec.yaml -not -path '*/.*' -execdir flutter pub get \;
+        for pubspec in $(find . -name pubspec.yaml -not -path '*/.*'); do
+          (cd "$(dirname "$pubspec")" && flutter pub get)
+        done
         dart format .
+        git clean -fdq # formatting never creates files, so drop generated pub and Flutter metadata
+        git ls-files -z '*pubspec.lock' | xargs -0 -r git checkout --
       shell: bash
       continue-on-error: true # Important so that commit step can pick up changes
 

--- a/action.yml
+++ b/action.yml
@@ -242,9 +242,12 @@ runs:
     # language version and silently falls back to the pre-3.7 short style.
     - name: Setup Flutter SDK
       if: github.event_name == 'pull_request' && inputs.dart == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
-      uses: subosito/flutter-action@v2
-      with:
-        channel: stable
+      run: |
+        echo "::group::Setup Flutter SDK"
+        trap 'echo "::endgroup::"' EXIT
+        git clone --depth 1 --branch stable https://github.com/flutter/flutter.git "$RUNNER_TEMP/flutter"
+        echo "$RUNNER_TEMP/flutter/bin" >> "$GITHUB_PATH"
+      shell: bash
 
     - name: Run Dart Formatter
       if: github.event_name == 'pull_request' && inputs.dart == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')

--- a/action.yml
+++ b/action.yml
@@ -259,7 +259,7 @@ runs:
           (cd "$(dirname "$pubspec")" && flutter pub get) || ok=false
         done < <(find . -name pubspec.yaml -not -path '*/.*' -print0)
         $ok && dart format . || ok=false # never format with an unresolved language version
-        git clean -fdqx # formatting never creates files, so drop generated pub and Flutter metadata
+        git clean -fdq # formatting never creates files, so drop generated pub and Flutter metadata
         git ls-files -z '*pubspec.lock' | xargs -0 -r git checkout --
         $ok
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -255,9 +255,9 @@ runs:
         echo "::group::Run Dart Formatter"
         # Formatting never creates files: always drop generated pub/Flutter metadata and restore tracked lockfiles
         trap 'git clean -fdqx; git ls-files -z "*pubspec.lock" | xargs -0 -r git checkout --; echo "::endgroup::"' EXIT
-        for pubspec in $(find . -name pubspec.yaml -not -path '*/.*'); do
+        while IFS= read -r -d '' pubspec; do
           (cd "$(dirname "$pubspec")" && flutter pub get)
-        done
+        done < <(find . -name pubspec.yaml -not -path '*/.*' -print0)
         dart format .
       shell: bash
       continue-on-error: true # Important so that commit step can pick up changes

--- a/action.yml
+++ b/action.yml
@@ -253,13 +253,12 @@ runs:
       if: github.event_name == 'pull_request' && inputs.dart == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
         echo "::group::Run Dart Formatter"
-        trap 'echo "::endgroup::"' EXIT
+        # Formatting never creates files: always drop generated pub/Flutter metadata and restore tracked lockfiles
+        trap 'git clean -fdqx; git ls-files -z "*pubspec.lock" | xargs -0 -r git checkout --; echo "::endgroup::"' EXIT
         for pubspec in $(find . -name pubspec.yaml -not -path '*/.*'); do
           (cd "$(dirname "$pubspec")" && flutter pub get)
         done
         dart format .
-        git clean -fdq # formatting never creates files, so drop generated pub and Flutter metadata
-        git ls-files -z '*pubspec.lock' | xargs -0 -r git checkout --
       shell: bash
       continue-on-error: true # Important so that commit step can pick up changes
 

--- a/action.yml
+++ b/action.yml
@@ -238,17 +238,20 @@ runs:
       continue-on-error: true
 
     # Dart formatting --------------------------------------------------------------------------------------------------
-    - name: Setup Dart SDK
+    # Flutter bundles Dart and resolves Flutter packages; without `pub get`, `dart format` cannot read the package
+    # language version and silently falls back to the pre-3.7 short style.
+    - name: Setup Flutter SDK
       if: github.event_name == 'pull_request' && inputs.dart == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
-      uses: dart-lang/setup-dart@v1
+      uses: subosito/flutter-action@v2
       with:
-        sdk: stable
+        channel: stable
 
     - name: Run Dart Formatter
       if: github.event_name == 'pull_request' && inputs.dart == 'true' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       run: |
         echo "::group::Run Dart Formatter"
         trap 'echo "::endgroup::"' EXIT
+        find . -name pubspec.yaml -not -path '*/.*' -execdir flutter pub get \;
         dart format .
       shell: bash
       continue-on-error: true # Important so that commit step can pick up changes


### PR DESCRIPTION
`dart format` reads the package language version from `.dart_tool/package_config.json`; on a fresh checkout without `pub get` it silently falls back to the pre-3.7 short style, so the bot reformatted 13 files in ultralytics/yolo-flutter-app#585 into the wrong style. Install Flutter from the official flutter/flutter repository (`git clone --depth 1 --branch stable`, as documented by Flutter; no third-party action) — it bundles Dart and is required to resolve Flutter packages — and run `flutter pub get` in every package before formatting. Verified locally with the cloned stable SDK (Dart 3.13.0) against yolo-flutter-app: without package config → short style, with → correct tall style.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
The Dart-formatting workflow now installs Flutter, resolves every package before formatting, and cleans up generated package metadata to ensure formatting uses the correct Dart language version.

### 📊 Key Changes
- Replaced `dart-lang/setup-dart` with a shallow clone of the official Flutter stable repository and added its bundled Dart SDK to `GITHUB_PATH`.
- Runs `flutter pub get` in every non-hidden directory containing `pubspec.yaml` before invoking `dart format`.
- Skips formatting when package resolution fails, while preserving the action’s existing `continue-on-error` behavior.
- Removes generated files and restores tracked `pubspec.lock` files after formatting.

### 🎯 Purpose & Impact
- Pull requests using Dart formatting now resolve Flutter and Dart package metadata first, preventing formatting with the fallback pre-3.7 style.
- The workflow applies this behavior to `opened` and `synchronize` pull request events when the Dart input is enabled.