### PR TITLE
Fix .git ignore entry suppressing redirects for GitHub subdomains

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.14"
+__version__ = "0.3.15"

--- a/actions/utils/common_utils.py
+++ b/actions/utils/common_utils.py
@@ -147,7 +147,6 @@ REDIRECT_START_IGNORE_LIST = frozenset(
         "ultralytics.com/assets",
         "app.gong.io/call?",
         "docs.openvino.ai",
-        ".git",
         "/raw/",  # GitHub images
         ".slack.com",  # Slack URLs to private channels
         "https://maps.app.goo.gl/nxB8YygRQeXSS9G18",  # Ultralytics Madrid office - Cra de San Jeronimo 15
@@ -281,6 +280,7 @@ def allow_redirect(start="", end=""):
     return (
         end
         and end.startswith("https://")
+        and not start_lower.endswith(".git")  # git clone URLs, i.e. https://github.com/org/repo.git
         and all(item not in end_lower for item in REDIRECT_END_IGNORE_LIST)
         and all(item not in start_lower for item in REDIRECT_START_IGNORE_LIST)
     )

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -41,11 +41,18 @@ def test_allow_redirect():
     # Should not allow - start ignores
     assert not allow_redirect("https://youtu.be/xyz", "https://youtube.com")
 
+    # Should not allow - git clone URLs
+    assert not allow_redirect("https://github.com/ultralytics/ultralytics.git", "https://github.com/ultralytics/yolo")
+
     # Should not allow - end ignores
     assert not allow_redirect("https://example.com", "https://example.com/404")
 
     # Empty end URL
     assert not allow_redirect("https://example.com", "")
+
+    # Should allow - GitHub subdomains are not git clone URLs
+    assert allow_redirect("https://docs.github.com/en/old", "https://docs.github.com/en/new")
+    assert allow_redirect("https://gist.github.com/user/abc", "https://gist.github.com/user/def")
 
 
 @patch("requests.get")


### PR DESCRIPTION
### Problem

`allow_redirect()` applies `REDIRECT_START_IGNORE_LIST` with plain substring matching (`all(item not in start_lower ...)`). The bare `".git"` entry was meant to skip clone URLs such as `https://github.com/org/repo.git`, but as a substring it also matched any URL whose host contains `.git`:

- `docs.github.com`, `gist.github.com`, `api.github.com`
- `raw.githubusercontent.com`, `objects.githubusercontent.com`
- third-party hosts too: `gitlab.com`, `gitbook.io`, `gitpod.io`

So redirect refreshing was silently suppressed for essentially every GitHub-subdomain URL. Found when a permanently-moved `docs.github.com` link survived a repo-wide redirect refresh.

### Fix

Drop `".git"` from `REDIRECT_START_IGNORE_LIST` and check the suffix directly in `allow_redirect()`, which is the only consumer of the list:

```python
and not start_lower.endswith(".git")  # git clone URLs, i.e. https://github.com/org/repo.git
```

Net zero lines, and the ignore list keeps its single "plain substring" semantics.

Verified live before/after:

```
https://docs.github.com/en/actions/guides/about-continuous-integration
  -> https://docs.github.com/en/actions/get-started/continuous-integration   (now rewritten)
https://github.com/ultralytics/ultralytics.git
  -> https://github.com/ultralytics/ultralytics.git                          (still ignored)
```

`REDIRECT_END_IGNORE_LIST` still contains `githubusercontent.com`, so redirects *to* temporary signed GitHub asset URLs remain blocked — unchanged by this PR.

### Other ignore-list entries (reviewed, intentionally not changed)

Checked every remaining entry for the same "matches more than intended" property. None cause a domain-wide blackout like `.git` did, so they stay as-is:

- `"{"`, `"}"`, `"("`, `")"` — deliberate character guards for f-strings/pattern breakage; substring matching is exactly right.
- `"badge"` — catches shields.io badges, but also any path containing "badge" (e.g. GitHub's own workflow-status-badge docs page). Intentional catch-all today.
- `"example"`, `"url"`, `"api."` (from `URL_IGNORE_LIST`) — broad by design: they also hit paths like `/examples/`, `?url=`, `openapi.json`. Pre-existing behavior shared with `is_url()`'s allow list, so narrowing them is a separate change.
- `"ow.ly"`, `"bit.ly"`, `".slack.com"`, `"/raw/"`, `"https://x.com"` — anchored enough not to collide in practice.

Also noted (not touched): `REDIRECT_START_IGNORE_LIST` is a frozenset built at import time from `URL_IGNORE_LIST`, so private-repo entries added to `URL_IGNORE_LIST` at runtime by `is_url()` do not propagate into it. Out of scope here.

### Tests

Extended `test_allow_redirect` in `tests/test_common_utils.py` to pin both directions: `docs.github.com` / `gist.github.com` redirects are allowed, a `repo.git` start URL stays ignored.

- `ruff check` + `ruff format` (repo commands from AGENTS.md): clean, 44 files unchanged
- `pytest tests -v`: 166 passed

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated redirect filtering so only URLs ending in `.git` are ignored, while GitHub subdomain URLs can be refreshed normally.

### 📊 Key Changes
- Removed `.git` from `REDIRECT_START_IGNORE_LIST`.
- Added an explicit `start_lower.endswith(".git")` check in `allow_redirect()` for clone URLs.
- Added tests covering ignored `.git` clone URLs and allowed `docs.github.com` and `gist.github.com` redirects.
- Bumped the package version from `0.3.14` to `0.3.15`.

### 🎯 Purpose & Impact
- Redirects originating from GitHub subdomains such as `docs.github.com` and `gist.github.com` are no longer suppressed because their hosts contain `.git`.
- Git clone URLs ending in `.git` remain excluded from redirect processing.
- Redirects to `githubusercontent.com` remain blocked as before.