### PR TITLE
Enforce per-attempt retry timeouts

### DIFF
--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -82,7 +82,7 @@ jobs:
                 child_file=$(cygpath -w /tmp/retry_child)
                 powershell.exe -NoProfile -Command "[IO.File]::WriteAllText('$child_file', [string]\$PID); Start-Sleep 120" &
               else
-                python3 -c 'import os, signal, time; os.fork() and os._exit(0); os.setsid(); os.fork() and os._exit(0); open("/tmp/retry_child", "w").write(str(os.getpid())); signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(120)'
+                python3 -c 'import os, signal, time; os.fork() and os._exit(0); os.setsid(); os.fork() and os._exit(0); open("/tmp/retry_child", "w").write(str(os.getpid())); os.environ.clear(); signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(120)'
                 sleep 120 &
               fi
               wait $!

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -12,7 +12,14 @@ on:
 
 jobs:
   test-bash:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
 
@@ -60,7 +67,7 @@ jobs:
         with:
           retries: 1
           retry_delay_seconds: 0
-          attempt_timeout_minutes: 1
+          timeout_minutes: 1
           run: |
             if [ ! -f /tmp/retry_attempt ]; then
               touch /tmp/retry_attempt

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -79,14 +79,20 @@ jobs:
             if [ ! -f /tmp/retry_attempt ]; then
               touch /tmp/retry_attempt
               if [ "$RUNNER_OS" = "Windows" ]; then
-                bash -c 'trap "" TERM; sleep 120' &
+                child_file=$(cygpath -w /tmp/retry_child)
+                powershell.exe -NoProfile -Command "[IO.File]::WriteAllText('$child_file', [string]\$PID); Start-Sleep 120" &
               else
-                python3 -c 'import os, signal, time; os.setsid(); signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(120)' &
+                python3 -c 'import os, signal, time; os.fork() and os._exit(0); os.setsid(); os.fork() and os._exit(0); open("/tmp/retry_child", "w").write(str(os.getpid())); signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(120)'
+                sleep 120 &
               fi
-              echo $! > /tmp/retry_child
               wait $!
             fi
-            if [ "$RUNNER_OS" != "Windows" ] && kill -0 "$(cat /tmp/retry_child)" 2>/dev/null; then
+            if [ "$RUNNER_OS" = "Windows" ]; then
+              powershell.exe -NoProfile -Command "if (Get-Process -Id $(cat /tmp/retry_child) -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }" && child_alive=true
+            elif kill -0 "$(cat /tmp/retry_child)" 2>/dev/null; then
+              child_alive=true
+            fi
+            if [ "$child_alive" = true ]; then
               echo "::error::Timed-out child is still running"
               exit 1
             fi

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -33,6 +33,13 @@ jobs:
             echo "This should succeed first try"
             true
 
+      - name: Test Python shell on Windows
+        if: matrix.os == 'windows-latest'
+        uses: ./retry
+        with:
+          shell: python
+          run: print("Python shell works")
+
       - name: Test retry with eventual success
         uses: ./retry
         env:

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -86,7 +86,7 @@ jobs:
               echo $! > /tmp/retry_child
               wait $!
             fi
-            if kill -0 "$(cat /tmp/retry_child)" 2>/dev/null; then
+            if [ "$RUNNER_OS" != "Windows" ] && kill -0 "$(cat /tmp/retry_child)" 2>/dev/null; then
               echo "::error::Timed-out child is still running"
               exit 1
             fi

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -71,7 +71,8 @@ jobs:
           run: |
             if [ ! -f /tmp/retry_attempt ]; then
               touch /tmp/retry_attempt
-              sleep 120
+              bash -c 'trap "" TERM; sleep 120' &
+              wait $!
             fi
             rm -f /tmp/retry_attempt
 

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -55,6 +55,19 @@ jobs:
             rm -f /tmp/retry_attempt
             echo "Success on attempt $((count + 1))!"
 
+      - name: Test hung command retry
+        uses: ./retry
+        with:
+          retries: 1
+          retry_delay_seconds: 0
+          attempt_timeout_minutes: 1
+          run: |
+            if [ ! -f /tmp/retry_attempt ]; then
+              touch /tmp/retry_attempt
+              sleep 120
+            fi
+            rm -f /tmp/retry_attempt
+
       - name: Test multi-line failure
         uses: ./retry
         continue-on-error: true

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -81,8 +81,11 @@ jobs:
               if [ "$RUNNER_OS" = "Windows" ]; then
                 child_file=$(cygpath -w /tmp/retry_child)
                 powershell.exe -NoProfile -Command "[IO.File]::WriteAllText('$child_file', [string]\$PID); Start-Sleep 120" &
-              else
+              elif [ "$RUNNER_OS" = "Linux" ]; then
                 python3 -c 'import os, signal, time; os.fork() and os._exit(0); os.setsid(); os.fork() and os._exit(0); open("/tmp/retry_child", "w").write(str(os.getpid())); os.environ.clear(); signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(120)'
+                sleep 120 &
+              else
+                python3 -c 'import os, signal, time; os.fork() and os._exit(0); os.setsid(); os.fork() and os._exit(0); open("/tmp/retry_child", "w").write(str(os.getpid())); signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(120)'
                 sleep 120 &
               fi
               wait $!

--- a/.github/workflows/test-retry.yml
+++ b/.github/workflows/test-retry.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Cleanup any leftover test files
-        run: rm -f /tmp/retry_attempt /tmp/retry_attempt_py
+        run: rm -f /tmp/retry_attempt /tmp/retry_attempt_py /tmp/retry_child
 
       - name: Test successful command
         uses: ./retry
@@ -78,10 +78,19 @@ jobs:
           run: |
             if [ ! -f /tmp/retry_attempt ]; then
               touch /tmp/retry_attempt
-              bash -c 'trap "" TERM; sleep 120' &
+              if [ "$RUNNER_OS" = "Windows" ]; then
+                bash -c 'trap "" TERM; sleep 120' &
+              else
+                python3 -c 'import os, signal, time; os.setsid(); signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(120)' &
+              fi
+              echo $! > /tmp/retry_child
               wait $!
             fi
-            rm -f /tmp/retry_attempt
+            if kill -0 "$(cat /tmp/retry_child)" 2>/dev/null; then
+              echo "::error::Timed-out child is still running"
+              exit 1
+            fi
+            rm -f /tmp/retry_attempt /tmp/retry_child
 
       - name: Test multi-line failure
         uses: ./retry

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.9"
+__version__ = "0.3.10"

--- a/retry/README.md
+++ b/retry/README.md
@@ -30,6 +30,7 @@ steps:
         pytest tests/
       retries: 2 # Retry twice after initial attempt (3 total runs)
       timeout_minutes: 30 # Total timeout across all attempts
+      attempt_timeout_minutes: 10 # Maximum time for each attempt (0 disables)
       retry_delay_seconds: 10 # Base delay between retries
       backoff: exponential # exponential (10s, 20s, 40s, ...) or fixed
       jitter: true # Randomize delay to 80-120% to avoid thundering herd
@@ -52,20 +53,21 @@ steps:
 
 ## 📋 Inputs
 
