### PR TITLE
Harden disk cleanup resource handling

### DIFF
--- a/cleanup-disk/action.yml
+++ b/cleanup-disk/action.yml
@@ -14,11 +14,18 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Remove Tool Cache, Docker Images, and Swap"
+        toolcache_pid=""
         if [ -e /opt/hostedtoolcache ]; then
           # Remove tool cache to free up ~15GB of space per https://github.com/ultralytics/ultralytics/pull/15848
-          rm -rf /opt/hostedtoolcache || true
+          rm -rf /opt/hostedtoolcache &
+          toolcache_pid=$!
         fi
-        docker image prune --all --force || true
+        docker image prune --all --force &
+        docker_pid=$!
+        if [ -n "$toolcache_pid" ]; then
+          wait "$toolcache_pid" || true
+        fi
+        wait "$docker_pid" || true
         # Remove swap space to free up ~4GB
         for swap_file in /swapfile /mnt/swapfile; do
           if [ -f "$swap_file" ]; then

--- a/cleanup-disk/action.yml
+++ b/cleanup-disk/action.yml
@@ -18,7 +18,7 @@ runs:
           # Remove tool cache to free up ~15GB of space per https://github.com/ultralytics/ultralytics/pull/15848
           rm -rf /opt/hostedtoolcache || true
         fi
-        docker image prune --all --force
+        docker image prune --all --force || true
         # Remove swap space to free up ~4GB
         for swap_file in /swapfile /mnt/swapfile; do
           if [ -f "$swap_file" ]; then

--- a/cleanup-disk/action.yml
+++ b/cleanup-disk/action.yml
@@ -14,23 +14,20 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Remove Tool Cache, Docker Images, and Swap"
-        toolcache_pid=""
         if [ -e /opt/hostedtoolcache ]; then
           # Remove tool cache to free up ~15GB of space per https://github.com/ultralytics/ultralytics/pull/15848
-          rm -rf /opt/hostedtoolcache &
-          toolcache_pid=$!
+          rm -rf /opt/hostedtoolcache || true
         fi
-        docker image prune --all --force &
-        docker_pid=$!
+        docker image prune --all --force
         # Remove swap space to free up ~4GB
-        if [ -f /swapfile ] || [ -f /mnt/swapfile ]; then
-          sudo swapoff -a
-          sudo rm -f /swapfile /mnt/swapfile
-        fi
-        if [ -n "$toolcache_pid" ]; then
-          wait "$toolcache_pid" || true
-        fi
-        wait "$docker_pid" || true
+        for swap_file in /swapfile /mnt/swapfile; do
+          if [ -f "$swap_file" ]; then
+            if swapon --show=NAME --noheadings | grep -Fxq "$swap_file"; then
+              sudo swapoff "$swap_file"
+            fi
+            sudo rm -f "$swap_file"
+          fi
+        done
         echo "::endgroup::"
 
         echo "::group::Disk Space After Cleanup"


### PR DESCRIPTION
## Summary

- keep slow tool-cache deletion and Docker pruning parallel
- wait for both disk operations before removing swap so all three do not overlap
- disable only active swap files being removed instead of all configured swap devices
- retain best-effort cleanup behavior and the same disk reclamation scope

## Validation

- Ruby YAML parse
- extracted composite script: `bash -n` and `shellcheck -s bash -`
- `npx prettier@3.8.5 --print-width 120 --check cleanup-disk/action.yml cleanup-disk/README.md`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated disk cleanup ordering and swap handling to avoid overlapping swap removal with other cleanup operations while preserving parallel tool-cache deletion and Docker pruning.

### 📊 Key Changes

- Keeps tool-cache deletion and `docker image prune --all --force` running in parallel.
- Waits for both background cleanup operations to finish before processing swap files.
- Checks `/swapfile` and `/mnt/swapfile` individually, disables only files currently active according to `swapon`, and then removes them.
- Retains best-effort behavior by continuing when background cleanup commands fail.

### 🎯 Purpose & Impact

- Prevents swap removal from running concurrently with tool-cache deletion or Docker pruning.
- Avoids disabling unrelated configured swap devices.
- Maintains the existing disk cleanup scope and reclamation behavior.