### PR TITLE
Use the Action token and accept inputs in workflow dispatch

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"

--- a/actions/dispatch_actions.py
+++ b/actions/dispatch_actions.py
@@ -35,9 +35,9 @@ def get_pr_branch(event) -> tuple[str, str | None]:
         fork_repo = head["repo"]["full_name"]
         fork_branch = head["ref"]
         base_repo = event.repository
-        token = os.environ.get("GITHUB_TOKEN")
+        token = event.token
         if not token:
-            raise ValueError("GITHUB_TOKEN environment variable is not set")
+            raise ValueError("A GitHub token is required to push the temporary branch")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_dir = os.path.join(tmp_dir, "repo")
@@ -73,9 +73,11 @@ def get_pr_branch(event) -> tuple[str, str | None]:
 
 
 def trigger_and_get_workflow_info(
-    event, branch: str, workflow_files: list[str], temp_branch: str | None = None
+    event, branch: str, workflow_files: list[str], temp_branch: str | None = None, inputs: dict | None = None
 ) -> list[dict]:
-    """Triggers workflows and returns their information, deleting temp branch if provided."""
+    """Triggers workflows with optional workflow_dispatch inputs and returns their information, deleting temp branch if
+    provided.
+    """
     repo = event.repository
     results = []
     failed = {}
@@ -84,7 +86,8 @@ def trigger_and_get_workflow_info(
         # Trigger all workflows
         for file in workflow_files:
             response = event.post(
-                f"{GITHUB_API_URL}/repos/{repo}/actions/workflows/{file}/dispatches", json={"ref": branch}
+                f"{GITHUB_API_URL}/repos/{repo}/actions/workflows/{file}/dispatches",
+                json={"ref": branch, **({"inputs": inputs} if inputs else {})},
             )
             if isinstance(response.status_code, int) and response.status_code != 204:
                 failed[file] = response.json().get("message", "workflow dispatch failed")

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -3,6 +3,8 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from actions.dispatch_actions import (
     RUN_ALL_KEYWORD,
     RUN_CI_KEYWORD,
@@ -40,9 +42,8 @@ def test_get_pr_branch_fork():
         "base": {"repo": {"id": 1}},
     }
 
-    with patch("time.time", return_value=1234567.890), patch("subprocess.run") as mock_run, patch(
-        "os.environ.get", return_value="test-token"
-    ):
+    mock_event.token = "test-token"
+    with patch("time.time", return_value=1234567.890), patch("subprocess.run") as mock_run:
         branch, temp_branch = get_pr_branch(mock_event)
 
     assert branch == "temp-ci-456-1234567890"
@@ -60,13 +61,9 @@ def test_get_pr_branch_fork_requires_token():
         "base": {"repo": {"id": 1}},
     }
 
-    try:
-        with patch("os.environ.get", return_value=None):
-            get_pr_branch(mock_event)
-    except ValueError as e:
-        assert str(e) == "GITHUB_TOKEN environment variable is not set"
-    else:
-        raise AssertionError("Expected missing token to raise")
+    mock_event.token = None
+    with pytest.raises(ValueError, match="token is required"):
+        get_pr_branch(mock_event)
 
 
 def test_get_pr_branch_fork_sanitizes_git_errors():
@@ -82,8 +79,9 @@ def test_get_pr_branch_fork_sanitizes_git_errors():
     }
     error = subprocess.CalledProcessError(128, ["git"], stderr=b"https://x-access-token:test-token@github.com")
 
+    mock_event.token = "test-token"
     try:
-        with patch("subprocess.run", side_effect=error), patch("os.environ.get", return_value="test-token"):
+        with patch("subprocess.run", side_effect=error):
             get_pr_branch(mock_event)
     except RuntimeError as e:
         assert "test-token" not in str(e)
@@ -123,9 +121,10 @@ def test_trigger_and_get_workflow_info():
 
     # Use patch to skip time.sleep and limit to one workflow
     with patch("time.sleep"):
-        results = trigger_and_get_workflow_info(mock_event, "feature-branch", ["ci.yml"])
+        results = trigger_and_get_workflow_info(mock_event, "feature-branch", ["ci.yml"], inputs={"tests": "true"})
 
     # Check results
+    assert mock_event.post.call_args.kwargs["json"] == {"ref": "feature-branch", "inputs": {"tests": "true"}}
     assert len(results) == 1
     assert results[0]["name"] == "CI Workflow"
     assert results[0]["run_number"] == 42


### PR DESCRIPTION
\`dispatch_actions.get_pr_branch\` now pushes the temporary fork branch with the \`Action\`'s own token instead of re-reading \`GITHUB_TOKEN\` from the environment, and \`trigger_and_get_workflow_info\` accepts optional \`workflow_dispatch\` \`inputs\` (e.g. \`{"tests": "true"}\` for slow CI). Both let callers that construct an \`Action(token=..., event_data=...)\` directly — such as the Ultralytics Assistant's GitHub mention agent, which reuses this module to run CI/Docker on a PR — dispatch workflows without duplicating the fork temp-branch handling. Behavior for the existing \`@ultralytics/run-*\` comment path is unchanged: \`Action\` still resolves its token from \`GITHUB_TOKEN\` when none is passed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated workflow dispatching to use the `Action` instance token for temporary fork branches and to support optional `workflow_dispatch` inputs.

### 📊 Key Changes

- `get_pr_branch` now reads the push token from `event.token` instead of the `GITHUB_TOKEN` environment variable, with an updated missing-token error.
- `trigger_and_get_workflow_info` accepts an optional `inputs` dictionary and includes it in workflow dispatch requests when provided.
- Added test coverage for token handling and dispatching inputs such as `{"tests": "true"}`.
- Bumped the package version from `0.3.8` to `0.3.9`.

### 🎯 Purpose & Impact

- Callers that construct an `Action` with a token can push temporary fork branches and dispatch workflows without separately configuring `GITHUB_TOKEN`.
- Workflow callers can pass dispatch inputs to control workflow behavior.
- Existing callers that omit a token continue to rely on `Action`'s existing `GITHUB_TOKEN` resolution.