### PR TITLE
Simplify uv setup fallback

### DIFF
--- a/setup-uv/README.md
+++ b/setup-uv/README.md
@@ -1,6 +1,6 @@
 # Setup uv Action
 
-Provides Ultralytics defaults for the official [uv setup action](https://github.com/astral-sh/setup-uv), retrying the latest uv release before falling back to the latest known release and optionally activating a Python environment and dependency caching.
+Provides Ultralytics defaults for the official [uv setup action](https://github.com/astral-sh/setup-uv), using the latest uv release with the latest known release as a fallback and optionally activating a Python environment and dependency caching.
 
 ## Usage
 

--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -40,22 +40,8 @@ runs:
         ignore-empty-workdir: ${{ inputs.ignore-empty-workdir }}
         ignore-nothing-to-cache: true
 
-    - name: Retry latest uv
-      id: latest_retry
-      if: steps.latest.outcome == 'failure'
-      continue-on-error: true
-      uses: astral-sh/setup-uv@v10.0.0
-      with:
-        version: latest
-        python-version: ${{ inputs.python-version }}
-        activate-environment: ${{ inputs.activate-environment }}
-        enable-cache: ${{ inputs.enable-cache }}
-        cache-dependency-glob: ${{ inputs.cache-dependency-glob }}
-        ignore-empty-workdir: ${{ inputs.ignore-empty-workdir }}
-        ignore-nothing-to-cache: true
-
     - name: Install latest known uv
-      if: steps.latest_retry.outcome == 'failure'
+      if: steps.latest.outcome == 'failure'
       uses: astral-sh/setup-uv@v10.0.0
       with:
         version: latest-known


### PR DESCRIPTION
## Summary

- remove the redundant retry of the same live version manifest
- fall back directly from latest uv to the manifest-free latest-known release
- preserve the independent fallback while reducing the worst case from three setup calls to two

## Validation

- YAML parse
- Prettier
- `git diff --check`
- CI exercises the composite action on Linux, macOS, and Windows

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Simplified the `setup-uv` fallback flow by removing the redundant retry of `latest` and falling back directly to `latest-known` after the initial setup fails.

### 📊 Key Changes
- Removed the separate `Retry latest uv` step from `setup-uv/action.yml`.
- Updated the `Install latest known uv` condition to run when the initial `latest` setup fails.
- Retained the existing Python environment activation, caching, and dependency-glob inputs for the fallback setup.
- Updated `setup-uv/README.md` to describe the simplified fallback behavior.

### 🎯 Purpose & Impact
- Reduces the maximum setup attempts from three to two: the initial `latest` attempt followed by `latest-known` if needed.
- No user-facing change to the action’s configured environment or caching options.