### PR TITLE
Keep CLA recheck comments exact

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   CLA:
-    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (contains(github.event.comment.body, 'recheck') || contains(github.event.comment.body, 'I have read the CLA Document and I sign the CLA')))
+    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I sign the CLA')))
     concurrency:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest

--- a/cla/README.md
+++ b/cla/README.md
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   CLA:
-    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (contains(github.event.comment.body, 'recheck') || contains(github.event.comment.body, 'I have read the CLA Document and I sign the CLA')))
+    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I sign the CLA')))
     concurrency:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Keeps the `recheck` escape hatch exact while leaving the normalized signature gate permissive. This aligns the repository workflow with the organization rollout and avoids triggering rechecks from unrelated prose.\n\nValidation:\n- `actionlint .github/workflows/cla.yml`\n- `npx prettier@3.8.5 --check .github/workflows/cla.yml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the CLA workflow so the `recheck` command must match the entire comment exactly, while CLA signature comments remain substring-matched.

### 📊 Key Changes
- Changed the CLA workflow condition in `.github/workflows/cla.yml` to recognize `recheck` only when the full comment body equals `recheck`.
- Applied the same condition update to the workflow example in `cla/README.md`.
- Preserved permissive matching for comments containing `I have read the CLA Document and I sign the CLA`.

### 🎯 Purpose & Impact
- Prevents comments containing `recheck` as part of unrelated text from triggering the CLA recheck workflow.
- Keeps existing signature-comment detection behavior unchanged.