### PR TITLE
Document the three-number PyPI release policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Ultralytics Actions (`ultralytics-actions` on PyPI, AGPL-3.0) is the GitHub auto
 
 ## Core Principles (CRITICAL)
 
+**PyPI releases:** Ultralytics-owned packages must use three-number `MAJOR.MINOR.PATCH` versions only; increment the patch number, never add suffixes or bypass version guards.
+
 **Less is more. The simplest solution is the best solution.** The action hierarchy for every change: **Delete > Replace > Add**.
 
 1. **Solve at the owner**: Put behavior in the code path that owns or observes it. For fixes, never guard a symptom with a staleness check, initialization flag, skip-first-call branch, or `try/except` around broken logic; relocate the trigger and delete the wrong path. For features, extend the existing owner rather than creating a parallel abstraction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,6 @@ Ultralytics Actions (`ultralytics-actions` on PyPI, AGPL-3.0) is the GitHub auto
 
 ## Core Principles (CRITICAL)
 
-**PyPI releases:** Ultralytics-owned packages must use three-number `MAJOR.MINOR.PATCH` versions only; increment the patch number, never add suffixes or bypass version guards.
-
 **Less is more. The simplest solution is the best solution.** The action hierarchy for every change: **Delete > Replace > Add**.
 
 1. **Solve at the owner**: Put behavior in the code path that owns or observes it. For fixes, never guard a symptom with a staleness check, initialization flag, skip-first-call branch, or `try/except` around broken logic; relocate the trigger and delete the wrong path. For features, extend the existing owner rather than creating a parallel abstraction.
@@ -72,6 +70,7 @@ Security detail: `.github/workflows/format.yml` runs `ultralytics/actions@main` 
 
 ## Conventions
 
+- Ultralytics-owned PyPI packages use `MAJOR.MINOR.PATCH` versions only; no suffixes.
 - License headers (`# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`) are added automatically by Ultralytics Actions (`ultralytics-actions-headers`, extensions in `COMMENT_MAP`) — don't add or revert them manually.
 - Bump `__version__` in `actions/__init__.py` when a PR changes package behavior — publishing to PyPI is gated on the version change (`publish.yml`).
 - Google-style docstrings, single-line summaries where possible; formatting is enforced by the repo's own action (`format.yml`), which auto-commits fixes to PRs.


### PR DESCRIPTION
Record the organization-wide rule that Ultralytics-owned PyPI packages use only three-number `MAJOR.MINOR.PATCH` releases, advance patch versions, and never add suffixes or bypass publishing guards.

Adds one instruction line to `AGENTS.md`. No runtime or release workflow changes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Documented the requirement that Ultralytics-owned PyPI packages use three-part versions without suffixes in `AGENTS.md`.

### 📊 Key Changes
- Added a convention requiring `MAJOR.MINOR.PATCH` versioning for Ultralytics-owned PyPI packages.
- Explicitly prohibited version suffixes.
- Made no changes to runtime code or release workflows.

### 🎯 Purpose & Impact
- Updates repository guidance for contributors and release maintenance.
- No user-facing change.