### PR TITLE
Restore pinned Prettier formatter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -213,7 +213,7 @@ runs:
       run: |
         echo "::group::Run Prettier"
         trap 'echo "::endgroup::"' EXIT
-        npm install -g prettier@latest
+        npm install -g prettier@3.8.5
         curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt"
         chmod +x "$(npm prefix -g)/bin/shfmt"
         ultralytics-actions-update-markdown-code-blocks

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.11"
+__version__ = "0.3.12"

--- a/actions/format_code.py
+++ b/actions/format_code.py
@@ -19,7 +19,7 @@ RUFF_CHECK = [
 RUFF_FORMAT = ["ruff", "format", "--line-length=120", "."]
 DOCSTRINGS = ["ultralytics-actions-format-python-docstrings", "."]
 PRETTIER = """
-npm install -g prettier@latest
+npm install -g prettier@3.8.5
 curl -fsSL "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o "$(npm prefix -g)/bin/shfmt"
 chmod +x "$(npm prefix -g)/bin/shfmt"
 ultralytics-actions-update-markdown-code-blocks


### PR DESCRIPTION
Restores the Prettier 3.8.5 pin that #880 accidentally replaced with `@latest`. The floating version rewrites unrelated Markdown across every consumer PR and can corrupt MiniJinja macro tables. Both formatter owners now use the same deterministic version again.\n\nValidation: `uv run --extra dev pytest tests/test_format_code.py -q` (4 passed).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Restored the pinned Prettier 3.8.5 version in both formatting paths and bumped the package version to 0.3.12 to make Markdown formatting deterministic.

### 📊 Key Changes

- Changed the GitHub Action workflow from `prettier@latest` to `prettier@3.8.5`.
- Changed the `format_code.py` formatter command to install the same pinned Prettier version.
- Updated `actions.__version__` from `0.3.11` to `0.3.12`.
- The PR reports that the formatter tests pass: `4 passed`.

### 🎯 Purpose & Impact

- Formatting runs now use Prettier 3.8.5 consistently instead of a floating latest release, preventing unrelated Markdown rewrites and the reported risk of corrupting MiniJinja macro tables.