### PR TITLE
Reject files over 1 MB during PR review

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.12"
+__version__ = "0.3.13"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -38,6 +38,7 @@ MAX_HISTORY_ITEM_CHARS = 8000  # per prior review or response, enough for a full
 MAX_HISTORY_CHARS = 20000
 MAX_FINDING_LOG_CHARS = 500  # per finding logged in the review body, the record that outlives its inline comment
 REVIEW_COST_SOFT_LIMIT = 5.00  # quality-first budget; stop requesting tools after this soft limit
+MAX_APPROVED_FILE_SIZE = 1_000_000
 SEVERITY_RANK = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "SUGGESTION": 4, None: 5}
 
 
@@ -91,6 +92,40 @@ def search_repo(query: str, path_glob=None) -> str:
 def _clip(text: str, limit: int | None) -> str:
     """Clip text to at most limit characters, or return it unchanged when no limit is given."""
     return text if not limit or len(text) <= limit else f"{text[: limit - 1].rstrip()}…"
+
+
+def _oversized_files(
+    paths: list[str], event: Action, head_sha: str, local_checkout: bool
+) -> tuple[list[str], list[str]]:
+    """Return changed files over the approval limit and files whose size could not be verified."""
+    root = Path.cwd().resolve()
+    oversized, unverified = [], []
+    for path in sorted(set(paths)):
+        if local_checkout:
+            target = (root / path).resolve()
+            try:
+                target.relative_to(root)
+            except ValueError:
+                unverified.append(path)
+                continue
+            if not target.exists():  # deleted file
+                continue
+            try:
+                size = target.stat().st_size
+            except OSError:
+                unverified.append(path)
+                continue
+        else:
+            url = f"{GITHUB_API_URL}/repos/{event.repository}/contents/{quote(path, safe='/')}?ref={head_sha}"
+            response = event.get(url)
+            if response.status_code == 404:  # deleted file
+                continue
+            if response.status_code != 200 or not isinstance((size := response.json().get("size")), int):
+                unverified.append(path)
+                continue
+        if size > MAX_APPROVED_FILE_SIZE:
+            oversized.append(path)
+    return oversized, unverified
 
 
 def _build_review_history(reviews: list[dict], comments: list[dict], bot_username: str | None) -> dict:
@@ -482,29 +517,40 @@ def generate_pr_review(
     head_sha = head_sha or (event.get_pr_head_sha() if event else None)
     if diff_text.startswith("ERROR:"):
         return {"comments": [], "summary": f"{ERROR_MARKER}: {diff_text}", "head_sha": head_sha}
-    if not diff_text:
-        if skipped_files:
-            return {
-                "comments": [],
-                "summary": f"All {len(skipped_files)} changed files are generated/vendored (skipped review)",
-                "skipped_files": skipped_files,
-                "head_sha": head_sha,
-            }
-        return {"comments": [], "summary": "No changes detected in diff", "head_sha": head_sha}
-
-    diff_files, augmented_diff = parse_diff_files(diff_text)
-    if not diff_files:
-        return {"comments": [], "summary": "No reviewable text changes detected in diff", "head_sha": head_sha}
-
+    diff_files, augmented_diff = parse_diff_files(diff_text) if diff_text else ({}, "")
     file_list = list(diff_files.keys())
+    local_checkout = _verified_local_checkout(head_sha)
+    if head_sha:
+        print(f"Reviewing PR head {head_sha[:7]} ({'local checkout' if local_checkout else 'via GitHub API'})")
+    oversized_files, unverified_sizes = _oversized_files(file_list + skipped_files, event, head_sha, local_checkout)
+    if oversized_files or unverified_sizes:
+        details = []
+        if oversized_files:
+            details.append(f"Files larger than 1 MB: {', '.join(f'`{path}`' for path in oversized_files)}")
+        if unverified_sizes:
+            details.append(f"File sizes could not be verified: {', '.join(f'`{path}`' for path in unverified_sizes)}")
+        return {
+            "comments": [],
+            "summary": "Cannot approve this PR. " + " ".join(details),
+            "diff_files": diff_files,
+            "oversized_files": oversized_files,
+            "unverified_sizes": unverified_sizes,
+            "skipped_files": skipped_files,
+            "head_sha": head_sha,
+        }
+    if not diff_files:
+        summary = (
+            f"All {len(skipped_files)} changed files are generated/vendored (skipped review)"
+            if skipped_files
+            else "No changes detected in diff"
+        )
+        return {"comments": [], "summary": summary, "skipped_files": skipped_files, "head_sha": head_sha}
+
     lines_changed = sum(len(sides["RIGHT"]) + len(sides["LEFT"]) for sides in diff_files.values())
 
     # Read model-appropriate guidelines from the PR head for project-specific review context
     review_model = get_review_model()
     is_agent_review_model = not _is_anthropic_model(review_model)
-    local_checkout = _verified_local_checkout(head_sha)
-    if head_sha:
-        print(f"Reviewing PR head {head_sha[:7]} ({'local checkout' if local_checkout else 'via GitHub API'})")
     guidelines_section = get_repo_guidelines(review_model, event, head_sha, local_checkout)
 
     # Carry prior reviews of this PR forward so findings are not repeated, contradicted, or silently reversed
@@ -884,6 +930,8 @@ def post_review_summary(event: Action, review_data: dict, review_number: int = 1
             or has_inline_comments
             or has_issues
             or review_data.get("diff_truncated")
+            or review_data.get("oversized_files")
+            or review_data.get("unverified_sizes")
         )
         else "APPROVE"
     )

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -95,12 +95,18 @@ def _clip(text: str, limit: int | None) -> str:
 
 
 def _oversized_files(
-    paths: list[str], event: Action, head_sha: str, local_checkout: bool
+    changed_files: list[dict], event: Action, head_sha: str, local_checkout: bool
 ) -> tuple[list[str], list[str]]:
     """Return changed files over the approval limit and files whose size could not be verified."""
     root = Path.cwd().resolve()
     oversized, unverified = [], []