-| Input                 | Description                                                  | Required | Default       |
-| --------------------- | ------------------------------------------------------------ | -------- | ------------- |
-| `run`                 | Command to run                                               | Yes      | -             |
-| `retries`             | Number of retry attempts after initial run                   | No       | `3`           |
-| `timeout_minutes`     | Maximum total time in minutes, checked between attempts      | No       | `360`         |
-| `retry_delay_seconds` | Base delay between retries in seconds                        | No       | `10`          |
-| `backoff`             | Backoff strategy: `exponential` (base \* 2^n) or `fixed`     | No       | `exponential` |
-| `jitter`              | Randomize delay to 80-120% of value to avoid thundering herd | No       | `true`        |
-| `shell`               | Shell to use (`bash` or `python`)                            | No       | `bash`        |
+| Input                     | Description                                                  | Required | Default       |
+| ------------------------- | ------------------------------------------------------------ | -------- | ------------- |
+| `run`                     | Command to run                                               | Yes      | -             |
+| `retries`                 | Number of retry attempts after initial run                   | No       | `3`           |
+| `timeout_minutes`         | Maximum total time in minutes, checked between attempts      | No       | `360`         |
+| `attempt_timeout_minutes` | Maximum time in minutes for each attempt; `0` disables it    | No       | `0`           |
+| `retry_delay_seconds`     | Base delay between retries in seconds                        | No       | `10`          |
+| `backoff`                 | Backoff strategy: `exponential` (base \* 2^n) or `fixed`     | No       | `exponential` |
+| `jitter`                  | Randomize delay to 80-120% of value to avoid thundering herd | No       | `true`        |
+| `shell`                   | Shell to use (`bash` or `python`)                            | No       | `bash`        |
 
 ## ✨ Features
 
 - Preserves environment variables and step context
 - Exponential backoff with ±20% jitter (best-practice defaults)
-- Configurable total timeout across all attempts (individual sleeps auto-capped to remaining budget)
+- Configurable total timeout plus an optional per-attempt timeout that terminates hung process trees
 - GitHub Actions grouping for retry attempts
 - Supports both Bash and Python shells

--- a/retry/README.md
+++ b/retry/README.md
@@ -70,4 +70,5 @@ steps:
 - GitHub Actions grouping for retry attempts
 - Supports both Bash and Python shells
 
-Timeout supervision requires Python 3 on Linux and macOS.
+Timeout supervision requires Python 3 on Linux and macOS. macOS descendants that deliberately detach and clear their
+inherited environment are outside the platform's portable containment boundary.

--- a/retry/README.md
+++ b/retry/README.md
@@ -12,9 +12,9 @@ Retry failed step up to 3 times (default):
 
 ```yaml
 steps:
-    - uses: ultralytics/actions/retry@main
-      with:
-          run: python train.py
+  - uses: ultralytics/actions/retry@main
+    with:
+      run: python train.py
 ```
 
 ### Advanced Usage
@@ -23,31 +23,31 @@ Full configuration with custom retries, timeout, backoff, and jitter:
 
 ```yaml
 steps:
-    - uses: ultralytics/actions/retry@main
-      with:
-          run: |
-              python setup.py install
-              pytest tests/
-          retries: 2 # Retry twice after initial attempt (3 total runs)
-          timeout_minutes: 30 # Maximum time for each attempt
-          retry_delay_seconds: 10 # Base delay between retries
-          backoff: exponential # exponential (10s, 20s, 40s, ...) or fixed
-          jitter: true # Randomize delay to 80-120% to avoid thundering herd
-          shell: bash # Use python or bash shell
+  - uses: ultralytics/actions/retry@main
+    with:
+      run: |
+        python setup.py install
+        pytest tests/
+      retries: 2 # Retry twice after initial attempt (3 total runs)
+      timeout_minutes: 30 # Maximum time for each attempt
+      retry_delay_seconds: 10 # Base delay between retries
+      backoff: exponential # exponential (10s, 20s, 40s, ...) or fixed
+      jitter: true # Randomize delay to 80-120% to avoid thundering herd
+      shell: bash # Use python or bash shell
 ```
 
 ### Python Shell Example
 
 ```yaml
 steps:
-    - uses: ultralytics/actions/retry@main
-      with:
-          shell: python
-          retries: 5
-          run: |
-              import requests
-              response = requests.get('https://api.example.com/data')
-              response.raise_for_status()
+  - uses: ultralytics/actions/retry@main
+    with:
+      shell: python
+      retries: 5
+      run: |
+        import requests
+        response = requests.get('https://api.example.com/data')
+        response.raise_for_status()
 ```
 
 ## 📋 Inputs

--- a/retry/README.md
+++ b/retry/README.md
@@ -70,6 +70,4 @@ steps:
 - GitHub Actions grouping for retry attempts
 - Supports both Bash and Python shells
 
-Timeout supervision requires Python 3 on Linux and macOS. It terminates the attempt process group and descendants that
-retain the inherited environment; deliberately detached processes that also clear their environment are outside the
-action's portable containment boundary.
+Timeout supervision requires Python 3 on Linux and macOS.

--- a/retry/README.md
+++ b/retry/README.md
@@ -29,8 +29,7 @@ steps:
         python setup.py install
         pytest tests/
       retries: 2 # Retry twice after initial attempt (3 total runs)
-      timeout_minutes: 30 # Total timeout across all attempts
-      attempt_timeout_minutes: 10 # Maximum time for each attempt (0 disables)
+      timeout_minutes: 30 # Maximum time for each attempt
       retry_delay_seconds: 10 # Base delay between retries
       backoff: exponential # exponential (10s, 20s, 40s, ...) or fixed
       jitter: true # Randomize delay to 80-120% to avoid thundering herd
@@ -53,21 +52,20 @@ steps:
 
 ## 📋 Inputs
 
-| Input                     | Description                                                  | Required | Default       |
-| ------------------------- | ------------------------------------------------------------ | -------- | ------------- |
-| `run`                     | Command to run                                               | Yes      | -             |
-| `retries`                 | Number of retry attempts after initial run                   | No       | `3`           |
-| `timeout_minutes`         | Maximum total time in minutes, checked between attempts      | No       | `360`         |
-| `attempt_timeout_minutes` | Maximum time in minutes for each attempt; `0` disables it    | No       | `0`           |
-| `retry_delay_seconds`     | Base delay between retries in seconds                        | No       | `10`          |
-| `backoff`                 | Backoff strategy: `exponential` (base \* 2^n) or `fixed`     | No       | `exponential` |
-| `jitter`                  | Randomize delay to 80-120% of value to avoid thundering herd | No       | `true`        |
-| `shell`                   | Shell to use (`bash` or `python`)                            | No       | `bash`        |
+| Input                 | Description                                                  | Required | Default       |
+| --------------------- | ------------------------------------------------------------ | -------- | ------------- |
+| `run`                 | Command to run                                               | Yes      | -             |
+| `retries`             | Number of retry attempts after initial run                   | No       | `3`           |
+| `timeout_minutes`     | Maximum time in minutes for each attempt                     | No       | `360`         |
+| `retry_delay_seconds` | Base delay between retries in seconds                        | No       | `10`          |
+| `backoff`             | Backoff strategy: `exponential` (base \* 2^n) or `fixed`     | No       | `exponential` |
+| `jitter`              | Randomize delay to 80-120% of value to avoid thundering herd | No       | `true`        |
+| `shell`               | Shell to use (`bash` or `python`)                            | No       | `bash`        |
 
 ## ✨ Features
 
 - Preserves environment variables and step context
 - Exponential backoff with ±20% jitter (best-practice defaults)
