### PR TITLE
Add robust uv setup fallback

### DIFF
--- a/setup-uv/README.md
+++ b/setup-uv/README.md
@@ -1,6 +1,6 @@
 # Setup uv Action
 
-Provides Ultralytics defaults for the official [uv setup action](https://github.com/astral-sh/setup-uv), using the latest uv release and optionally activating a Python environment and dependency caching.
+Provides Ultralytics defaults for the official [uv setup action](https://github.com/astral-sh/setup-uv), retrying the latest uv release before falling back to the latest known release and optionally activating a Python environment and dependency caching.
 
 ## Usage
 

--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -27,9 +27,38 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: astral-sh/setup-uv@v10.0.0
+    - name: Install latest uv
+      id: latest
+      continue-on-error: true
+      uses: astral-sh/setup-uv@v10.0.0
       with:
         version: latest
+        python-version: ${{ inputs.python-version }}
+        activate-environment: ${{ inputs.activate-environment }}
+        enable-cache: ${{ inputs.enable-cache }}
+        cache-dependency-glob: ${{ inputs.cache-dependency-glob }}
+        ignore-empty-workdir: ${{ inputs.ignore-empty-workdir }}
+        ignore-nothing-to-cache: true
+
+    - name: Retry latest uv
+      id: latest_retry
+      if: steps.latest.outcome == 'failure'
+      continue-on-error: true
+      uses: astral-sh/setup-uv@v10.0.0
+      with:
+        version: latest
+        python-version: ${{ inputs.python-version }}
+        activate-environment: ${{ inputs.activate-environment }}
+        enable-cache: ${{ inputs.enable-cache }}
+        cache-dependency-glob: ${{ inputs.cache-dependency-glob }}
+        ignore-empty-workdir: ${{ inputs.ignore-empty-workdir }}
+        ignore-nothing-to-cache: true
+
+    - name: Install latest known uv
+      if: steps.latest_retry.outcome == 'failure'
+      uses: astral-sh/setup-uv@v10.0.0
+      with:
+        version: latest-known
         python-version: ${{ inputs.python-version }}
         activate-environment: ${{ inputs.activate-environment }}
         enable-cache: ${{ inputs.enable-cache }}


### PR DESCRIPTION
## Summary

- retry latest uv setup after transient failures
- fall back to the checksum-known uv release without fetching live version metadata
- preserve Python, environment activation, and cache behavior on every path

## Validation

- reproduced the motivating failure from ultralytics/ultralytics run 32469033603: `version: latest` failed fetching the Astral manifest from raw.githubusercontent.com
- YAML parse
- Prettier
- `git diff --check`
- CI exercises the composite action on Linux, macOS, and Windows

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the `setup-uv` composite action to retry `latest` uv installation failures and then fall back to `latest-known` while preserving the configured Python, environment, and cache options.

### 📊 Key Changes

- Added a first `astral-sh/setup-uv@v10.0.0` step for `version: latest` that continues on failure.
- Added a conditional retry of the `latest` installation when the first attempt fails.
- Added a final conditional installation using `version: latest-known` if both `latest` attempts fail.
- Passed the existing Python, environment activation, cache, dependency glob, and workdir options through all installation paths.
- Updated `setup-uv/README.md` to document the retry and fallback behavior.

### 🎯 Purpose & Impact

- Workflows using this action can recover from a failed latest-version setup by retrying it and then using the latest known release.
- Python setup, environment activation, and dependency caching configuration remain applied on each path.