### PR TITLE
Auto-redeploy Cloud Run actions and shorten trigger comments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,16 @@ concurrency:
   queue: max
 
 jobs:
+  deploy-actions:
+    if: github.repository == 'ultralytics/actions' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Redeploy Cloud Run actions service
+        env:
+          GH_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+        run: gh workflow run deploy_cloud_run.yml --repo ultralytics/assistant --ref main -f actions=true
+
   check:
     if: github.repository == 'ultralytics/actions' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -28,4 +28,4 @@
 #     ├── test_summarize_pr.py
 #     └── ...
 
-__version__ = "0.3.21"
+__version__ = "0.3.22"

--- a/actions/dispatch_actions.py
+++ b/actions/dispatch_actions.py
@@ -144,17 +144,15 @@ def update_comment(event, comment_body: str, command: str, triggered_actions: li
 
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
     failed = all(action.get("error") for action in triggered_actions)
-    status = (
-        "No GitHub Actions workflows were started" if failed else "GitHub Actions below triggered via workflow dispatch"
-    )
+    status = "No GitHub Actions workflows were started" if failed else "Actions triggered"
     summary = f"""
 
 ## ⚡ Actions Trigger
 
 {ACTIONS_CREDIT}
 
-{status} for this PR at {timestamp} with `{command}` command
-(available commands are `{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}`):
+{status} via `{command}` at {timestamp}.<br>
+Commands: `{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, `{RUN_DOCKER_KEYWORD}`.
 
 """
 

--- a/tests/test_dispatch_actions.py
+++ b/tests/test_dispatch_actions.py
@@ -217,10 +217,7 @@ def test_update_comment_function():
     assert "Actions Trigger" in kwargs["json"]["body"]
     assert "CI Workflow" in kwargs["json"]["body"]
     assert "2023-01-01 12:00:00 UTC" in kwargs["json"]["body"]
-    assert (
-        f"(available commands are `{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, and `{RUN_DOCKER_KEYWORD}`):"
-        in kwargs["json"]["body"]
-    )
+    assert f"Commands: `{RUN_ALL_KEYWORD}`, `{RUN_CI_KEYWORD}`, `{RUN_DOCKER_KEYWORD}`." in kwargs["json"]["body"]
 
 
 def test_update_comment_skips_empty_actions():


### PR DESCRIPTION
The Cloud Run actions service installs `ultralytics/actions@main` during its image build, but changes to this repository currently require a manual redeployment.

Add an independent job to the existing main-push workflow that dispatches the existing Cloud Run deployment workflow with `actions=true`. Reuse `_GITHUB_TOKEN` for the cross-repository request. The job runs on every main push, including pushes without a package version change, and leaves the chat input at its existing false default.

Shorten the Actions Trigger comment to two lines while retaining its timestamp, invoked command, and all three command examples. Bump the package to 0.3.22 for the comment change.

Validation: all 15 dispatch tests pass; Ruff check and format pass; parsed YAML and verified all existing jobs are unchanged; isolated dispatch job passes actionlint. Whole-workflow actionlint diagnostics are identical to the baseline (the installed validator does not recognize existing `queue: max`, plus an existing shellcheck quoting note). Confirmed the target workflow is active and supports the actions input.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Added automatic Cloud Run redeployment on every push to `main` and shortened Actions Trigger comments, with the package version bumped to 0.3.22.

### 📊 Key Changes
- Added a `deploy-actions` job to `.github/workflows/publish.yml` that runs on push events and dispatches `deploy_cloud_run.yml` in `ultralytics/assistant` with `actions=true`, using `_GITHUB_TOKEN`.
- Updated Actions Trigger comments to use a two-line format while retaining the status, timestamp, invoked command, and all three command examples.
- Updated the comment test to verify the shortened command list and bumped `actions.__version__` from `0.3.21` to `0.3.22`.

### 🎯 Purpose & Impact
- Cloud Run actions are now redeployed automatically after pushes to `main`, including pushes without a package version change.
- Actions Trigger comments are shorter while preserving their operational details.