### PR TITLE
Preserve DFine spelling during formatting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -285,7 +285,7 @@ runs:
           --write-changes \
           --uri-ignore-words-list "*" \
           --ignore-regex '\b[a-z]+[A-Z][a-zA-Z]*\b' \
-          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN,tbe" \
+          --ignore-words-list "nin,cancelled,MapPin,couldn,grey,writeable,RepResNet,Idenfy,Smoot,EHR,ALS,Carmel,FPR,Hach,Calle,crate,nd,ned,strack,dota,ane,segway,fo,gool,winn,nam,afterall,skelton,goin,cann,CANN,tbe,dfine" \
           --skip "*.pt,*.pth,*.torchscript,*.onnx,*.tflite,*.pb,*.bin,*.param,*.mlmodel,*.engine,*.npy,*.data*,*.csv,*pnnx*,*venv*,*translat*,*lock*,__pycache__*,*.ico,*.jpg,*.png,*.webp,*.avif,*.mp4,*.mov,/runs,/.git,./docs/??/*.md,./docs/mkdocs_??.yml,action.yml"
       shell: bash
       continue-on-error: true


### PR DESCRIPTION
Codespell rewrites `DFine` to `define`, corrupting references to the public [D-FINE model](https://github.com/Peterande/D-FINE). Add `dfine` to the existing spelling ignore list to preserve this identifier spelling.

Validated with codespell 2.4.3: `DFine` is preserved while `Controling` and `neighbouring` still receive the expected corrections. Prettier and `git diff --check` pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the codespell configuration in `action.yml` to ignore `dfine`, preserving references to the D-FINE model during formatting.

### 📊 Key Changes

- Added `dfine` to the existing `--ignore-words-list` used by the codespell action.
- Prevents codespell from rewriting `DFine` as `define`.
- Leaves the existing spelling-correction behavior for other words unchanged.

### 🎯 Purpose & Impact

- D-FINE model references retain their correct identifier spelling when the formatting action runs.
- Other configured codespell corrections continue to be applied.