### PR TITLE
Sanitize PR review text

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.16"
+__version__ = "0.3.17"

--- a/actions/review_pr.py
+++ b/actions/review_pr.py
@@ -699,11 +699,12 @@ def generate_pr_review(
             # Do not pass background=True; queued background reviews can consume the full 900s poll timeout.
         )
 
-        # Sanitize leaked tool-citation tokens from model output
+        # Sanitize model-authored text before posting it to GitHub
         response["summary"] = sanitize_ai_text(response.get("summary", ""))
         for c in response.get("comments", []):
-            if "message" in c:
-                c["message"] = sanitize_ai_text(c["message"])
+            for field in ("message", "suggestion"):
+                if c.get(field):
+                    c[field] = sanitize_ai_text(c[field])
 
         print(json.dumps(response, indent=2))
 

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import time
+import unicodedata
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
@@ -69,15 +70,27 @@ SYSTEM_PROMPT_ADDITION = """Guidance:
   - Use the "@" symbol to refer to GitHub users, e.g. @glenn-jocher.
   - Tone: Adopt a professional, friendly, and concise tone.
 """
+_PRIVATE_USE_RANGE = r"\uE000-\uF8FF\U000F0000-\U000FFFFD\U00100000-\U0010FFFD"
 _CITATION_PATTERN = re.compile(
-    r"[\uE000-\uF8FF]*\bcite[\uE000-\uF8FF]*(turn\d+(?:search|view)\d+|[\w\d]+)[\uE000-\uF8FF]*"
-    r"|\bturn\d+(?:search|view)\d+[\uE000-\uF8FF]+"
+    rf"[{_PRIVATE_USE_RANGE}]*\bcite[{_PRIVATE_USE_RANGE}]*(turn\d+(?:search|view)\d+|[\w\d]+)"
+    rf"[{_PRIVATE_USE_RANGE}]*|\bturn\d+(?:search|view)\d+[{_PRIVATE_USE_RANGE}]+"
 )
+_UNSAFE_UNICODE_CATEGORIES = {"Cc", "Cn", "Co", "Cs"}
+_UNSAFE_FORMAT_CHARACTERS = {"\u200b", "\ufeff"}
 
 
 def sanitize_ai_text(s: str) -> str:
-    """Strip citation tokens and non-printing Unicode characters from AI output."""
-    return "".join(c for c in _CITATION_PATTERN.sub("", s) if c in "\n\t" or c.isprintable()) if s else ""
+    """Strip citation tokens and unsafe Unicode characters from AI output."""
+    return (
+        "".join(
+            c
+            for c in _CITATION_PATTERN.sub("", s)
+            if c in "\n\t"
+            or (unicodedata.category(c) not in _UNSAFE_UNICODE_CATEGORIES and c not in _UNSAFE_FORMAT_CHARACTERS)
+        )
+        if s
+        else ""
+    )
 
 
 def remove_outer_codeblocks(string):

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -77,23 +77,31 @@ _CITATION_PATTERN = re.compile(
 )
 _UNSAFE_UNICODE_CATEGORIES = {"Cc", "Cf", "Co", "Cs"}
 _SAFE_FORMAT_CHARACTERS = {"\u200c", "\u200d"}
+_EMOJI_TAG_SEQUENCE_PATTERN = re.compile(
+    "\U0001f3f4\U000e0067\U000e0062"
+    "(?:\U000e0065\U000e006e\U000e0067|\U000e0073\U000e0063\U000e0074|\U000e0077\U000e006c\U000e0073)"
+    "\U000e007f"
+)
 
 
 def sanitize_ai_text(s: str) -> str:
     """Strip citation tokens and unsafe Unicode characters from AI output."""
