### PR TITLE
Exclude Copilot from CLA checks

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.13"
+__version__ = "0.3.14"

--- a/actions/cla.py
+++ b/actions/cla.py
@@ -25,7 +25,7 @@ SIGN_COMMENT = "I have read the CLA Document and I sign the CLA"
 COMMENT_MARKER = "<!-- ultralytics-cla -->"
 LEGACY_MARKER = "CLA Assistant Lite bot"
 BOT_LOGIN = "github-actions[bot]"
-ALLOWLIST = frozenset(("dependabot[bot]", "github-actions[bot]", "pre-commit-ci[bot]"))
+ALLOWLIST = frozenset(("copilot", "dependabot[bot]", "github-actions[bot]", "pre-commit-ci[bot]"))
 TRANSIENT_STATUS = (429, 500, 502, 503, 504)
 
 

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -69,6 +69,7 @@ def test_contributors_paginates_and_requires_verified_github_identity():
         {"name": "Alias", "email": "2+alias@users.noreply.github.com", "user": None},
         {"name": "Unknown", "email": "private@example.com", "user": None},
         {"user": {"databaseId": 3, "login": "dependabot[bot]"}},
+        {"user": {"databaseId": 6, "login": "Copilot"}},
         {"user": {"databaseId": 4, "login": "other[bot]"}},
         {"user": {"databaseId": 5, "login": "bot-attacker"}},
     ]


### PR DESCRIPTION
### Summary

- exclude the GitHub Copilot coding agent from CLA contributor checks
- retain CLA enforcement for unrecognized bot accounts
- bump the package version to 0.3.14

### Validation

- `pytest tests -q` (166 passed)
- `ruff check --extend-select F,I,D,UP,RUF,FA --target-version py38 --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 .`
- `ruff format --check --line-length 120 .`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The CLA checker now excludes GitHub Copilot from contributor verification while continuing to enforce CLA checks for other unrecognized bot accounts, with the package version updated to 0.3.14.

### 📊 Key Changes

- Added `copilot` to the CLA contributor allowlist.
- Added test coverage for a contributor logged in as `Copilot`.
- Left unrecognized bot accounts subject to CLA enforcement.
- Bumped `actions.__version__` from `0.3.13` to `0.3.14`.

### 🎯 Purpose & Impact

- GitHub Copilot contributions no longer require CLA verification.
- Other bot accounts not included in the allowlist continue through the existing CLA checks.