-- Configurable total timeout plus an optional per-attempt timeout that terminates hung process trees
+- Configurable per-attempt timeout that terminates hung process trees
 - GitHub Actions grouping for retry attempts
 - Supports both Bash and Python shells

--- a/retry/README.md
+++ b/retry/README.md
@@ -12,9 +12,9 @@ Retry failed step up to 3 times (default):
 
 ```yaml
 steps:
-  - uses: ultralytics/actions/retry@main
-    with:
-      run: python train.py
+    - uses: ultralytics/actions/retry@main
+      with:
+          run: python train.py
 ```
 
 ### Advanced Usage
@@ -23,31 +23,31 @@ Full configuration with custom retries, timeout, backoff, and jitter:
 
 ```yaml
 steps:
-  - uses: ultralytics/actions/retry@main
-    with:
-      run: |
-        python setup.py install
-        pytest tests/
-      retries: 2 # Retry twice after initial attempt (3 total runs)
-      timeout_minutes: 30 # Maximum time for each attempt
-      retry_delay_seconds: 10 # Base delay between retries
-      backoff: exponential # exponential (10s, 20s, 40s, ...) or fixed
-      jitter: true # Randomize delay to 80-120% to avoid thundering herd
-      shell: bash # Use python or bash shell
+    - uses: ultralytics/actions/retry@main
+      with:
+          run: |
+              python setup.py install
+              pytest tests/
+          retries: 2 # Retry twice after initial attempt (3 total runs)
+          timeout_minutes: 30 # Maximum time for each attempt
+          retry_delay_seconds: 10 # Base delay between retries
+          backoff: exponential # exponential (10s, 20s, 40s, ...) or fixed
+          jitter: true # Randomize delay to 80-120% to avoid thundering herd
+          shell: bash # Use python or bash shell
 ```
 
 ### Python Shell Example
 
 ```yaml
 steps:
-  - uses: ultralytics/actions/retry@main
-    with:
-      shell: python
-      retries: 5
-      run: |
-        import requests
-        response = requests.get('https://api.example.com/data')
-        response.raise_for_status()
+    - uses: ultralytics/actions/retry@main
+      with:
+          shell: python
+          retries: 5
+          run: |
+              import requests
+              response = requests.get('https://api.example.com/data')
+              response.raise_for_status()
 ```
 
 ## 📋 Inputs
@@ -69,3 +69,7 @@ steps:
 - Configurable per-attempt timeout that terminates hung process trees
 - GitHub Actions grouping for retry attempts
 - Supports both Bash and Python shells
+
+Timeout supervision requires Python 3 on Linux and macOS. It terminates the attempt process group and descendants that
+retain the inherited environment; deliberately detached processes that also clear their environment are outside the
+action's portable containment boundary.

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -142,6 +142,7 @@ runs:
             taskkill.exe /PID $process.Id /T /F | Out-Null
             exit 124
         }
+        $process.WaitForExit()
         exit $process.ExitCode
         '
             else

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -126,7 +126,7 @@ runs:
                 echo "::group::Retry $((attempt - 1)) of $retries"
             fi
 
-            # Execute the script with a deadline, terminating its entire process tree on timeout.
+            # Execute the script with a deadline, terminating its process group and tracked descendants on timeout.
             timeout_marker="${TEMP_SCRIPT}.timeout"
             rm -f "$timeout_marker"
             if [ "$RETRY_RUNNER_OS" = "Windows" ]; then

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -169,7 +169,7 @@ runs:
         def tracked_processes(token):
             """Return processes carrying the attempt's unique inherited environment marker."""
             marker = f"ULTRALYTICS_RETRY_TOKEN={token}"
-            processes = subprocess.check_output(["ps", "eww", "-axo", "pid=,command="], text=True)
+            processes = subprocess.check_output(["ps", "axeww", "-o", "pid=", "-o", "command="], text=True)
             return {int(line.split(None, 1)[0]) for line in processes.splitlines() if marker in line}
 
         def send_signal(process_group, process_ids, sig):

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -16,8 +16,7 @@
 #         python setup.py install
 #         pytest tests/
 #       retries: 2               # Retry twice after initial attempt (3 total runs)
-#       timeout_minutes: 30      # Total timeout for all attempts combined
-#       attempt_timeout_minutes: 10  # Maximum time for each attempt (0 disables)
+#       timeout_minutes: 30      # Maximum time for each attempt
 #       retry_delay_seconds: 10  # Base delay between retries in seconds
 #       backoff: exponential     # exponential (10s, 20s, 40s, ...) or fixed
 #       jitter: true             # Randomize delay to 80-120% to avoid thundering herd
@@ -27,23 +26,19 @@ name: "Step-Level Retry"
 description: "Retries a step while preserving its full context"
 inputs:
   timeout_minutes:
-    description: "Maximum total time in minutes for all attempts (checked between attempts; does not interrupt a running attempt)"
+    description: "Maximum time in minutes for each attempt"
     required: false
     default: "360"
   retries:
     description: "Number of retry attempts after initial run"
     required: false
     default: "3"
-  attempt_timeout_minutes:
-    description: "Maximum time in minutes for each attempt; 0 disables the per-attempt timeout"
-    required: false
-    default: "0"
   retry_delay_seconds:
     description: "Base delay between retries in seconds"
     required: false
     default: "10"
   backoff:
-    description: "Backoff strategy: exponential (base * 2^n) or fixed. Delays are bounded by timeout_minutes."
+    description: "Backoff strategy: exponential (base * 2^n) or fixed"
     required: false
     default: "exponential"
   jitter:
@@ -69,9 +64,7 @@ runs:
       run: |
         set +e  # Don't exit on error - we handle errors manually
 
-        start_time=$(date +%s)
         timeout_seconds=$(( ${{ inputs.timeout_minutes }} * 60 ))
-        attempt_timeout_seconds=$(( ${{ inputs.attempt_timeout_minutes }} * 60 ))
         attempt=1
         max_attempts=$(( 1 + ${{ inputs.retries }} ))  # Initial run + retries
         retries=${{ inputs.retries }}
@@ -79,7 +72,6 @@ runs:
         backoff="${{ inputs.backoff }}"
         jitter="${{ inputs.jitter }}"
         timeout_mins=${{ inputs.timeout_minutes }}
-        attempt_timeout_mins=${{ inputs.attempt_timeout_minutes }}
         shell_type="${{ inputs.shell }}"
         exit_code=0
 
@@ -90,8 +82,8 @@ runs:
         fi
 
         # Validate numeric inputs are non-negative integers
