### PR TITLE
Avoid overlapping JavaScript formatters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -218,7 +218,7 @@ runs:
         chmod +x "$(npm prefix -g)/bin/shfmt"
         ultralytics-actions-update-markdown-code-blocks
         extensions="css,less,scss,yml,yaml,html,vue,svelte"
-        [ "${INPUTS_BIOME:-false}" = "true" ] || extensions="js,jsx,ts,tsx,json,$extensions"
+        [ "${INPUTS_BIOME:-false}" = "true" ] && { [ -f "biome.json" ] || [ -f "biome.jsonc" ]; } || extensions="js,jsx,ts,tsx,json,$extensions"
         npx prettier --write --list-different --print-width 120 "**/*.{$extensions}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
         # Handle Markdown separately
         find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +

--- a/action.yml
+++ b/action.yml
@@ -208,14 +208,18 @@ runs:
     # Prettier (JavaScript, JSX, Angular, Vue, Flow, TypeScript, CSS, HTML, JSON, GraphQL, Markdown, YAML) -------------
     - name: Run Prettier
       if: github.event_name == 'pull_request' && (inputs.prettier == 'true' || inputs.markdown == 'true') && (github.event.action == 'opened' || github.event.action == 'synchronize')
+      env:
+        INPUTS_BIOME: ${{ inputs.biome }}
       run: |
         echo "::group::Run Prettier"
         trap 'echo "::endgroup::"' EXIT
-        npm install -g prettier@3.8.5
+        npm install -g prettier@latest
         curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt"
         chmod +x "$(npm prefix -g)/bin/shfmt"
         ultralytics-actions-update-markdown-code-blocks
-        npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
+        extensions="css,less,scss,yml,yaml,html,vue,svelte"
+        [ "${INPUTS_BIOME:-false}" = "true" ] || extensions="js,jsx,ts,tsx,json,$extensions"
+        npx prettier --write --list-different --print-width 120 "**/*.{$extensions}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
         # Handle Markdown separately
         find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
         if [ -d "./docs" ]; then

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.10"
+__version__ = "0.3.11"

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -24,7 +24,7 @@ curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_
 chmod +x "$(npm prefix -g)/bin/shfmt"
 ultralytics-actions-update-markdown-code-blocks
 extensions="css,less,scss,yml,yaml,html,vue,svelte"
-[ "${INPUTS_BIOME:-false}" = "true" ] || extensions="js,jsx,ts,tsx,json,$extensions"
+[ "${INPUTS_BIOME:-false}" = "true" ] && { [ -f "biome.json" ] || [ -f "biome.jsonc" ]; } || extensions="js,jsx,ts,tsx,json,$extensions"
 npx prettier --write --list-different --print-width 120 "**/*.{$extensions}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
 # Handle Markdown separately
 find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -19,11 +19,13 @@ RUFF_CHECK = [
 RUFF_FORMAT = ["ruff", "format", "--line-length=120", "."]
 DOCSTRINGS = ["ultralytics-actions-format-python-docstrings", "."]
 PRETTIER = """
-npm install -g prettier@3.8.5
+npm install -g prettier@latest
 curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt"
 chmod +x "$(npm prefix -g)/bin/shfmt"
 ultralytics-actions-update-markdown-code-blocks
-npx prettier --write --list-different --print-width 120 "**/*.{js,jsx,ts,tsx,css,less,scss,json,yml,yaml,html,vue,svelte}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
+extensions="css,less,scss,yml,yaml,html,vue,svelte"
+[ "${INPUTS_BIOME:-false}" = "true" ] || extensions="js,jsx,ts,tsx,json,$extensions"
+npx prettier --write --list-different --print-width 120 "**/*.{$extensions}" '!**/*lock.{json,yaml,yml}' '!**/*.lock' '!**/model.json' '!**/*.min.js' '!**/*.min.css'
 # Handle Markdown separately
 find . -name "*.md" -type f ! -path "*/docs/*" -exec npx prettier --write --list-different --print-width 120 {} +
 if [ -d "./docs" ]; then


### PR DESCRIPTION
## Summary

- update the shared formatter to install the latest stable Prettier release
- leave JavaScript, TypeScript, and JSON exclusively to Biome when Biome is enabled
- preserve Prettier coverage for repositories that do not enable Biome

## Validation

- `uv run --extra dev pytest tests -q`
- `uv run ruff check --extend-select F,I,D,UP,RUF,FA --target-version py38 --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 actions/format_code.py tests/test_format_code.py`
- `uv run ruff format --line-length 120 --check actions/format_code.py tests/test_format_code.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the shared formatter to use the latest Prettier release and avoid formatting JavaScript, TypeScript, and JSON files with Prettier when a Biome configuration is present.

### 📊 Key Changes

- Changed Prettier installation from version `3.8.5` to `prettier@latest` in both formatter workflows.
- Added Biome-aware extension selection using the `biome` input and `biome.json` or `biome.jsonc` configuration files.
- Excluded JavaScript, JSX, TypeScript, TSX, and JSON from Prettier when Biome is enabled and configured.
- Preserved those Prettier extensions when Biome is not enabled or no Biome configuration file exists.
- Incremented the package version from `0.3.10` to `0.3.11`.

### 🎯 Purpose & Impact

- Repositories using Biome no longer have JavaScript, TypeScript, or JSON files processed by both formatters, while repositories without Biome retain the existing Prettier coverage.