### PR TITLE
Honor header: false to disable file header updates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,9 +63,9 @@ inputs:
     required: false
     default: "true"
   header:
-    description: "File header (false to disable updates)"
+    description: "File header"
     required: false
-    default: ""
+    default: "true"
   brave_api_key:
     description: "Brave API Key"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ inputs:
     required: false
     default: "true"
   header:
-    description: "File header"
+    description: "File header (false to disable updates)"
     required: false
     default: ""
   brave_api_key:
@@ -145,7 +145,7 @@ runs:
 
     # File header ------------------------------------------------------------------------------------------------------
     - name: File Header
-      if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize')
+      if: inputs.header != 'false' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize')
       env:
         HEADER: ${{ inputs.header }}
       run: |


### PR DESCRIPTION
Setting `header: false` currently still rewrites file headers in Ultralytics repositories because the composite action always invokes the header updater. Honor the existing input in the File Header step condition so callers can disable header updates while keeping other formatting and review steps enabled. Default `header` to `"true"` to make the existing enabled behavior explicit.

Validation: Prettier 3.8.5, Actionlint expression validation, and `git diff --check` pass. Only the composite action condition and input default change; no Python package release is needed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

The composite action now honors `header: false` to skip file header updates while keeping the existing header-update behavior enabled by default.

### 📊 Key Changes

- Changed the `header` input default from an empty value to `"true"`.
- Added `inputs.header != 'false'` to the `File Header` step condition.
- The header updater still runs only for pull request `opened` and `synchronize` events when enabled.
- Validation passed with Prettier 3.8.5, Actionlint expression checks, and `git diff --check`.

### 🎯 Purpose & Impact

Callers can set `header: false` to prevent automatic file header rewrites without disabling the composite action’s other formatting and review steps.