-    return (
-        "".join(
-            c
-            for c in _CITATION_PATTERN.sub("", s)
-            if c in "\n\t"
-            or c in _SAFE_FORMAT_CHARACTERS
-            or (
-                unicodedata.category(c) not in _UNSAFE_UNICODE_CATEGORIES
-                and not (0xFDD0 <= ord(c) <= 0xFDEF or (ord(c) & 0xFFFF) in (0xFFFE, 0xFFFF))
-            )
+    if not s:
+        return ""
+    s = _CITATION_PATTERN.sub("", s)
+    safe_tag_positions = {
+        i for match in _EMOJI_TAG_SEQUENCE_PATTERN.finditer(s) for i in range(match.start(), match.end())
+    }
+    return "".join(
+        c
+        for i, c in enumerate(s)
+        if i in safe_tag_positions
+        or c in "\n\t"
+        or c in _SAFE_FORMAT_CHARACTERS
+        or (
+            unicodedata.category(c) not in _UNSAFE_UNICODE_CATEGORIES
+            and not (0xFDD0 <= ord(c) <= 0xFDEF or (ord(c) & 0xFFFF) in (0xFFFE, 0xFFFF))
         )
-        if s
-        else ""
     )
 
 

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -73,7 +73,7 @@ SYSTEM_PROMPT_ADDITION = """Guidance:
 _PRIVATE_USE_RANGE = r"\uE000-\uF8FF\U000F0000-\U000FFFFD\U00100000-\U0010FFFD"
 _CITATION_PATTERN = re.compile(
     rf"[{_PRIVATE_USE_RANGE}]*\bcite[{_PRIVATE_USE_RANGE}]*(turn\d+(?:search|view)\d+|[\w\d]+)"
-    rf"[{_PRIVATE_USE_RANGE}]*|\bturn\d+(?:search|view)\d+[{_PRIVATE_USE_RANGE}]+"
+    rf"[{_PRIVATE_USE_RANGE}]*|\bturn\d+[a-z_]+\d+[{_PRIVATE_USE_RANGE}]+"
 )
 _UNSAFE_UNICODE_CATEGORIES = {"Cc", "Cf", "Co", "Cs"}
 _SAFE_FORMAT_CHARACTERS = {"\u200c", "\u200d", *(chr(c) for c in range(0xE0020, 0xE0080))}

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -76,7 +76,7 @@ _CITATION_PATTERN = re.compile(
     rf"[{_PRIVATE_USE_RANGE}]*|\bturn\d+[a-z_]+\d+[{_PRIVATE_USE_RANGE}]+"
 )
 _UNSAFE_UNICODE_CATEGORIES = {"Cc", "Cf", "Co", "Cs"}
-_SAFE_FORMAT_CHARACTERS = {"\u200c", "\u200d", *(chr(c) for c in range(0xE0020, 0xE0080))}
+_SAFE_FORMAT_CHARACTERS = {"\u200c", "\u200d"}
 
 
 def sanitize_ai_text(s: str) -> str:

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -71,12 +71,13 @@ SYSTEM_PROMPT_ADDITION = """Guidance:
 """
 _CITATION_PATTERN = re.compile(
     r"[\uE000-\uF8FF]*\bcite[\uE000-\uF8FF]*(turn\d+(?:search|view)\d+|[\w\d]+)[\uE000-\uF8FF]*"
+    r"|\bturn\d+(?:search|view)\d+[\uE000-\uF8FF]+"
 )
 
 
 def sanitize_ai_text(s: str) -> str:
-    """Strip private-use citation tokens (for example, ``cite...`` markers)."""
-    return _CITATION_PATTERN.sub("", s) if s else ""
+    """Strip citation tokens and non-printing Unicode characters from AI output."""
+    return "".join(c for c in _CITATION_PATTERN.sub("", s) if c in "\n\t" or c.isprintable()) if s else ""
 
 
 def remove_outer_codeblocks(string):

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -75,8 +75,8 @@ _CITATION_PATTERN = re.compile(
     rf"[{_PRIVATE_USE_RANGE}]*\bcite[{_PRIVATE_USE_RANGE}]*(turn\d+(?:search|view)\d+|[\w\d]+)"
     rf"[{_PRIVATE_USE_RANGE}]*|\bturn\d+(?:search|view)\d+[{_PRIVATE_USE_RANGE}]+"
 )
-_UNSAFE_UNICODE_CATEGORIES = {"Cc", "Cn", "Co", "Cs"}
-_UNSAFE_FORMAT_CHARACTERS = {"\u200b", "\ufeff"}
+_UNSAFE_UNICODE_CATEGORIES = {"Cc", "Co", "Cs"}
+_UNSAFE_FORMAT_PATTERN = re.compile(r"[\u061C\u200B\u200E\u200F\u202A-\u202E\u2060-\u206F\uFEFF]+")
 
 
 def sanitize_ai_text(s: str) -> str:
@@ -84,9 +84,8 @@ def sanitize_ai_text(s: str) -> str:
     return (
         "".join(
             c
-            for c in _CITATION_PATTERN.sub("", s)
-            if c in "\n\t"
-            or (unicodedata.category(c) not in _UNSAFE_UNICODE_CATEGORIES and c not in _UNSAFE_FORMAT_CHARACTERS)
+            for c in _UNSAFE_FORMAT_PATTERN.sub("", _CITATION_PATTERN.sub("", s))
+            if c in "\n\t" or unicodedata.category(c) not in _UNSAFE_UNICODE_CATEGORIES
         )
         if s
         else ""

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -75,8 +75,8 @@ _CITATION_PATTERN = re.compile(
     rf"[{_PRIVATE_USE_RANGE}]*\bcite[{_PRIVATE_USE_RANGE}]*(turn\d+(?:search|view)\d+|[\w\d]+)"
     rf"[{_PRIVATE_USE_RANGE}]*|\bturn\d+(?:search|view)\d+[{_PRIVATE_USE_RANGE}]+"
 )
-_UNSAFE_UNICODE_CATEGORIES = {"Cc", "Co", "Cs"}
-_UNSAFE_FORMAT_PATTERN = re.compile(r"[\u061C\u200B\u200E\u200F\u202A-\u202E\u2060-\u206F\uFEFF]+")
+_UNSAFE_UNICODE_CATEGORIES = {"Cc", "Cf", "Co", "Cs"}
+_SAFE_FORMAT_CHARACTERS = {"\u200c", "\u200d", *(chr(c) for c in range(0xE0020, 0xE0080))}
 
 
 def sanitize_ai_text(s: str) -> str:
@@ -84,8 +84,8 @@ def sanitize_ai_text(s: str) -> str:
     return (
         "".join(
             c
-            for c in _UNSAFE_FORMAT_PATTERN.sub("", _CITATION_PATTERN.sub("", s))
-            if c in "\n\t" or unicodedata.category(c) not in _UNSAFE_UNICODE_CATEGORIES
+            for c in _CITATION_PATTERN.sub("", s)
+            if c in "\n\t" or unicodedata.category(c) not in _UNSAFE_UNICODE_CATEGORIES or c in _SAFE_FORMAT_CHARACTERS
         )
         if s
         else ""

--- a/actions/utils/openai_utils.py
+++ b/actions/utils/openai_utils.py
@@ -85,7 +85,12 @@ def sanitize_ai_text(s: str) -> str:
         "".join(
             c
             for c in _CITATION_PATTERN.sub("", s)
-            if c in "\n\t" or unicodedata.category(c) not in _UNSAFE_UNICODE_CATEGORIES or c in _SAFE_FORMAT_CHARACTERS
+            if c in "\n\t"
+            or c in _SAFE_FORMAT_CHARACTERS
+            or (
+                unicodedata.category(c) not in _UNSAFE_UNICODE_CATEGORIES
+                and not (0xFDD0 <= ord(c) <= 0xFDEF or (ord(c) & 0xFFFF) in (0xFFFE, 0xFFFF))
+            )
         )
         if s
         else ""

--- a/tests/test_first_interaction.py
+++ b/tests/test_first_interaction.py
@@ -145,7 +145,20 @@ def test_get_first_interaction_response(mock_get_response, mock_check_links):
 def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, mock_checkout, tmp_path, monkeypatch):
     """Test PR reviews avoid background polling for code diffs."""
     monkeypatch.chdir(tmp_path)
-    mock_get_agent_response.return_value = {"comments": [], "summary": "LGTM"}
+    mock_get_agent_response.return_value = {
+        "comments": [
+            {
+                "file": "test.py",
+                "line": 1,
+                "side": "RIGHT",
+                "severity": "MEDIUM",
+                "message": "Finding.\ue201",
+                "start_line": None,
+                "suggestion": "old = False\ue201",
+            }
+        ],
+        "summary": "LGTM\ue201",
+    }
     mock_event = MagicMock()
     mock_event.repository = "ultralytics/actions"
     mock_event.pr = {"number": 1, "head": {"sha": "headsha"}}
@@ -163,6 +176,8 @@ def test_generate_pr_review_uses_synchronous_response(mock_get_agent_response, m
     review = review_pr.generate_pr_review("ultralytics/actions", (diff, []), "Test PR", "", event=mock_event)
 
     assert review["summary"] == "LGTM"
+    assert review["comments"][0]["message"] == "Finding."
+    assert review["comments"][0]["suggestion"] == "old = False"
     mock_get_agent_response.assert_called_once()
     kwargs = mock_get_agent_response.call_args.kwargs
     assert "background" not in kwargs

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -19,6 +19,7 @@ from actions.utils.openai_utils import (
     get_response,
     get_review_model,
     remove_outer_codeblocks,
+    sanitize_ai_text,
 )
 
 
@@ -94,6 +95,15 @@ def test_remove_outer_codeblocks():
     # Test with no code blocks
     input_str = "def test():\n    return True"
     assert remove_outer_codeblocks(input_str) == input_str
+
+
+def test_sanitize_ai_text():
+    """Strip citation markers and non-printing characters while preserving normal Unicode and Markdown whitespace."""
+    assert sanitize_ai_text("Finding. \ue200cite\ue202turn10search1\ue201") == "Finding. "
+    assert sanitize_ai_text("Finding. turn10search1\ue201") == "Finding. "
+    assert sanitize_ai_text("Finding.\x00\u200b\ue201\U000f0000") == "Finding."
+    assert sanitize_ai_text("Finding. turn10search1") == "Finding. turn10search1"
+    assert sanitize_ai_text("Café 中文 🚀\n\tMarkdown") == "Café 中文 🚀\n\tMarkdown"
 
 
 def test_get_review_model_override():

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -103,7 +103,9 @@ def test_sanitize_ai_text():
     assert sanitize_ai_text("Finding. turn10search1\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn7fetch3\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn10search1\U000f0000") == "Finding. "
-    assert sanitize_ai_text("Finding.\x00\u200b\u202e\u2066\ufeff\ufff9\U000e0001\ue201\U000f0000") == "Finding."
+    assert (
+        sanitize_ai_text("Finding.\x00\u200b\u202e\u2066\ufeff\ufff9\U000e0001\U000e0020\ue201\U000f0000") == "Finding."
+    )
     assert sanitize_ai_text("Finding. turn10search1") == "Finding. turn10search1"
     assert sanitize_ai_text("Café 中文 🩷 👩‍💻\n\tMarkdown") == "Café 中文 🩷 👩‍💻\n\tMarkdown"
 

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -102,7 +102,7 @@ def test_sanitize_ai_text():
     assert sanitize_ai_text("Finding. \ue200cite\ue202turn10search1\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn10search1\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn10search1\U000f0000") == "Finding. "
-    assert sanitize_ai_text("Finding.\x00\u200b\u202e\u2066\ufeff\ue201\U000f0000") == "Finding."
+    assert sanitize_ai_text("Finding.\x00\u200b\u202e\u2066\ufeff\ufff9\U000e0001\ue201\U000f0000") == "Finding."
     assert sanitize_ai_text("Finding. turn10search1") == "Finding. turn10search1"
     assert sanitize_ai_text("Café 中文 🩷 👩‍💻\n\tMarkdown") == "Café 中文 🩷 👩‍💻\n\tMarkdown"
 

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -102,9 +102,9 @@ def test_sanitize_ai_text():
     assert sanitize_ai_text("Finding. \ue200cite\ue202turn10search1\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn10search1\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn10search1\U000f0000") == "Finding. "
-    assert sanitize_ai_text("Finding.\x00\u200b\ufeff\ue201\U000f0000") == "Finding."
+    assert sanitize_ai_text("Finding.\x00\u200b\u202e\u2066\ufeff\ue201\U000f0000") == "Finding."
     assert sanitize_ai_text("Finding. turn10search1") == "Finding. turn10search1"
-    assert sanitize_ai_text("Café 中文 👩‍💻\n\tMarkdown") == "Café 中文 👩‍💻\n\tMarkdown"
+    assert sanitize_ai_text("Café 中文 🩷 👩‍💻\n\tMarkdown") == "Café 中文 🩷 👩‍💻\n\tMarkdown"
 
 
 def test_get_review_model_override():

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -101,9 +101,10 @@ def test_sanitize_ai_text():
     """Strip citation markers and non-printing characters while preserving normal Unicode and Markdown whitespace."""
     assert sanitize_ai_text("Finding. \ue200cite\ue202turn10search1\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn10search1\ue201") == "Finding. "
-    assert sanitize_ai_text("Finding.\x00\u200b\ue201\U000f0000") == "Finding."
+    assert sanitize_ai_text("Finding. turn10search1\U000f0000") == "Finding. "
+    assert sanitize_ai_text("Finding.\x00\u200b\ufeff\ue201\U000f0000") == "Finding."
     assert sanitize_ai_text("Finding. turn10search1") == "Finding. turn10search1"
-    assert sanitize_ai_text("Café 中文 🚀\n\tMarkdown") == "Café 中文 🚀\n\tMarkdown"
+    assert sanitize_ai_text("Café 中文 👩‍💻\n\tMarkdown") == "Café 中文 👩‍💻\n\tMarkdown"
 
 
 def test_get_review_model_override():

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -104,7 +104,10 @@ def test_sanitize_ai_text():
     assert sanitize_ai_text("Finding. turn7fetch3\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn10search1\U000f0000") == "Finding. "
     assert (
-        sanitize_ai_text("Finding.\x00\u200b\u202e\u2066\ufeff\ufff9\U000e0001\U000e0020\ue201\U000f0000") == "Finding."
+        sanitize_ai_text(
+            "Finding.\x00\u200b\u202e\u2066\ufeff\ufdd0\ufff9\uffff\U000e0001\U000e0020\U0010ffff\ue201\U000f0000"
+        )
+        == "Finding."
     )
     assert sanitize_ai_text("Finding. turn10search1") == "Finding. turn10search1"
     assert sanitize_ai_text("Café 中文 🩷 👩‍💻\n\tMarkdown") == "Café 中文 🩷 👩‍💻\n\tMarkdown"

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -101,6 +101,7 @@ def test_sanitize_ai_text():
     """Strip citation markers and non-printing characters while preserving normal Unicode and Markdown whitespace."""
     assert sanitize_ai_text("Finding. \ue200cite\ue202turn10search1\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn10search1\ue201") == "Finding. "
+    assert sanitize_ai_text("Finding. turn7fetch3\ue201") == "Finding. "
     assert sanitize_ai_text("Finding. turn10search1\U000f0000") == "Finding. "
     assert sanitize_ai_text("Finding.\x00\u200b\u202e\u2066\ufeff\ufff9\U000e0001\ue201\U000f0000") == "Finding."
     assert sanitize_ai_text("Finding. turn10search1") == "Finding. turn10search1"

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -111,6 +111,12 @@ def test_sanitize_ai_text():
     )
     assert sanitize_ai_text("Finding. turn10search1") == "Finding. turn10search1"
     assert sanitize_ai_text("Café 中文 🩷 👩‍💻\n\tMarkdown") == "Café 中文 🩷 👩‍💻\n\tMarkdown"
+    for flag in (
+        "\U0001f3f4\U000e0067\U000e0062\U000e0065\U000e006e\U000e0067\U000e007f",
+        "\U0001f3f4\U000e0067\U000e0062\U000e0073\U000e0063\U000e0074\U000e007f",
+        "\U0001f3f4\U000e0067\U000e0062\U000e0077\U000e006c\U000e0073\U000e007f",
+    ):
+        assert sanitize_ai_text(flag) == flag
 
 
 def test_get_review_model_override():


### PR DESCRIPTION
## Summary

Prevent internal citation artifacts and non-printing Unicode characters from appearing in AI-generated PR reviews.

## Changes

- remove orphaned web-search references such as `turn10search1` followed by a private-use terminator
- strip non-printing/control/private-use Unicode while preserving normal Unicode and Markdown whitespace
- add regression coverage and bump the package version to `0.3.17`

## Validation

- `uv run pytest tests -q` (167 passed)
- repo Ruff lint and format checks

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

AI-generated PR review text is now sanitized before posting to remove leaked citation artifacts and unsafe Unicode characters, while preserving normal Unicode and Markdown whitespace.

### 📊 Key Changes

- Expanded `sanitize_ai_text()` to remove private-use, control, formatting, surrogate, and noncharacter Unicode values.
- Removed orphaned search references such as `turn10search1` and `turn7fetch3` when followed by private-use terminators.
- Applied sanitization to review summaries, comment messages, and comment suggestions.
- Preserved standard Unicode, newlines, tabs, zero-width joiners/non-joiners, and supported emoji flag sequences.
- Added regression coverage and bumped the package version to `0.3.17`.

### 🎯 Purpose & Impact

- Posted GitHub reviews no longer include the targeted internal citation markers or non-printing Unicode artifacts in summaries, findings, or suggestions.
- Existing readable Unicode and Markdown-relevant whitespace remain intact.