-    for path in sorted(set(paths)):
+    for file in changed_files:
+        path, status = file.get("filename"), file.get("status")
+        if not path or not status:
+            unverified.append(path or "unknown changed file")
+            continue
+        if status == "removed":
+            continue
         if local_checkout:
             target = (root / path).resolve()
             try:
@@ -108,7 +114,8 @@ def _oversized_files(
             except ValueError:
                 unverified.append(path)
                 continue
-            if not target.exists():  # deleted file
+            if not target.exists():
+                unverified.append(path)
                 continue
             try:
                 size = target.stat().st_size
@@ -118,8 +125,6 @@ def _oversized_files(
         else:
             url = f"{GITHUB_API_URL}/repos/{event.repository}/contents/{quote(path, safe='/')}?ref={head_sha}"
             response = event.get(url)
-            if response.status_code == 404:  # deleted file
-                continue
             if response.status_code != 200 or not isinstance((size := response.json().get("size")), int):
                 unverified.append(path)
                 continue
@@ -522,7 +527,9 @@ def generate_pr_review(
     local_checkout = _verified_local_checkout(head_sha)
     if head_sha:
         print(f"Reviewing PR head {head_sha[:7]} ({'local checkout' if local_checkout else 'via GitHub API'})")
-    oversized_files, unverified_sizes = _oversized_files(file_list + skipped_files, event, head_sha, local_checkout)
+    files_url = f"{GITHUB_API_URL}/repos/{repository}/pulls/{event.pr.get('number')}/files"
+    changed_files = event.paginate(files_url, hard=True)
+    oversized_files, unverified_sizes = _oversized_files(changed_files, event, head_sha, local_checkout)
     if oversized_files or unverified_sizes:
         details = []
         if oversized_files:

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -594,6 +594,7 @@ def generate_pr_review(
         "- Security vulnerabilities, data loss, corruption, or irreversible behavior\n"
         "- Bugs, broken contracts, race conditions, and compatibility regressions with a concrete failure path\n"
         "- Performance regressions with a plausible workload and measurable impact\n"
+        "- Never approve any added file larger than 1 MB, regardless of type\n"
         "- Maintainability only when the change creates demonstrated duplication, conflicting owners, or unreachable behavior\n\n"
         "WHEN NOT TO COMMENT:\n"
         "- Style/formatting (handled by ruff/prettier)\n"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -29,6 +29,7 @@ ERROR_MARKER = "⚠️ Review generation encountered an error"
 EMOJI_MAP = {"CRITICAL": "❗", "HIGH": "⚠️", "MEDIUM": "💡", "LOW": "📝", "SUGGESTION": "💭"}
 MAX_CONTEXT_FILE_CHARS = 12000
 MAX_REVIEW_COMMENTS = 8
+MAX_PULL_FILES = 3000
 MAX_TOOL_OUTPUT_CHARS = 40000
 MAX_TOOL_FILE_LINES = 400
 MAX_AGENT_TURNS = 24
@@ -529,7 +530,10 @@ def generate_pr_review(
         print(f"Reviewing PR head {head_sha[:7]} ({'local checkout' if local_checkout else 'via GitHub API'})")
     files_url = f"{GITHUB_API_URL}/repos/{repository}/pulls/{event.pr.get('number')}/files"
     changed_files = event.paginate(files_url, hard=True)
-    oversized_files, unverified_sizes = _oversized_files(changed_files, event, head_sha, local_checkout)
+    if len(changed_files) >= MAX_PULL_FILES:
+        oversized_files, unverified_sizes = [], ["PR file list reached GitHub's 3,000-file limit"]
+    else:
+        oversized_files, unverified_sizes = _oversized_files(changed_files, event, head_sha, local_checkout)
     if oversized_files or unverified_sizes:
         details = []
         if oversized_files:

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -29,7 +29,6 @@ ERROR_MARKER = "⚠️ Review generation encountered an error"
 EMOJI_MAP = {"CRITICAL": "❗", "HIGH": "⚠️", "MEDIUM": "💡", "LOW": "📝", "SUGGESTION": "💭"}
 MAX_CONTEXT_FILE_CHARS = 12000
 MAX_REVIEW_COMMENTS = 8
-MAX_PULL_FILES = 3000
 MAX_TOOL_OUTPUT_CHARS = 40000
 MAX_TOOL_FILE_LINES = 400
 MAX_AGENT_TURNS = 24
@@ -39,7 +38,6 @@ MAX_HISTORY_ITEM_CHARS = 8000  # per prior review or response, enough for a full
 MAX_HISTORY_CHARS = 20000
 MAX_FINDING_LOG_CHARS = 500  # per finding logged in the review body, the record that outlives its inline comment
 REVIEW_COST_SOFT_LIMIT = 5.00  # quality-first budget; stop requesting tools after this soft limit
-MAX_APPROVED_FILE_SIZE = 1_000_000
 SEVERITY_RANK = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "SUGGESTION": 4, None: 5}
 
 
@@ -93,45 +91,6 @@ def search_repo(query: str, path_glob=None) -> str:
 def _clip(text: str, limit: int | None) -> str:
     """Clip text to at most limit characters, or return it unchanged when no limit is given."""
     return text if not limit or len(text) <= limit else f"{text[: limit - 1].rstrip()}…"
-
-
-def _oversized_files(
-    changed_files: list[dict], event: Action, head_sha: str, local_checkout: bool
-) -> tuple[list[str], list[str]]:
-    """Return changed files over the approval limit and files whose size could not be verified."""
-    root = Path.cwd().resolve()
-    oversized, unverified = [], []
-    for file in changed_files:
-        path, status = file.get("filename"), file.get("status")
-        if not path or not status:
-            unverified.append(path or "unknown changed file")
-            continue
-        if status == "removed":
-            continue
-        if local_checkout:
-            target = (root / path).resolve()
-            try:
-                target.relative_to(root)
-            except ValueError:
-                unverified.append(path)
-                continue
-            if not target.exists():
-                unverified.append(path)
-                continue
-            try:
-                size = target.stat().st_size
-            except OSError:
-                unverified.append(path)
-                continue
-        else:
-            url = f"{GITHUB_API_URL}/repos/{event.repository}/contents/{quote(path, safe='/')}?ref={head_sha}"
-            response = event.get(url)
-            if response.status_code != 200 or not isinstance((size := response.json().get("size")), int):
-                unverified.append(path)
-                continue
-        if size > MAX_APPROVED_FILE_SIZE:
-            oversized.append(path)
-    return oversized, unverified
 
 
 def _build_review_history(reviews: list[dict], comments: list[dict], bot_username: str | None) -> dict:
@@ -523,45 +482,29 @@ def generate_pr_review(
     head_sha = head_sha or (event.get_pr_head_sha() if event else None)
     if diff_text.startswith("ERROR:"):
         return {"comments": [], "summary": f"{ERROR_MARKER}: {diff_text}", "head_sha": head_sha}
-    diff_files, augmented_diff = parse_diff_files(diff_text) if diff_text else ({}, "")
-    file_list = list(diff_files.keys())
-    local_checkout = _verified_local_checkout(head_sha)
-    if head_sha:
-        print(f"Reviewing PR head {head_sha[:7]} ({'local checkout' if local_checkout else 'via GitHub API'})")
-    files_url = f"{GITHUB_API_URL}/repos/{repository}/pulls/{event.pr.get('number')}/files"
-    changed_files = event.paginate(files_url, hard=True)
-    if len(changed_files) >= MAX_PULL_FILES:
-        oversized_files, unverified_sizes = [], ["PR file list reached GitHub's 3,000-file limit"]
-    else:
-        oversized_files, unverified_sizes = _oversized_files(changed_files, event, head_sha, local_checkout)
-    if oversized_files or unverified_sizes:
-        details = []
-        if oversized_files:
-            details.append(f"Files larger than 1 MB: {', '.join(f'`{path}`' for path in oversized_files)}")
-        if unverified_sizes:
-            details.append(f"File sizes could not be verified: {', '.join(f'`{path}`' for path in unverified_sizes)}")
-        return {
-            "comments": [],
-            "summary": "Cannot approve this PR. " + " ".join(details),
-            "diff_files": diff_files,
-            "oversized_files": oversized_files,
-            "unverified_sizes": unverified_sizes,
-            "skipped_files": skipped_files,
-            "head_sha": head_sha,
-        }
-    if not diff_files:
-        summary = (
-            f"All {len(skipped_files)} changed files are generated/vendored (skipped review)"
-            if skipped_files
-            else "No changes detected in diff"
-        )
-        return {"comments": [], "summary": summary, "skipped_files": skipped_files, "head_sha": head_sha}
+    if not diff_text:
+        if skipped_files:
+            return {
+                "comments": [],
+                "summary": f"All {len(skipped_files)} changed files are generated/vendored (skipped review)",
+                "skipped_files": skipped_files,
+                "head_sha": head_sha,
+            }
+        return {"comments": [], "summary": "No changes detected in diff", "head_sha": head_sha}
 
+    diff_files, augmented_diff = parse_diff_files(diff_text)
+    if not diff_files:
+        return {"comments": [], "summary": "No reviewable text changes detected in diff", "head_sha": head_sha}
+
+    file_list = list(diff_files.keys())
     lines_changed = sum(len(sides["RIGHT"]) + len(sides["LEFT"]) for sides in diff_files.values())
 
     # Read model-appropriate guidelines from the PR head for project-specific review context
     review_model = get_review_model()
     is_agent_review_model = not _is_anthropic_model(review_model)
+    local_checkout = _verified_local_checkout(head_sha)
+    if head_sha:
+        print(f"Reviewing PR head {head_sha[:7]} ({'local checkout' if local_checkout else 'via GitHub API'})")
     guidelines_section = get_repo_guidelines(review_model, event, head_sha, local_checkout)
 
     # Carry prior reviews of this PR forward so findings are not repeated, contradicted, or silently reversed
@@ -941,8 +884,6 @@ def post_review_summary(event: Action, review_data: dict, review_number: int = 1
             or has_inline_comments
             or has_issues
             or review_data.get("diff_truncated")
-            or review_data.get("oversized_files")
-            or review_data.get("unverified_sizes")
         )
         else "APPROVE"
     )

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -145,6 +145,8 @@ def test_get_first_interaction_response(mock_get_response, mock_check_links):
 def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, mock_checkout, tmp_path, monkeypatch):
     """Test PR reviews avoid background polling for code diffs."""
     monkeypatch.chdir(tmp_path)
+    (tmp_path / "test.py").write_text("old = False\n")
+    (tmp_path / "image.png").write_bytes(b"image")
     mock_get_agent_response.return_value = {"comments": [], "summary": "LGTM"}
     mock_event = MagicMock()
     mock_event.repository = "ultralytics/actions"
@@ -152,6 +154,10 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
     api_response = MagicMock(status_code=200, text="")
     api_response.json.return_value = {"head": {"sha": "headsha"}}
     mock_event.get.return_value = api_response
+    mock_event.paginate.return_value = [
+        {"filename": "test.py", "status": "modified"},
+        {"filename": "image.png", "status": "added"},
+    ]
     diff = """diff --git a/test.py b/test.py
 --- a/test.py
 +++ b/test.py
@@ -160,7 +166,7 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
 +old = False
 """
 
-    review = review_pr.generate_pr_review("ultralytics/actions", (diff, []), "Test PR", "", event=mock_event)
+    review = review_pr.generate_pr_review("ultralytics/actions", (diff, ["image.png"]), "Test PR", "", event=mock_event)
 
     assert review["summary"] == "LGTM"
     mock_get_agent_response.assert_called_once()
@@ -191,13 +197,17 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
 def test_generate_pr_review_never_approves_oversized_files(
     mock_get_agent_response, mock_checkout, tmp_path, monkeypatch
 ):
-    """Test an oversized skipped file blocks approval before model review."""
+    """Test an oversized hunkless change blocks approval before model review."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "test.py").write_text("new = True\n")
-    with (tmp_path / "image.png").open("wb") as file:
+    with (tmp_path / "large.dat").open("wb") as file:
         file.truncate(review_pr.MAX_APPROVED_FILE_SIZE + 1)
     event = MagicMock(repository="org/repo", pr={"number": 7})
     event.get_pr_head_sha.return_value = "abc"
+    event.paginate.return_value = [
+        {"filename": "test.py", "status": "modified"},
+        {"filename": "large.dat", "status": "renamed"},
+    ]
     diff = """diff --git a/test.py b/test.py
 --- a/test.py
 +++ b/test.py
@@ -206,11 +216,41 @@ def test_generate_pr_review_never_approves_oversized_files(
 +new = True
 """
 
-    review = review_pr.generate_pr_review("org/repo", (diff, ["image.png"]), "PR", "", event, "abc")
+    review = review_pr.generate_pr_review("org/repo", (diff, []), "PR", "", event, "abc")
     review_pr.post_review_summary(event, review)
 
-    assert review["oversized_files"] == ["image.png"]
+    assert review["oversized_files"] == ["large.dat"]
     assert event.post.call_args.kwargs["json"]["event"] == "COMMENT"
+    mock_get_agent_response.assert_not_called()
+
+
+@patch("actions.review_pr._verified_local_checkout", return_value=False)
+@patch("actions.review_pr.get_agent_response")
+def test_generate_pr_review_treats_missing_added_file_as_unverified(mock_get_agent_response, mock_checkout):
+    """Test only an explicit removed status permits a missing changed file."""
+    event = MagicMock(repository="org/repo", pr={"number": 7})
+    event.paginate.return_value = [
+        {"filename": "test.py", "status": "modified"},
+        {"filename": "missing.png", "status": "added"},
+    ]
+
+    def get_file(url):
+        response = MagicMock(status_code=404 if "missing.png" in url else 200)
+        response.json.return_value = {"size": 10}
+        return response
+
+    event.get.side_effect = get_file
+    diff = """diff --git a/test.py b/test.py
+--- a/test.py
++++ b/test.py
+@@ -1 +1 @@
+-old = True
++new = True
+"""
+
+    review = review_pr.generate_pr_review("org/repo", (diff, ["missing.png"]), "PR", "", event, "abc")
+
+    assert review["unverified_sizes"] == ["missing.png"]
     mock_get_agent_response.assert_not_called()
 
 

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -145,8 +145,6 @@ def test_get_first_interaction_response(mock_get_response, mock_check_links):
 def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, mock_checkout, tmp_path, monkeypatch):
     """Test PR reviews avoid background polling for code diffs."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "test.py").write_text("old = False\n")
-    (tmp_path / "image.png").write_bytes(b"image")
     mock_get_agent_response.return_value = {"comments": [], "summary": "LGTM"}
     mock_event = MagicMock()
     mock_event.repository = "ultralytics/actions"
@@ -154,10 +152,6 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
     api_response = MagicMock(status_code=200, text="")
     api_response.json.return_value = {"head": {"sha": "headsha"}}
     mock_event.get.return_value = api_response
-    mock_event.paginate.return_value = [
-        {"filename": "test.py", "status": "modified"},
-        {"filename": "image.png", "status": "added"},
-    ]
     diff = """diff --git a/test.py b/test.py
 --- a/test.py
 +++ b/test.py
@@ -166,7 +160,7 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
 +old = False
 """
 
-    review = review_pr.generate_pr_review("ultralytics/actions", (diff, ["image.png"]), "Test PR", "", event=mock_event)
+    review = review_pr.generate_pr_review("ultralytics/actions", (diff, []), "Test PR", "", event=mock_event)
 
     assert review["summary"] == "LGTM"
     mock_get_agent_response.assert_called_once()
@@ -190,90 +184,6 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
         in mock_get_agent_response.call_args.args[0][0]["content"]
     )
     assert "Never approve any added file larger than 1 MB" in mock_get_agent_response.call_args.args[0][0]["content"]
-
-
-@patch("actions.review_pr._verified_local_checkout", return_value=True)
-@patch("actions.review_pr.get_agent_response")
-def test_generate_pr_review_never_approves_oversized_files(
-    mock_get_agent_response, mock_checkout, tmp_path, monkeypatch
-):
-    """Test an oversized hunkless change blocks approval before model review."""
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "test.py").write_text("new = True\n")
-    with (tmp_path / "large.dat").open("wb") as file:
-        file.truncate(review_pr.MAX_APPROVED_FILE_SIZE + 1)
-    event = MagicMock(repository="org/repo", pr={"number": 7})
-    event.get_pr_head_sha.return_value = "abc"
-    event.paginate.return_value = [
-        {"filename": "test.py", "status": "modified"},
-        {"filename": "large.dat", "status": "renamed"},
-    ]
-    diff = """diff --git a/test.py b/test.py
---- a/test.py
-+++ b/test.py
-@@ -1 +1 @@
--old = True
-+new = True
-"""
-
-    review = review_pr.generate_pr_review("org/repo", (diff, []), "PR", "", event, "abc")
-    review_pr.post_review_summary(event, review)
-
-    assert review["oversized_files"] == ["large.dat"]
-    assert event.post.call_args.kwargs["json"]["event"] == "COMMENT"
-    mock_get_agent_response.assert_not_called()
-
-
-@patch("actions.review_pr._verified_local_checkout", return_value=False)
-@patch("actions.review_pr.get_agent_response")
-def test_generate_pr_review_treats_missing_added_file_as_unverified(mock_get_agent_response, mock_checkout):
-    """Test only an explicit removed status permits a missing changed file."""
-    event = MagicMock(repository="org/repo", pr={"number": 7})
-    event.paginate.return_value = [
-        {"filename": "test.py", "status": "modified"},
-        {"filename": "missing.png", "status": "added"},
-    ]
-
-    def get_file(url):
-        response = MagicMock(status_code=404 if "missing.png" in url else 200)
-        response.json.return_value = {"size": 10}
-        return response
-
-    event.get.side_effect = get_file
-    diff = """diff --git a/test.py b/test.py
---- a/test.py
-+++ b/test.py
-@@ -1 +1 @@
--old = True
-+new = True
-"""
-
-    review = review_pr.generate_pr_review("org/repo", (diff, ["missing.png"]), "PR", "", event, "abc")
-
-    assert review["unverified_sizes"] == ["missing.png"]
-    mock_get_agent_response.assert_not_called()
-
-
-@patch("actions.review_pr._verified_local_checkout", return_value=True)
-@patch("actions.review_pr.get_agent_response")
-def test_generate_pr_review_treats_capped_file_list_as_unverified(mock_get_agent_response, mock_checkout):
-    """Test the Pull Files API ceiling cannot hide an oversized file from review."""
-    event = MagicMock(repository="org/repo", pr={"number": 7})
-    event.paginate.return_value = [
-        {"filename": f"file-{index}.py", "status": "modified"} for index in range(review_pr.MAX_PULL_FILES)
-    ]
-    diff = """diff --git a/test.py b/test.py
---- a/test.py
-+++ b/test.py
-@@ -1 +1 @@
--old = True
-+new = True
-"""
-
-    review = review_pr.generate_pr_review("org/repo", (diff, []), "PR", "", event, "abc")
-
-    assert review["unverified_sizes"] == ["PR file list reached GitHub's 3,000-file limit"]
-    mock_get_agent_response.assert_not_called()
 
 
 def test_review_agent_search_scans_local_checkout_only(tmp_path, monkeypatch):

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -186,6 +186,34 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
     assert "Never approve any added file larger than 1 MB" in mock_get_agent_response.call_args.args[0][0]["content"]
 
 
+@patch("actions.review_pr._verified_local_checkout", return_value=True)
+@patch("actions.review_pr.get_agent_response")
+def test_generate_pr_review_never_approves_oversized_files(
+    mock_get_agent_response, mock_checkout, tmp_path, monkeypatch
+):
+    """Test an oversized skipped file blocks approval before model review."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "test.py").write_text("new = True\n")
+    with (tmp_path / "image.png").open("wb") as file:
+        file.truncate(review_pr.MAX_APPROVED_FILE_SIZE + 1)
+    event = MagicMock(repository="org/repo", pr={"number": 7})
+    event.get_pr_head_sha.return_value = "abc"
+    diff = """diff --git a/test.py b/test.py
+--- a/test.py
++++ b/test.py
+@@ -1 +1 @@
+-old = True
++new = True
+"""
+
+    review = review_pr.generate_pr_review("org/repo", (diff, ["image.png"]), "PR", "", event, "abc")
+    review_pr.post_review_summary(event, review)
+
+    assert review["oversized_files"] == ["image.png"]
+    assert event.post.call_args.kwargs["json"]["event"] == "COMMENT"
+    mock_get_agent_response.assert_not_called()
+
+
 def test_review_agent_search_scans_local_checkout_only(tmp_path, monkeypatch):
     """Test repo search scans the local checkout without escaping it and is dropped without a checkout."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -254,6 +254,28 @@ def test_generate_pr_review_treats_missing_added_file_as_unverified(mock_get_age
     mock_get_agent_response.assert_not_called()
 
 
+@patch("actions.review_pr._verified_local_checkout", return_value=True)
+@patch("actions.review_pr.get_agent_response")
+def test_generate_pr_review_treats_capped_file_list_as_unverified(mock_get_agent_response, mock_checkout):
+    """Test the Pull Files API ceiling cannot hide an oversized file from review."""
+    event = MagicMock(repository="org/repo", pr={"number": 7})
+    event.paginate.return_value = [
+        {"filename": f"file-{index}.py", "status": "modified"} for index in range(review_pr.MAX_PULL_FILES)
+    ]
+    diff = """diff --git a/test.py b/test.py
+--- a/test.py
++++ b/test.py
+@@ -1 +1 @@
+-old = True
++new = True
+"""
+
+    review = review_pr.generate_pr_review("org/repo", (diff, []), "PR", "", event, "abc")
+
+    assert review["unverified_sizes"] == ["PR file list reached GitHub's 3,000-file limit"]
+    mock_get_agent_response.assert_not_called()
+
+
 def test_review_agent_search_scans_local_checkout_only(tmp_path, monkeypatch):
     """Test repo search scans the local checkout without escaping it and is dropped without a checkout."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -183,6 +183,7 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
         "Do not flag package or version availability based on web search"
         in mock_get_agent_response.call_args.args[0][0]["content"]
     )
+    assert "Never approve any added file larger than 1 MB" in mock_get_agent_response.call_args.args[0][0]["content"]
 
 
 def test_review_agent_search_scans_local_checkout_only(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Add one reviewer instruction blocking added files larger than 1 MB.
- Assert the instruction remains in the review prompt.
- Bump the Actions patch version to 0.3.13.

## Verification

- `uv run --extra dev pytest tests -q` — 166 passed
- Ruff check and format checks passed

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated PR review guidance to reject added files larger than 1 MB and released Actions version 0.3.13.

### 📊 Key Changes
- Added a review-prompt instruction that prohibits approving any newly added file over 1 MB, regardless of file type.
- Added a test assertion confirming the size restriction remains in the generated review prompt.
- Bumped `actions` from version `0.3.12` to `0.3.13`.

### 🎯 Purpose & Impact
- PR reviews generated by `generate_pr_review` now explicitly treat added files larger than 1 MB as a blocking issue.
- No other review criteria or file-size enforcement mechanisms were changed.