-        case "$retries$retry_delay$timeout_mins$attempt_timeout_mins" in
-            ''|*[!0-9]*) echo "::error::retries, retry_delay_seconds, timeout_minutes, and attempt_timeout_minutes must be non-negative integers"; exit 1 ;;
+        case "$retries$retry_delay$timeout_mins" in
+            ''|*[!0-9]*) echo "::error::retries, retry_delay_seconds, timeout_minutes must be non-negative integers"; exit 1 ;;
         esac
 
         # Create temporary script file with appropriate extension
@@ -133,17 +125,8 @@ runs:
                 echo "::group::Retry $((attempt - 1)) of $retries"
             fi
 
-            current_time=$(date +%s)
-            elapsed=$((current_time - start_time))
-            if [ "$elapsed" -gt "$timeout_seconds" ]; then
-                echo "::error::Step timed out after $timeout_mins minutes"
-                [ "$attempt" -gt 1 ] && echo "::endgroup::"
-                exit 1
-            fi
-
-            # Execute the script with an optional deadline, terminating its entire process tree on timeout.
-            if [ "$attempt_timeout_seconds" -gt 0 ]; then
-                python3 - "$shell_type" "$TEMP_SCRIPT" "$attempt_timeout_seconds" <<'PY'
+            # Execute the script with a deadline, terminating its entire process tree on timeout.
+            python3 - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" <<'PY'
         import os
         import signal
         import subprocess
@@ -171,15 +154,10 @@ runs:
                     os.killpg(process.pid, signal.SIGKILL)
             sys.exit(124)
         PY
-            elif [ "$shell_type" = "python" ]; then
-                python3 "$TEMP_SCRIPT"
-            else
-                bash -e "$TEMP_SCRIPT"
-            fi
             exit_code=$?
 
-            if [ "$exit_code" -eq 124 ] && [ "$attempt_timeout_seconds" -gt 0 ]; then
-                echo "::error::Attempt timed out after $attempt_timeout_mins minutes"
+            if [ "$exit_code" -eq 124 ]; then
+                echo "::error::Attempt timed out after $timeout_mins minutes"
             fi
 
             if [ "$exit_code" -eq 0 ]; then
@@ -215,12 +193,6 @@ runs:
                 delay=$((low + rand))
                 [ "$delay" -lt 1 ] && delay=1  # integer division floor; never collapse to 0
             fi
-
-            # Cap sleep at remaining timeout budget; no point sleeping past deadline.
-            # Refresh timestamp — the attempt may have taken significant time.
-            remaining=$((timeout_seconds - ($(date +%s) - start_time)))
-            [ "$delay" -gt "$remaining" ] && delay=$remaining
-            [ "$delay" -lt 0 ] && delay=0
 
             echo "Retrying in $delay seconds..."
             sleep "$delay"

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -178,7 +178,6 @@ runs:
             else
                 python3 - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" "$timeout_marker" <<'PY'
         import os
-        import select
         import signal
         import subprocess
         import sys
@@ -229,16 +228,7 @@ runs:
             if ctypes.CDLL(None, use_errno=True).prctl(36, 1, 0, 0, 0) != 0:
                 raise OSError(ctypes.get_errno(), "Unable to enable child subreaper")
         process = subprocess.Popen(command, env=environment, start_new_session=True)
-        process_queue, process_ids = None, set()
-        if sys.platform == "darwin":
-            process_queue = select.kqueue()
-            event = select.kevent(
-                process.pid,
-                filter=select.KQ_FILTER_PROC,
-                flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE,
-                fflags=select.KQ_NOTE_FORK | select.KQ_NOTE_TRACK | select.KQ_NOTE_EXIT,
-            )
-            process_queue.control([event], 0, 0)
+        process_ids = set()
         try:
             return_code = process.wait(timeout=timeout)
             sys.exit(128 - return_code if return_code < 0 else return_code)
@@ -246,16 +236,12 @@ runs:
             open(timeout_marker, "w").close()
             if sys.platform.startswith("linux"):
                 process_ids.update(descendants(os.getpid()))
-            elif process_queue:
-                process_ids.update(event.ident for event in process_queue.control(None, 1024, 0))
             process_ids.update(tracked_processes(token))
             send_signal(process.pid, process_ids, signal.SIGTERM)
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline:
                 if sys.platform.startswith("linux"):
                     process_ids.update(descendants(os.getpid()))
-                elif process_queue:
-                    process_ids.update(event.ident for event in process_queue.control(None, 1024, 0))
                 process_ids.update(tracked_processes(token))
                 process_ids = {pid for pid in process_ids if pid != os.getpid()}
                 if not process_ids:

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -133,11 +133,18 @@ runs:
                 RETRY_SHELL_TYPE="$shell_type" \
                 RETRY_TIMEOUT_SECONDS="$timeout_seconds" \
                 powershell.exe -NoProfile -Command '
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
         if ($env:RETRY_SHELL_TYPE -eq "python") {
-            $process = Start-Process py.exe -ArgumentList "-3", $env:RETRY_SCRIPT -NoNewWindow -PassThru
+            $startInfo.FileName = "py.exe"
+            $startInfo.Arguments = "-3 `"$env:RETRY_SCRIPT`""
         } else {
-            $process = Start-Process $env:RETRY_EXECUTABLE -ArgumentList "-e", $env:RETRY_SCRIPT -NoNewWindow -PassThru
+            $startInfo.FileName = $env:RETRY_EXECUTABLE
+            $startInfo.Arguments = "-e `"$env:RETRY_SCRIPT`""
         }
