### PR TITLE
Fix release summaries and bump version to 0.3.18

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.16"
+__version__ = "0.3.18"

--- a/actions/summarize_release.py
+++ b/actions/summarize_release.py
@@ -53,8 +53,7 @@ def get_prs_between_tags(event, previous_tag: str, latest_tag: str) -> list:
         time.sleep(1)  # Rate limit: space out GitHub REST API requests
         pr_url = f"{GITHUB_API_URL}/repos/{event.repository}/pulls/{pr_number}"
         pr_response = event.get(pr_url)
-        if pr_response.status_code == 200:
-            pr_data = pr_response.json()
+        if pr_response.status_code == 200 and (pr_data := pr_response.json()).get("merged_at"):
             prs.append(
                 {
                     "number": pr_data["number"],


### PR DESCRIPTION
## Summary

- Prevents release-summary generation from crashing when a commit message references an open or unmerged PR whose `merged_at` value is null.
- Bumps the package version to `0.3.18` because `0.3.17` is already published.

## Validation

- Reproduced the pre-fix `TypeError` from `datetime.strptime(None, ...)`
- Confirmed unmerged PR references are now excluded
- 166 tests passed
- Ruff check and format check passed
- Confirmed PyPI latest is `0.3.17` and local version is `0.3.18`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated release-summary PR filtering to ignore unmerged PR references and bumped the package version to `0.3.18` to prevent failures caused by missing `merged_at` values.

### 📊 Key Changes

- `get_prs_between_tags()` now includes a PR only when the API response is successful and `merged_at` is present.
- Open or unmerged PRs referenced by commit messages are excluded from release summaries.
- Updated `actions.__version__` from `0.3.16` to `0.3.18`.

### 🎯 Purpose & Impact

- Release-summary generation no longer attempts to parse a null merge timestamp for unmerged PRs, avoiding the reported `TypeError`.
- Published package version `0.3.18` matches the updated local version.