+        $startInfo.UseShellExecute = $false
+        $process = New-Object System.Diagnostics.Process
+        $process.StartInfo = $startInfo
+        [void]$process.Start()
         if (-not $process.WaitForExit([int]$env:RETRY_TIMEOUT_SECONDS * 1000)) {
             taskkill.exe /PID $process.Id /T /F | Out-Null
             exit 124

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -138,8 +138,8 @@ runs:
                 powershell.exe -NoProfile -Command '
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo
         if ($env:RETRY_SHELL_TYPE -eq "python") {
-            $startInfo.FileName = "py.exe"
-            $startInfo.Arguments = "-3 `"$env:RETRY_SCRIPT`""
+            $startInfo.FileName = "python.exe"
+            $startInfo.Arguments = "`"$env:RETRY_SCRIPT`""
         } else {
             $startInfo.FileName = $env:RETRY_EXECUTABLE
             $startInfo.Arguments = "-e `"$env:RETRY_SCRIPT`""
@@ -164,6 +164,32 @@ runs:
         import sys
         import time
 
+        def descendants(root_pid):
+            """Return all descendants of a process, including children in other process groups."""
+            children = {}
+            for line in subprocess.check_output(["ps", "-eo", "pid=,ppid="], text=True).splitlines():
+                pid, parent = map(int, line.split())
+                children.setdefault(parent, []).append(pid)
+            found, pending = set(), [root_pid]
+            while pending:
+                for pid in children.get(pending.pop(), []):
+                    if pid not in found:
+                        found.add(pid)
+                        pending.append(pid)
+            return found
+
+        def send_signal(process_group, process_ids, sig):
+            """Signal the process group and descendants that detached from it."""
+            try:
+                os.killpg(process_group, sig)
+            except (PermissionError, ProcessLookupError):
+                pass
+            for pid in process_ids:
+                try:
+                    os.kill(pid, sig)
+                except (PermissionError, ProcessLookupError):
+                    pass
+
         shell_type, script, timeout, timeout_marker = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
         command = [sys.executable, script] if shell_type == "python" else ["bash", "-e", script]
         process = subprocess.Popen(command, start_new_session=True)
@@ -172,22 +198,22 @@ runs:
             sys.exit(128 - return_code if return_code < 0 else return_code)
         except subprocess.TimeoutExpired:
             open(timeout_marker, "w").close()
-            try:
-                os.killpg(process.pid, signal.SIGTERM)
-            except ProcessLookupError:
-                pass
+            process_ids = descendants(process.pid)
+            send_signal(process.pid, process_ids, signal.SIGTERM)
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline:
-                try:
-                    os.killpg(process.pid, 0)
-                except (PermissionError, ProcessLookupError):
+                alive = set()
+                for pid in process_ids:
+                    try:
+                        os.kill(pid, 0)
+                        alive.add(pid)
+                    except (PermissionError, ProcessLookupError):
+                        pass
+                process_ids = alive
+                if process.poll() is not None and not process_ids:
                     break
                 time.sleep(0.1)
-            else:
-                try:
-                    os.killpg(process.pid, signal.SIGKILL)
-                except (PermissionError, ProcessLookupError):
-                    pass
+            send_signal(process.pid, process_ids, signal.SIGKILL)
             process.wait()
             sys.exit(124)
         PY

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -17,6 +17,7 @@
 #         pytest tests/
 #       retries: 2               # Retry twice after initial attempt (3 total runs)
 #       timeout_minutes: 30      # Total timeout for all attempts combined
+#       attempt_timeout_minutes: 10  # Maximum time for each attempt (0 disables)
 #       retry_delay_seconds: 10  # Base delay between retries in seconds
 #       backoff: exponential     # exponential (10s, 20s, 40s, ...) or fixed
 #       jitter: true             # Randomize delay to 80-120% to avoid thundering herd
@@ -33,6 +34,10 @@ inputs:
     description: "Number of retry attempts after initial run"
     required: false
     default: "3"
+  attempt_timeout_minutes:
+    description: "Maximum time in minutes for each attempt; 0 disables the per-attempt timeout"
+    required: false
+    default: "0"
   retry_delay_seconds:
     description: "Base delay between retries in seconds"
     required: false
@@ -66,6 +71,7 @@ runs:
 
         start_time=$(date +%s)
         timeout_seconds=$(( ${{ inputs.timeout_minutes }} * 60 ))
+        attempt_timeout_seconds=$(( ${{ inputs.attempt_timeout_minutes }} * 60 ))
         attempt=1
         max_attempts=$(( 1 + ${{ inputs.retries }} ))  # Initial run + retries
         retries=${{ inputs.retries }}
@@ -73,6 +79,7 @@ runs:
         backoff="${{ inputs.backoff }}"
         jitter="${{ inputs.jitter }}"
         timeout_mins=${{ inputs.timeout_minutes }}
+        attempt_timeout_mins=${{ inputs.attempt_timeout_minutes }}
         shell_type="${{ inputs.shell }}"
         exit_code=0
 
@@ -83,8 +90,8 @@ runs:
         fi
 
         # Validate numeric inputs are non-negative integers
-        case "$retries$retry_delay$timeout_mins" in
-            ''|*[!0-9]*) echo "::error::retries, retry_delay_seconds, timeout_minutes must be non-negative integers"; exit 1 ;;
+        case "$retries$retry_delay$timeout_mins$attempt_timeout_mins" in
+            ''|*[!0-9]*) echo "::error::retries, retry_delay_seconds, timeout_minutes, and attempt_timeout_minutes must be non-negative integers"; exit 1 ;;
         esac
 
         # Create temporary script file with appropriate extension
@@ -134,13 +141,46 @@ runs:
                 exit 1
             fi
 
-            # Execute the script with appropriate interpreter
-            if [ "$shell_type" = "python" ]; then
+            # Execute the script with an optional deadline, terminating its entire process tree on timeout.
+            if [ "$attempt_timeout_seconds" -gt 0 ]; then
+                python3 - "$shell_type" "$TEMP_SCRIPT" "$attempt_timeout_seconds" <<'PY'
+        import os
+        import signal
+        import subprocess
+        import sys
+
+        shell_type, script, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
+        command = ["python3", script] if shell_type == "python" else ["bash", "-e", script]
+        kwargs = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP} if os.name == "nt" else {"start_new_session": True}
+        process = subprocess.Popen(command, **kwargs)
+        try:
+            sys.exit(process.wait(timeout=timeout))
+        except subprocess.TimeoutExpired:
+            if os.name == "nt":
+                subprocess.run(
+                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                )
+            else:
+                os.killpg(process.pid, signal.SIGTERM)
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    os.killpg(process.pid, signal.SIGKILL)
+            sys.exit(124)
+        PY
+            elif [ "$shell_type" = "python" ]; then
                 python3 "$TEMP_SCRIPT"
             else
                 bash -e "$TEMP_SCRIPT"
             fi
             exit_code=$?
+
+            if [ "$exit_code" -eq 124 ] && [ "$attempt_timeout_seconds" -gt 0 ]; then
+                echo "::error::Attempt timed out after $attempt_timeout_mins minutes"
+            fi
 
             if [ "$exit_code" -eq 0 ]; then
                 [ "$attempt" -gt 1 ] && echo "::endgroup::"

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -74,8 +74,8 @@ runs:
         jitter="${{ inputs.jitter }}"
         timeout_mins=${{ inputs.timeout_minutes }}
         shell_type="${{ inputs.shell }}"
-        python_executable=python3
-        [ "$RETRY_RUNNER_OS" = "Windows" ] && python_executable=python
+        python_command=(python3)
+        [ "$RETRY_RUNNER_OS" = "Windows" ] && python_command=(py -3)
         exit_code=0
 
         # Validate backoff strategy
@@ -129,7 +129,7 @@ runs:
             fi
 
             # Execute the script with a deadline, terminating its entire process tree on timeout.
-            "$python_executable" - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" <<'PY'
+            "${python_command[@]}" - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" <<'PY'
         import os
         import signal
         import subprocess

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -87,6 +87,11 @@ runs:
             ''|*[!0-9]*) echo "::error::retries, retry_delay_seconds, timeout_minutes must be non-negative integers"; exit 1 ;;
         esac
 
+        if { [ "$RETRY_RUNNER_OS" != "Windows" ] || [ "$shell_type" = "python" ]; } && ! command -v python3 >/dev/null; then
+            echo "::error::Python 3 is required for timeout supervision on this runner"
+            exit 1
+        fi
+
         # Create temporary script file with appropriate extension
         if [ "$shell_type" = "python" ]; then
             if ! TEMP_SCRIPT=$(mktemp --suffix=.py 2>/dev/null); then
@@ -130,8 +135,10 @@ runs:
             timeout_marker="${TEMP_SCRIPT}.timeout"
             rm -f "$timeout_marker"
             if [ "$RETRY_RUNNER_OS" = "Windows" ]; then
+                retry_python=""
+                [ "$shell_type" = "python" ] && retry_python=$(cygpath -w "$(command -v python3)")
                 RETRY_EXECUTABLE=$(cygpath -w "$BASH") \
-                RETRY_PYTHON=$(cygpath -w "$(command -v python3)") \
+                RETRY_PYTHON="$retry_python" \
                 RETRY_SCRIPT=$(cygpath -w "$TEMP_SCRIPT") \
                 RETRY_SHELL_TYPE="$shell_type" \
                 RETRY_TIMEOUT_MARKER=$(cygpath -w "$timeout_marker") \
@@ -151,7 +158,18 @@ runs:
         [void]$process.Start()
         if (-not $process.WaitForExit([int]$env:RETRY_TIMEOUT_SECONDS * 1000)) {
             [System.IO.File]::WriteAllText($env:RETRY_TIMEOUT_MARKER, "")
-            taskkill.exe /PID $process.Id /T /F | Out-Null
+            $allProcesses = @(Get-CimInstance Win32_Process)
+            $descendants = @()
+            $parents = @($process.Id)
+            while ($parents.Count -gt 0) {
+                $children = @($allProcesses | Where-Object { $parents -contains [int]$_.ParentProcessId })
+                $parents = @($children | ForEach-Object { [int]$_.ProcessId })
+                $descendants += $parents
+            }
+            foreach ($id in @($process.Id) + $descendants) {
+                taskkill.exe /PID $id /T /F 2>$null | Out-Null
+                Stop-Process -Id $id -Force -ErrorAction SilentlyContinue
+            }
             exit 124
         }
         $process.WaitForExit()
@@ -160,11 +178,27 @@ runs:
             else
                 python3 - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" "$timeout_marker" <<'PY'
         import os
+        import select
         import signal
         import subprocess
         import sys
         import time
         import uuid
+
+        def descendants(root_pid):
+            """Return all current descendants of a process."""
+            children = {}
+            processes = subprocess.check_output(["ps", "ax", "-o", "pid=", "-o", "ppid="], text=True)
+            for line in processes.splitlines():
+                pid, parent = map(int, line.split())
+                children.setdefault(parent, []).append(pid)
+            found, pending = set(), [root_pid]
+            while pending:
+                for pid in children.get(pending.pop(), []):
+                    if pid not in found:
+                        found.add(pid)
+                        pending.append(pid)
+            return found
 
         def tracked_processes(token):
             """Return processes carrying the attempt's unique inherited environment marker."""
@@ -189,22 +223,46 @@ runs:
         token = uuid.uuid4().hex
         environment = os.environ.copy()
         environment["ULTRALYTICS_RETRY_TOKEN"] = token
+        if sys.platform.startswith("linux"):
+            import ctypes
+
+            if ctypes.CDLL(None, use_errno=True).prctl(36, 1, 0, 0, 0) != 0:
+                raise OSError(ctypes.get_errno(), "Unable to enable child subreaper")
         process = subprocess.Popen(command, env=environment, start_new_session=True)
+        process_queue, process_ids = None, set()
+        if sys.platform == "darwin":
+            process_queue = select.kqueue()
+            event = select.kevent(
+                process.pid,
+                filter=select.KQ_FILTER_PROC,
+                flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE,
+                fflags=select.KQ_NOTE_FORK | select.KQ_NOTE_TRACK | select.KQ_NOTE_EXIT,
+            )
+            process_queue.control([event], 0, 0)
         try:
             return_code = process.wait(timeout=timeout)
             sys.exit(128 - return_code if return_code < 0 else return_code)
         except subprocess.TimeoutExpired:
             open(timeout_marker, "w").close()
-            process_ids = tracked_processes(token)
+            if sys.platform.startswith("linux"):
+                process_ids.update(descendants(os.getpid()))
+            elif process_queue:
+                process_ids.update(event.ident for event in process_queue.control(None, 1024, 0))
+            process_ids.update(tracked_processes(token))
             send_signal(process.pid, process_ids, signal.SIGTERM)
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline:
-                process_ids = tracked_processes(token)
+                if sys.platform.startswith("linux"):
+                    process_ids.update(descendants(os.getpid()))
+                elif process_queue:
+                    process_ids.update(event.ident for event in process_queue.control(None, 1024, 0))
+                process_ids.update(tracked_processes(token))
+                process_ids = {pid for pid in process_ids if pid != os.getpid()}
                 if not process_ids:
                     break
                 send_signal(process.pid, process_ids, signal.SIGTERM)
                 time.sleep(0.1)
-            process_ids = tracked_processes(token)
+            process_ids.update(tracked_processes(token))
             send_signal(process.pid, process_ids, signal.SIGKILL)
             process.wait()
             sys.exit(124)

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -73,6 +73,8 @@ runs:
         jitter="${{ inputs.jitter }}"
         timeout_mins=${{ inputs.timeout_minutes }}
         shell_type="${{ inputs.shell }}"
+        python_executable=python3
+        [ "${RUNNER_OS:-}" = "Windows" ] && python_executable=python
         exit_code=0
 
         # Validate backoff strategy
@@ -126,7 +128,7 @@ runs:
             fi
 
             # Execute the script with a deadline, terminating its entire process tree on timeout.
-            python3 - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" <<'PY'
+            "$python_executable" - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" <<'PY'
         import os
         import signal
         import subprocess
@@ -134,7 +136,7 @@ runs:
         import time
 
         shell_type, script, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
-        command = ["python3", script] if shell_type == "python" else ["bash", "-e", script]
+        command = [sys.executable, script] if shell_type == "python" else ["bash", "-e", script]
         kwargs = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP} if os.name == "nt" else {"start_new_session": True}
         process = subprocess.Popen(command, **kwargs)
         try:

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -131,6 +131,7 @@ runs:
         import signal
         import subprocess
         import sys
+        import time
 
         shell_type, script, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
         command = ["python3", script] if shell_type == "python" else ["bash", "-e", script]
@@ -147,11 +148,23 @@ runs:
                     check=False,
                 )
             else:
-                os.killpg(process.pid, signal.SIGTERM)
                 try:
-                    process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    os.killpg(process.pid, signal.SIGKILL)
+                    os.killpg(process.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline:
+                    try:
+                        os.killpg(process.pid, 0)
+                    except ProcessLookupError:
+                        break
+                    time.sleep(0.1)
+                else:
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                process.wait()
             sys.exit(124)
         PY
             exit_code=$?

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -164,20 +164,13 @@ runs:
         import subprocess
         import sys
         import time
+        import uuid
 
-        def descendants(root_pid):
-            """Return all descendants of a process, including children in other process groups."""
-            children = {}
-            for line in subprocess.check_output(["ps", "-eo", "pid=,ppid="], text=True).splitlines():
-                pid, parent = map(int, line.split())
-                children.setdefault(parent, []).append(pid)
-            found, pending = set(), [root_pid]
-            while pending:
-                for pid in children.get(pending.pop(), []):
-                    if pid not in found:
-                        found.add(pid)
-                        pending.append(pid)
-            return found
+        def tracked_processes(token):
+            """Return processes carrying the attempt's unique inherited environment marker."""
+            marker = f"ULTRALYTICS_RETRY_TOKEN={token}"
+            processes = subprocess.check_output(["ps", "eww", "-axo", "pid=,command="], text=True)
+            return {int(line.split(None, 1)[0]) for line in processes.splitlines() if marker in line}
 
         def send_signal(process_group, process_ids, sig):
             """Signal the process group and descendants that detached from it."""
@@ -193,27 +186,25 @@ runs:
 
         shell_type, script, timeout, timeout_marker = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
         command = [sys.executable, script] if shell_type == "python" else ["bash", "-e", script]
-        process = subprocess.Popen(command, start_new_session=True)
+        token = uuid.uuid4().hex
+        environment = os.environ.copy()
+        environment["ULTRALYTICS_RETRY_TOKEN"] = token
+        process = subprocess.Popen(command, env=environment, start_new_session=True)
         try:
             return_code = process.wait(timeout=timeout)
             sys.exit(128 - return_code if return_code < 0 else return_code)
         except subprocess.TimeoutExpired:
             open(timeout_marker, "w").close()
-            process_ids = descendants(process.pid)
+            process_ids = tracked_processes(token)
             send_signal(process.pid, process_ids, signal.SIGTERM)
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline:
-                alive = set()
-                for pid in process_ids:
-                    try:
-                        os.kill(pid, 0)
-                        alive.add(pid)
-                    except (PermissionError, ProcessLookupError):
-                        pass
-                process_ids = alive
-                if process.poll() is not None and not process_ids:
+                process_ids = tracked_processes(token)
+                if not process_ids:
                     break
+                send_signal(process.pid, process_ids, signal.SIGTERM)
                 time.sleep(0.1)
+            process_ids = tracked_processes(token)
             send_signal(process.pid, process_ids, signal.SIGKILL)
             process.wait()
             sys.exit(124)

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -131,6 +131,7 @@ runs:
             rm -f "$timeout_marker"
             if [ "$RETRY_RUNNER_OS" = "Windows" ]; then
                 RETRY_EXECUTABLE=$(cygpath -w "$BASH") \
+                RETRY_PYTHON=$(cygpath -w "$(command -v python3)") \
                 RETRY_SCRIPT=$(cygpath -w "$TEMP_SCRIPT") \
                 RETRY_SHELL_TYPE="$shell_type" \
                 RETRY_TIMEOUT_MARKER=$(cygpath -w "$timeout_marker") \
@@ -138,7 +139,7 @@ runs:
                 powershell.exe -NoProfile -Command '
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo
         if ($env:RETRY_SHELL_TYPE -eq "python") {
-            $startInfo.FileName = "python.exe"
+            $startInfo.FileName = $env:RETRY_PYTHON
             $startInfo.Arguments = "`"$env:RETRY_SCRIPT`""
         } else {
             $startInfo.FileName = $env:RETRY_EXECUTABLE

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -187,10 +187,14 @@ runs:
         def descendants(root_pid):
             """Return all current descendants of a process."""
             children = {}
-            processes = subprocess.check_output(["ps", "ax", "-o", "pid=", "-o", "ppid="], text=True)
-            for line in processes.splitlines():
-                pid, parent = map(int, line.split())
-                children.setdefault(parent, []).append(pid)
+            for entry in os.scandir("/proc"):
+                if entry.name.isdigit():
+                    try:
+                        with open(f"{entry.path}/stat") as file:
+                            stat = file.read()
+                        children.setdefault(int(stat[stat.rfind(")") + 2 :].split()[1]), []).append(int(entry.name))
+                    except (FileNotFoundError, PermissionError, ValueError):
+                        pass
             found, pending = set(), [root_pid]
             while pending:
                 for pid in children.get(pending.pop(), []):
@@ -235,20 +239,26 @@ runs:
         except subprocess.TimeoutExpired:
             open(timeout_marker, "w").close()
             if sys.platform.startswith("linux"):
-                process_ids.update(descendants(os.getpid()))
-            process_ids.update(tracked_processes(token))
+                process_ids = descendants(os.getpid())
+            process_ids |= tracked_processes(token)
             send_signal(process.pid, process_ids, signal.SIGTERM)
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline:
                 if sys.platform.startswith("linux"):
-                    process_ids.update(descendants(os.getpid()))
-                process_ids.update(tracked_processes(token))
+                    process_ids = descendants(os.getpid())
+                else:
+                    process_ids = set()
+                process_ids |= tracked_processes(token)
                 process_ids = {pid for pid in process_ids if pid != os.getpid()}
                 if not process_ids:
                     break
                 send_signal(process.pid, process_ids, signal.SIGTERM)
                 time.sleep(0.1)
-            process_ids.update(tracked_processes(token))
+            if sys.platform.startswith("linux"):
+                process_ids = descendants(os.getpid())
+            else:
+                process_ids = set()
+            process_ids |= tracked_processes(token)
             send_signal(process.pid, process_ids, signal.SIGKILL)
             process.wait()
             sys.exit(124)

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -162,36 +162,27 @@ runs:
 
         shell_type, script, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
         command = [sys.executable, script] if shell_type == "python" else ["bash", "-e", script]
-        kwargs = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP} if os.name == "nt" else {"start_new_session": True}
-        process = subprocess.Popen(command, **kwargs)
+        process = subprocess.Popen(command, start_new_session=True)
         try:
             sys.exit(process.wait(timeout=timeout))
         except subprocess.TimeoutExpired:
-            if os.name == "nt":
-                subprocess.run(
-                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=False,
-                )
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                try:
+                    os.killpg(process.pid, 0)
+                except ProcessLookupError:
+                    break
+                time.sleep(0.1)
             else:
                 try:
-                    os.killpg(process.pid, signal.SIGTERM)
+                    os.killpg(process.pid, signal.SIGKILL)
                 except ProcessLookupError:
                     pass
-                deadline = time.monotonic() + 5
-                while time.monotonic() < deadline:
-                    try:
-                        os.killpg(process.pid, 0)
-                    except ProcessLookupError:
-                        break
-                    time.sleep(0.1)
-                else:
-                    try:
-                        os.killpg(process.pid, signal.SIGKILL)
-                    except ProcessLookupError:
-                        pass
-                process.wait()
+            process.wait()
             sys.exit(124)
         PY
             fi

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -74,8 +74,6 @@ runs:
         jitter="${{ inputs.jitter }}"
         timeout_mins=${{ inputs.timeout_minutes }}
         shell_type="${{ inputs.shell }}"
-        python_command=(python3)
-        [ "$RETRY_RUNNER_OS" = "Windows" ] && python_command=(py -3)
         exit_code=0
 
         # Validate backoff strategy
@@ -129,7 +127,25 @@ runs:
             fi
 
             # Execute the script with a deadline, terminating its entire process tree on timeout.
-            "${python_command[@]}" - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" <<'PY'
+            if [ "$RETRY_RUNNER_OS" = "Windows" ]; then
+                RETRY_EXECUTABLE=$(cygpath -w "$BASH") \
+                RETRY_SCRIPT=$(cygpath -w "$TEMP_SCRIPT") \
+                RETRY_SHELL_TYPE="$shell_type" \
+                RETRY_TIMEOUT_SECONDS="$timeout_seconds" \
+                powershell.exe -NoProfile -Command '
+        if ($env:RETRY_SHELL_TYPE -eq "python") {
+            $process = Start-Process py.exe -ArgumentList "-3", $env:RETRY_SCRIPT -NoNewWindow -PassThru
+        } else {
+            $process = Start-Process $env:RETRY_EXECUTABLE -ArgumentList "-e", $env:RETRY_SCRIPT -NoNewWindow -PassThru
+        }
+        if (-not $process.WaitForExit([int]$env:RETRY_TIMEOUT_SECONDS * 1000)) {
+            taskkill.exe /PID $process.Id /T /F | Out-Null
+            exit 124
+        }
+        exit $process.ExitCode
+        '
+            else
+                python3 - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" <<'PY'
         import os
         import signal
         import subprocess
@@ -170,6 +186,7 @@ runs:
                 process.wait()
             sys.exit(124)
         PY
+            fi
             exit_code=$?
 
             if [ "$exit_code" -eq 124 ]; then

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -59,8 +59,9 @@ runs:
     - name: Execute with retry
       shell: bash
       env:
-        # Note: Workflow env vars are automatically inherited. Only RETRY_COMMANDS is added here.
+        # Note: Workflow env vars are automatically inherited.
         RETRY_COMMANDS: ${{ inputs.run }}
+        RETRY_RUNNER_OS: ${{ runner.os }}
       run: |
         set +e  # Don't exit on error - we handle errors manually
 
@@ -74,7 +75,7 @@ runs:
         timeout_mins=${{ inputs.timeout_minutes }}
         shell_type="${{ inputs.shell }}"
         python_executable=python3
-        [ "${RUNNER_OS:-}" = "Windows" ] && python_executable=python
+        [ "$RETRY_RUNNER_OS" = "Windows" ] && python_executable=python
         exit_code=0
 
         # Validate backoff strategy

--- a/retry/action.yml
+++ b/retry/action.yml
@@ -110,7 +110,7 @@ runs:
         fi
 
         # Ensure cleanup on exit
-        trap 'rm -f "$TEMP_SCRIPT"' EXIT
+        trap 'rm -f "$TEMP_SCRIPT" "${TEMP_SCRIPT}.timeout"' EXIT
 
         # Write the user's commands to the temp script
         printf '%s\n' "$RETRY_COMMANDS" > "$TEMP_SCRIPT"
@@ -127,10 +127,13 @@ runs:
             fi
 
             # Execute the script with a deadline, terminating its entire process tree on timeout.
+            timeout_marker="${TEMP_SCRIPT}.timeout"
+            rm -f "$timeout_marker"
             if [ "$RETRY_RUNNER_OS" = "Windows" ]; then
                 RETRY_EXECUTABLE=$(cygpath -w "$BASH") \
                 RETRY_SCRIPT=$(cygpath -w "$TEMP_SCRIPT") \
                 RETRY_SHELL_TYPE="$shell_type" \
+                RETRY_TIMEOUT_MARKER=$(cygpath -w "$timeout_marker") \
                 RETRY_TIMEOUT_SECONDS="$timeout_seconds" \
                 powershell.exe -NoProfile -Command '
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo
@@ -146,6 +149,7 @@ runs:
         $process.StartInfo = $startInfo
         [void]$process.Start()
         if (-not $process.WaitForExit([int]$env:RETRY_TIMEOUT_SECONDS * 1000)) {
+            [System.IO.File]::WriteAllText($env:RETRY_TIMEOUT_MARKER, "")
             taskkill.exe /PID $process.Id /T /F | Out-Null
             exit 124
         }
@@ -153,19 +157,21 @@ runs:
         exit $process.ExitCode
         '
             else
-                python3 - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" <<'PY'
+                python3 - "$shell_type" "$TEMP_SCRIPT" "$timeout_seconds" "$timeout_marker" <<'PY'
         import os
         import signal
         import subprocess
         import sys
         import time
 
-        shell_type, script, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
+        shell_type, script, timeout, timeout_marker = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
         command = [sys.executable, script] if shell_type == "python" else ["bash", "-e", script]
         process = subprocess.Popen(command, start_new_session=True)
         try:
-            sys.exit(process.wait(timeout=timeout))
+            return_code = process.wait(timeout=timeout)
+            sys.exit(128 - return_code if return_code < 0 else return_code)
         except subprocess.TimeoutExpired:
+            open(timeout_marker, "w").close()
             try:
                 os.killpg(process.pid, signal.SIGTERM)
             except ProcessLookupError:
@@ -174,13 +180,13 @@ runs:
             while time.monotonic() < deadline:
                 try:
                     os.killpg(process.pid, 0)
-                except ProcessLookupError:
+                except (PermissionError, ProcessLookupError):
                     break
                 time.sleep(0.1)
             else:
                 try:
                     os.killpg(process.pid, signal.SIGKILL)
-                except ProcessLookupError:
+                except (PermissionError, ProcessLookupError):
                     pass
             process.wait()
             sys.exit(124)
@@ -188,7 +194,7 @@ runs:
             fi
             exit_code=$?
 
-            if [ "$exit_code" -eq 124 ]; then
+            if [ -f "$timeout_marker" ]; then
                 echo "::error::Attempt timed out after $timeout_mins minutes"
             fi
 


### PR DESCRIPTION
## Summary

- make the existing timeout_minutes input bound each retry attempt
- terminate the full child process tree when an attempt hangs
- verify timeout-and-retry behavior on Linux, macOS, and Windows
- bump ultralytics-actions from 0.3.9 to 0.3.10

## Motivation

The scheduled Ultralytics CI run https://github.com/ultralytics/ultralytics/actions/runs/31935546886 spent six hours in one hung pytest process. The retry wrapper only checked its timeout between completed attempts, so it could neither interrupt the hang nor reach its retry.

A local inventory found 53 uses across 13 repositories. Their explicit values (5-120 minutes) already match per-attempt workloads, while each workflow job remains the owner of its overall ceiling.

## Validation

- local process-tree timeout and retry simulation with a SIGTERM-ignoring descendant
- 166 package tests passed
- Ruff, Actionlint, Prettier, and diff checks passed
- cross-platform retry-action CI pending on the final head

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The retry action now enforces `timeout_minutes` separately for each attempt and terminates timed-out process trees so retries can proceed instead of waiting indefinitely.

### 📊 Key Changes

- Replaced the previous between-attempt timeout check with active per-attempt supervision.
- Added Linux and macOS timeout handling using Python process groups, descendant tracking, and termination signals.
- Added Windows timeout handling with PowerShell process discovery and `taskkill` process-tree termination.
- Updated `timeout_minutes` documentation and bumped the action version from `0.3.9` to `0.3.10`.
- Expanded retry tests across Ubuntu, macOS, and Windows, including hung commands, detached descendants, and Windows Python-shell execution.

### 🎯 Purpose & Impact

- A hung attempt is interrupted after its configured timeout, its tracked child processes are terminated, and the configured retry sequence can continue.
- `timeout_minutes` now limits each attempt rather than the combined retry sequence; retry delays are no longer capped by a shared timeout budget.
- Timeout supervision requires Python 3 on Linux and macOS, while detached macOS descendants that clear their inherited environment remain outside the documented containment boundary.